### PR TITLE
[FEAT] NAT 응답 로깅 강화

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -201,6 +201,11 @@ async def _llm_nat_chat(user_msg: str) -> str:
                     "stream": False,
                 },
             )
+            logger.info(
+                "NAT raw response: status_code=%s body=%s",
+                resp.status_code,
+                resp.text,
+            )
     except httpx.RequestError as exc:
         raise HTTPException(
             status_code=502,
@@ -213,6 +218,11 @@ async def _llm_nat_chat(user_msg: str) -> str:
     try:
         payload = resp.json()
     except ValueError as exc:
+        logger.exception(
+            "Failed to parse NAT response JSON: status_code=%s body=%s",
+            resp.status_code,
+            resp.text,
+        )
         raise HTTPException(
             status_code=502,
             detail=f"NAT JSON 파싱 실패: {exc}; body[:800]={resp.text[:800]!r}",
@@ -316,4 +326,3 @@ async def llm_chat(
     if provider_key == "ollama":
         return await _llm_ollama_chat(user_msg)
     return await _llm_nat_chat(user_msg)
-

--- a/backend/services.py
+++ b/backend/services.py
@@ -201,7 +201,7 @@ async def _llm_nat_chat(user_msg: str) -> str:
                     "stream": False,
                 },
             )
-            logger.info(
+            logger.debug(
                 "NAT raw response: status_code=%s body=%s",
                 resp.status_code,
                 resp.text,
@@ -219,10 +219,10 @@ async def _llm_nat_chat(user_msg: str) -> str:
         payload = resp.json()
     except ValueError as exc:
         logger.exception(
-            "Failed to parse NAT response JSON: status_code=%s body=%s",
+            "Failed to parse NAT response JSON: status_code=%s",
             resp.status_code,
-            resp.text,
         )
+        logger.debug("NAT response body: %s", resp.text)
         raise HTTPException(
             status_code=502,
             detail=f"NAT JSON 파싱 실패: {exc}; body[:800]={resp.text[:800]!r}",

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1,0 +1,66 @@
+import logging
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from backend import services
+
+
+class MockAsyncClient:
+    def __init__(self, response: httpx.Response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, *args, **kwargs):
+        return self.response
+
+
+def mock_async_client_factory(response: httpx.Response):
+    def factory(*args, **kwargs):
+        return MockAsyncClient(response)
+
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_llm_nat_chat_logs_raw_response(monkeypatch, caplog):
+    response = httpx.Response(
+        200,
+        json={"choices": [{"message": {"content": "분석 결과"}}]},
+    )
+    monkeypatch.setattr(
+        services.httpx,
+        "AsyncClient",
+        mock_async_client_factory(response),
+    )
+
+    with caplog.at_level(logging.INFO, logger=services.logger.name):
+        result = await services._llm_nat_chat("삼성전자 분석")
+
+    assert result == "분석 결과"
+    assert "NAT raw response: status_code=200" in caplog.text
+    assert '"content":"분석 결과"' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_llm_nat_chat_logs_json_parse_failure(monkeypatch, caplog):
+    response = httpx.Response(200, text="not-json")
+    monkeypatch.setattr(
+        services.httpx,
+        "AsyncClient",
+        mock_async_client_factory(response),
+    )
+
+    with caplog.at_level(logging.INFO, logger=services.logger.name):
+        with pytest.raises(HTTPException) as exc_info:
+            await services._llm_nat_chat("삼성전자 분석")
+
+    assert exc_info.value.status_code == 502
+    assert "NAT raw response: status_code=200 body=not-json" in caplog.text
+    assert "Failed to parse NAT response JSON: status_code=200 body=not-json" in caplog.text

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -40,7 +40,7 @@ async def test_llm_nat_chat_logs_raw_response(monkeypatch, caplog):
         mock_async_client_factory(response),
     )
 
-    with caplog.at_level(logging.INFO, logger=services.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=services.logger.name):
         result = await services._llm_nat_chat("삼성전자 분석")
 
     assert result == "분석 결과"
@@ -57,10 +57,11 @@ async def test_llm_nat_chat_logs_json_parse_failure(monkeypatch, caplog):
         mock_async_client_factory(response),
     )
 
-    with caplog.at_level(logging.INFO, logger=services.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=services.logger.name):
         with pytest.raises(HTTPException) as exc_info:
             await services._llm_nat_chat("삼성전자 분석")
 
     assert exc_info.value.status_code == 502
     assert "NAT raw response: status_code=200 body=not-json" in caplog.text
-    assert "Failed to parse NAT response JSON: status_code=200 body=not-json" in caplog.text
+    assert "Failed to parse NAT response JSON: status_code=200" in caplog.text
+    assert "NAT response body: not-json" in caplog.text


### PR DESCRIPTION
## 📝 개요

NAT 응답 디버깅을 위해 백엔드의 NAT 호출부에서 원본 응답 상태 코드와 body를 로그로 남기도록 개선합니다.

## 🚀 변경 사항
- `_llm_nat_chat`에서 NAT HTTP 응답 직후 `resp.status_code`와 `resp.text`를 `logger.info`로 출력
- NAT 응답 JSON 파싱 실패 시 상태 코드와 원본 body를 `logger.exception`으로 기록
- NAT 원본 응답 로그와 JSON 파싱 실패 로그를 검증하는 서비스 단위 테스트 추가

## 🔗 관련 이슈
- Related to #19

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)
