### PR TITLE
feat: SQLite DB 도입 및 개인 투자 기록/에이전트 리포트 영구 저장 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Thumbs.db
 .gemini/
 .claude/
 .cursor/
+*.db

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,3 +5,9 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 OLLAMA_OPENAI_BASE_URL=http://127.0.0.1:11434/v1
 OLLAMA_MODEL=qwen3.5:9b
 OLLAMA_API_KEY=ollama
+
+# Database
+DB_ECHO=false
+
+# Security
+ALLOW_ORIGINS=http://localhost:5173,http://127.0.0.1:5173

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,7 +20,7 @@ RUN pip install --no-cache-dir -r ./backend/requirements.txt
 
 COPY . .
 
-WORKDIR /app/backend
+WORKDIR /app
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/backend/config.py
+++ b/backend/config.py
@@ -42,6 +42,9 @@ def get_ollama_openai_base_url() -> str:
 _NEWS_MCP_DIR = (_FIN_US_ROOT / "mcp-news").resolve()
 _TRADING_MCP_DIR = (_FIN_US_ROOT / "mcp-trading").resolve()
 
+# SQLite 데이터베이스 파일 경로 설정 (backend 디렉토리 내 finus.db 생성)
+DATABASE_URL = os.environ.get("DATABASE_URL") or f"sqlite:///{_FIN_US_ROOT}/backend/finus.db"
+
 
 def _stdio_server_params(mcp_dir: Path) -> StdioServerParameters:
     return StdioServerParameters(

--- a/backend/config.py
+++ b/backend/config.py
@@ -44,6 +44,11 @@ _TRADING_MCP_DIR = (_FIN_US_ROOT / "mcp-trading").resolve()
 
 # SQLite 데이터베이스 파일 경로 설정 (backend 디렉토리 내 finus.db 생성)
 DATABASE_URL = os.environ.get("DATABASE_URL") or f"sqlite:///{_FIN_US_ROOT}/backend/finus.db"
+DB_ECHO = os.getenv("DB_ECHO", "false").lower() == "true"
+
+# CORS 설정
+_ALLOW_ORIGINS_RAW = os.getenv("ALLOW_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173")
+ALLOW_ORIGINS = [origin.strip() for origin in _ALLOW_ORIGINS_RAW.split(",") if origin.strip()]
 
 
 def _stdio_server_params(mcp_dir: Path) -> StdioServerParameters:

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,8 +1,8 @@
 from sqlmodel import create_engine, Session, SQLModel
-from .config import DATABASE_URL
+from .config import DATABASE_URL, DB_ECHO
 
 # SQLite 사용 시 connect_args={"check_same_thread": False}가 필요함
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False}, echo=True)
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False}, echo=DB_ECHO)
 
 def init_db():
     """

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,18 @@
+from sqlmodel import create_engine, Session, SQLModel
+from .config import DATABASE_URL
+
+# SQLite 사용 시 connect_args={"check_same_thread": False}가 필요함
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False}, echo=True)
+
+def init_db():
+    """
+    데이터베이스 테이블을 초기화합니다.
+    """
+    SQLModel.metadata.create_all(engine)
+
+def get_session():
+    """
+    FastAPI 의존성 주입을 위한 데이터베이스 세션 제너레이터입니다.
+    """
+    with Session(engine) as session:
+        yield session

--- a/backend/main.py
+++ b/backend/main.py
@@ -62,7 +62,9 @@ async def analyze_stock(
         "답변 마지막에 **다음 JSON 한 개만** 출력하라 (다른 텍스트 없이도 됨):\n"
         '{"summary":"한 줄 요약",'
         '"details":{"decision":"BUY"|"SELL"|"HOLD","confidence_score":0.0-1.0,'
-        f'"reason":"근거","target_stock":"{stock}"}},'
+                '"reason":"근거","target_stock":"'
+        f'{stock}'
+        '"},'
         '"source_news":["헤드라인1","헤드라인2"],'
         '"trading_trend":"수급 한줄 요약 또는 null"}'
     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,8 @@
 import os
-from fastapi import FastAPI, Query
+import logging
+from fastapi import FastAPI, Query, Depends
 from fastapi.middleware.cors import CORSMiddleware
+from sqlmodel import Session, select
 
 from .config import NAT_BASE_URL, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS
 from .schemas import CommonResponse
@@ -10,12 +12,23 @@ from .services import (
     llm_chat,
     analysis_from_nat_text
 )
+from .database import init_db, get_session
+from .models import Portfolio, TradeHistory, AgentReport, Diary
+
+# 로깅 설정
+logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="Fin-Us + NAT (integrate)",
     description="MCP market data from fin-us; multi-agent analysis via NeMo NAT FastAPI",
     version="1.0.0",
 )
+
+@app.on_event("startup")
+def on_startup():
+    # 앱 시작 시 데이터베이스 테이블 생성
+    init_db()
+    logger.info("Database initialized.")
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, Query, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
 
-from .config import NAT_BASE_URL, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS
+from .config import NAT_BASE_URL, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS, ALLOW_ORIGINS
 from .schemas import CommonResponse, DiaryCreate
 from .services import (
     run_mcp_tool,
@@ -32,7 +32,7 @@ def on_startup():
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=ALLOW_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import Session, select
 
 from .config import NAT_BASE_URL, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS
-from .schemas import CommonResponse
+from .schemas import CommonResponse, DiaryCreate
 from .services import (
     run_mcp_tool,
     normalize_llm_provider,
@@ -138,12 +138,11 @@ async def get_db_diary(session: Session = Depends(get_session)):
 
 @app.post("/api/v1/db/diary", response_model=CommonResponse, tags=["Database"])
 async def create_db_diary(
-    title: str,
-    content: str,
+    diary_in: DiaryCreate,
     session: Session = Depends(get_session)
 ):
     """새로운 투자 일지를 작성합니다."""
-    diary = Diary(title=title, content=content)
+    diary = Diary.model_validate(diary_in)
     session.add(diary)
     session.commit()
     session.refresh(diary)

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,7 +61,9 @@ async def analyze_stock(
         "답변 마지막에 **다음 JSON 한 개만** 출력하라 (다른 텍스트 없이도 됨):\n"
         '{"summary":"한 줄 요약",'
         '"details":{"decision":"BUY"|"SELL"|"HOLD","confidence_score":0.0-1.0,'
-        f'"reason":"근거","target_stock":"{stock}"}},'
+        '"reason":"근거","target_stock":"'
+        f'{stock}'
+        '"},'
         '"source_news":["헤드라인1","헤드라인2"],'
         '"trading_trend":"수급 한줄 요약 또는 null"}'
     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -55,21 +55,40 @@ async def analyze_stock(
             "nat=NAT multi-agent (still available via API query)"
         ),
     ),
+    session: Session = Depends(get_session),
 ):
     user_msg = (
         f"종목: {stock}. 라우터·서브에이전트를 활용해 투자 관점 분석을 하라. "
         "답변 마지막에 **다음 JSON 한 개만** 출력하라 (다른 텍스트 없이도 됨):\n"
         '{"summary":"한 줄 요약",'
         '"details":{"decision":"BUY"|"SELL"|"HOLD","confidence_score":0.0-1.0,'
-        '"reason":"근거","target_stock":"'
-        f'{stock}'
-        '"},'
+        f'"reason":"근거","target_stock":"{stock}"}},'
         '"source_news":["헤드라인1","헤드라인2"],'
         '"trading_trend":"수급 한줄 요약 또는 null"}'
     )
     key = normalize_llm_provider(provider)
     raw = await llm_chat(key, user_msg)
     data = analysis_from_nat_text(str(raw), stock)
+
+    # 분석 리포트를 데이터베이스에 자동으로 저장
+    try:
+        details = data.get("details", {})
+        report = AgentReport(
+            stock_code="",  # 향후 개선: MCP를 통해 코드를 가져오거나 분석 결과에서 추출
+            stock_name=stock,
+            provider=key,
+            summary=data.get("summary", ""),
+            decision=details.get("decision", "HOLD"),
+            confidence_score=details.get("confidence_score", 0.0),
+            reason=details.get("reason", ""),
+        )
+        session.add(report)
+        session.commit()
+        logger.info(f"AgentReport saved for {stock}")
+    except Exception as e:
+        # DB 저장 실패가 분석 API 응답 전체의 실패로 이어지지 않도록 예외 처리
+        logger.error(f"Failed to save AgentReport for {stock}: {e}")
+
     return {"status": "success", "data": data}
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -89,6 +89,48 @@ async def get_account_balance():
     return {"status": "success", "data": {"report": balance_text}}
 
 
+@app.get("/api/v1/db/portfolio", response_model=CommonResponse, tags=["Database"])
+async def get_db_portfolio(session: Session = Depends(get_session)):
+    """저장된 포트폴리오 정보를 조회합니다."""
+    portfolios = session.exec(select(Portfolio)).all()
+    return {"status": "success", "data": portfolios}
+
+
+@app.get("/api/v1/db/trades", response_model=CommonResponse, tags=["Database"])
+async def get_db_trades(session: Session = Depends(get_session)):
+    """저장된 매매 이력을 조회합니다."""
+    trades = session.exec(select(TradeHistory)).all()
+    return {"status": "success", "data": trades}
+
+
+@app.get("/api/v1/db/reports", response_model=CommonResponse, tags=["Database"])
+async def get_db_reports(session: Session = Depends(get_session)):
+    """저장된 에이전트 리포트 목록을 조회합니다."""
+    reports = session.exec(select(AgentReport).order_by(AgentReport.created_at.desc())).all()
+    return {"status": "success", "data": reports}
+
+
+@app.get("/api/v1/db/diary", response_model=CommonResponse, tags=["Database"])
+async def get_db_diary(session: Session = Depends(get_session)):
+    """저장된 투자 일지 목록을 조회합니다."""
+    diaries = session.exec(select(Diary).order_by(Diary.created_at.desc())).all()
+    return {"status": "success", "data": diaries}
+
+
+@app.post("/api/v1/db/diary", response_model=CommonResponse, tags=["Database"])
+async def create_db_diary(
+    title: str,
+    content: str,
+    session: Session = Depends(get_session)
+):
+    """새로운 투자 일지를 작성합니다."""
+    diary = Diary(title=title, content=content)
+    session.add(diary)
+    session.commit()
+    session.refresh(diary)
+    return {"status": "success", "data": diary}
+
+
 @app.get("/health", tags=["System"])
 async def health_check():
     return {"status": "alive", "nat_base_url": NAT_BASE_URL}

--- a/backend/models.py
+++ b/backend/models.py
@@ -32,6 +32,7 @@ class AgentReport(SQLModel, table=True):
     AI 에이전트가 생성한 종목 분석 리포트 및 투자 제안을 저장합니다.
     """
     id: Optional[int] = Field(default=None, primary_key=True)
+    stock_code: str = Field(index=True, description="분석 종목 코드")
     stock_name: str = Field(index=True, description="분석 종목명")
     provider: str = Field(description="사용된 LLM 제공자 (openai, anthropic 등)")
     summary: str = Field(description="분석 요약")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from typing import Optional
+from sqlmodel import Field, SQLModel
+
+class Portfolio(SQLModel, table=True):
+    """
+    사용자의 현재 주식 잔고 및 포트폴리오 정보를 저장합니다.
+    증권사 API(SSOT)의 데이터를 기반으로 동기화됩니다.
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    stock_code: str = Field(index=True, description="종목 코드")
+    stock_name: str = Field(description="종목명")
+    quantity: int = Field(default=0, description="보유 수량")
+    avg_price: float = Field(default=0.0, description="평균 매입가")
+    current_price: Optional[float] = Field(default=None, description="현재가")
+    updated_at: datetime = Field(default_factory=datetime.utcnow, description="최근 업데이트 시간")
+
+class TradeHistory(SQLModel, table=True):
+    """
+    사용자의 주식 매매 내역을 저장합니다.
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    stock_code: str = Field(index=True, description="종목 코드")
+    stock_name: str = Field(description="종목명")
+    trade_type: str = Field(description="매매 구분 (BUY/SELL)")
+    quantity: int = Field(description="매매 수량")
+    price: float = Field(description="매매 단가")
+    trade_date: datetime = Field(default_factory=datetime.utcnow, description="매매 일시")
+
+class AgentReport(SQLModel, table=True):
+    """
+    AI 에이전트가 생성한 종목 분석 리포트 및 투자 제안을 저장합니다.
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    stock_name: str = Field(index=True, description="분석 종목명")
+    provider: str = Field(description="사용된 LLM 제공자 (openai, anthropic 등)")
+    summary: str = Field(description="분석 요약")
+    decision: str = Field(description="투자 결정 (BUY/SELL/HOLD)")
+    confidence_score: float = Field(description="신뢰도 점수 (0.0~1.0)")
+    reason: str = Field(description="투자 결정 근거")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="생성 일시")
+
+class Diary(SQLModel, table=True):
+    """
+    사용자의 개인 투자 일지 및 메모를 저장합니다.
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str = Field(description="일지 제목")
+    content: str = Field(description="일지 내용")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="작성 일시")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from sqlmodel import Field, SQLModel
 
@@ -13,7 +13,7 @@ class Portfolio(SQLModel, table=True):
     quantity: int = Field(default=0, description="보유 수량")
     avg_price: float = Field(default=0.0, description="평균 매입가")
     current_price: Optional[float] = Field(default=None, description="현재가")
-    updated_at: datetime = Field(default_factory=datetime.utcnow, description="최근 업데이트 시간")
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="최근 업데이트 시간")
 
 class TradeHistory(SQLModel, table=True):
     """
@@ -25,7 +25,7 @@ class TradeHistory(SQLModel, table=True):
     trade_type: str = Field(description="매매 구분 (BUY/SELL)")
     quantity: int = Field(description="매매 수량")
     price: float = Field(description="매매 단가")
-    trade_date: datetime = Field(default_factory=datetime.utcnow, description="매매 일시")
+    trade_date: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="매매 일시")
 
 class AgentReport(SQLModel, table=True):
     """
@@ -39,7 +39,7 @@ class AgentReport(SQLModel, table=True):
     decision: str = Field(description="투자 결정 (BUY/SELL/HOLD)")
     confidence_score: float = Field(description="신뢰도 점수 (0.0~1.0)")
     reason: str = Field(description="투자 결정 근거")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="생성 일시")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="생성 일시")
 
 class Diary(SQLModel, table=True):
     """
@@ -48,4 +48,4 @@ class Diary(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     title: str = Field(description="일지 제목")
     content: str = Field(description="일지 내용")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="작성 일시")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="작성 일시")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ anthropic
 mcp
 pyyaml
 httpx
+sqlmodel

--- a/backend/schema_docs.md
+++ b/backend/schema_docs.md
@@ -1,0 +1,51 @@
+# Fin-Us Backend Database Schema
+
+이 문서는 SQLModel을 사용하여 정의된 SQLite 데이터베이스 스키마를 시각화합니다.
+
+## ER Diagram
+
+```mermaid
+erDiagram
+    Portfolio {
+        int id PK
+        string stock_code "종목 코드"
+        string stock_name "종목명"
+        int quantity "보유 수량"
+        float avg_price "평균 매입가"
+        float current_price "현재가"
+        datetime updated_at "수정 일시"
+    }
+    TradeHistory {
+        int id PK
+        string stock_code "종목 코드"
+        string stock_name "종목명"
+        string trade_type "매매 구분 (BUY/SELL)"
+        int quantity "매매 수량"
+        float price "매매 단가"
+        datetime trade_date "매매 일시"
+    }
+    AgentReport {
+        int id PK
+        string stock_code "분석 종목 코드"
+        string stock_name "분석 종목명"
+        string provider "LLM 제공자"
+        string summary "분석 요약"
+        string decision "투자 결정 (BUY/SELL/HOLD)"
+        float confidence_score "신뢰도 점수"
+        string reason "투자 결정 근거"
+        datetime created_at "생성 일시"
+    }
+    Diary {
+        int id PK
+        string title "일지 제목"
+        string content "일지 내용"
+        datetime created_at "작성 일시"
+    }
+```
+
+## 테이블 설명
+
+- **Portfolio**: 사용자의 현재 주식 잔고 정보를 관리합니다. 한국투자증권(KIS) API 데이터를 기준으로 동기화됩니다.
+- **TradeHistory**: 사용자의 매매 이력을 기록합니다.
+- **AgentReport**: AI 에이전트가 생성한 종목 분석 결과 및 투자 의견을 저장합니다.
+- **Diary**: 사용자의 개인적인 투자 생각이나 일지를 기록합니다.

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -17,5 +17,10 @@ class AnalysisReport(BaseModel):
 
 class CommonResponse(BaseModel):
     status: str = "success"
-    data: dict[str, Any] | None = None
+    data: Any | None = None
     message: str | None = None
+
+
+class DiaryCreate(BaseModel):
+    title: str = Field(..., description="일지 제목")
+    content: str = Field(..., description="일지 내용")

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,94 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel.pool import StaticPool
+
+from ..main import app, get_session
+from ..models import Diary, AgentReport
+
+# 테스트용 인메모리 SQLite 엔진 설정
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(session: Session):
+    def get_session_override():
+        return session
+
+    app.dependency_overrides[get_session] = get_session_override
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+def test_get_portfolio_empty(client: TestClient):
+    response = client.get("/api/v1/db/portfolio")
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert response.json()["data"] == []
+
+
+def test_create_and_get_diary(client: TestClient):
+    # Create
+    response = client.post(
+        "/api/v1/db/diary",
+        json={"title": "Test Title", "content": "Test Content"}
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["title"] == "Test Title"
+    assert data["content"] == "Test Content"
+    assert "id" in data
+
+    # Get
+    response = client.get("/api/v1/db/diary")
+    assert response.status_code == 200
+    diaries = response.json()["data"]
+    assert len(diaries) == 1
+    assert diaries[0]["title"] == "Test Title"
+
+
+def test_get_trades_empty(client: TestClient):
+    response = client.get("/api/v1/db/trades")
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert response.json()["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_analyze_stock_saves_report(client: TestClient, session: Session, monkeypatch):
+    # Mocking llm_chat and analysis_from_nat_text
+    async def mock_llm_chat(*args, **kwargs):
+        return "mocked raw response"
+
+    def mock_analysis_from_nat_text(raw_text, stock):
+        return {
+            "summary": f"Summary for {stock}",
+            "details": {
+                "decision": "BUY",
+                "confidence_score": 0.85,
+                "reason": "Strong momentum"
+            }
+        }
+
+    monkeypatch.setattr("backend.main.llm_chat", mock_llm_chat)
+    monkeypatch.setattr("backend.main.analysis_from_nat_text", mock_analysis_from_nat_text)
+
+    # API Call
+    response = client.get("/api/v1/analyze?stock=삼성전자")
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+
+    # Verify DB save
+    reports = session.query(AgentReport).all()
+    assert len(reports) == 1
+    assert reports[0].stock_name == "삼성전자"
+    assert reports[0].decision == "BUY"
+    assert reports[0].confidence_score == 0.85


### PR DESCRIPTION
## 📝 개요
- 백엔드에 SQLite 데이터베이스를 도입하여 개인 투자 기록 및 에이전트 분석 리포트를 영구 저장할 수 있는 기능을 구현했습니다.

## 🚀 변경 사항
- **데이터베이스 인프라 구축**: SQLite 및 SQLModel(ORM) 도입 및 설정 (`backend/database.py`, `backend/config.py`)
- **데이터 모델 정의**: `Portfolio`, `TradeHistory`, `AgentReport`, `Diary` 테이블 스키마 정의 (`backend/models.py`)
- **자동 저장 기능**: `/api/v1/analyze` API 호출 시 AI 에이전트의 분석 리포트를 `AgentReport` 테이블에 자동 저장하는 로직 추가
- **CRUD 엔드포인트 추가**:
    - `GET /api/v1/db/portfolio`: 포트폴리오 조회
    - `GET /api/v1/db/trades`: 매매 이력 조회
    - `GET /api/v1/db/reports`: 에이전트 리포트 조회
    - `GET /api/v1/db/diary`: 투자 일지 조회
    - `POST /api/v1/db/diary`: 투자 일지 작성
- **문서화**: Mermaid.js 기반의 데이터베이스 스키마 문서 추가 (`backend/schema_docs.md`)
- **의존성 업데이트**: `sqlmodel` 추가 (`backend/requirements.txt`)

## 🔗 관련 이슈
- Related to #18

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?