### PR TITLE
[FIX] NAT provider 한글 종목명 500 오류 및 ReAct 에이전트 도구 실행 실패 수정 (#44)

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -3,6 +3,7 @@ import httpx
 import logging
 from datetime import date
 from typing import Any, Literal, Optional
+from urllib.parse import quote as _url_quote
 from fastapi import HTTPException
 from anthropic import AsyncAnthropic
 from openai import AsyncOpenAI
@@ -30,7 +31,9 @@ def _nat_conversation_id(
     """Per-stock NAT thread so scheduler/API runs do not share ReAct transcript."""
     today = date.today().isoformat()
     prefix = trigger_source or "api"
-    return f"{prefix}:{stock}:{today}"
+    # HTTP 헤더는 ASCII만 허용되므로 한글 종목명을 퍼센트 인코딩
+    safe_stock = _url_quote(stock, safe="")
+    return f"{prefix}:{safe_stock}:{today}"
 
 
 async def perform_stock_analysis(

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import date
+from urllib.parse import quote
 from types import SimpleNamespace
 
 import httpx
@@ -131,7 +132,8 @@ async def test_perform_stock_analysis_includes_trigger_signal(monkeypatch):
     )
 
     assert prompts[0][0] == "nat"
-    assert captured_cids == [f"sns:삼성전자:{date.today().isoformat()}"]
+    encoded_stock = quote("삼성전자", safe="")
+    assert captured_cids == [f"sns:{encoded_stock}:{date.today().isoformat()}"]
     assert "분석 트리거 데이터 출처: sns" in prompts[0][1]
     assert "SNS mentions spiked after earnings guidance" in prompts[0][1]
     assert '"source_signals"' in prompts[0][1]

--- a/finus_nat/configs/agents/diary_agent.yml
+++ b/finus_nat/configs/agents/diary_agent.yml
@@ -25,7 +25,7 @@ functions:
     max_history: 8000
     parse_agent_response_max_retries: 2
     raise_on_parsing_failure: false
-    accept_direct_answer_without_react_format: true
+    accept_direct_answer_without_react_format: false
     additional_instructions: |
       당일 거래 내역을 기반으로 사용자의 매매일지의 초안을 작성합니다. 종목명, 거래 금액, 변동율, 매매 구분(매수, 매도, 보유)을 포함합니다.
       거래 근거가 필요하면 `kis-api-daily-trades`를 호출합니다. (환경 변수: KIS_URL, KIS_API_KEY, KIS_API_SECRET, KIS_ACCOUNT_NO)

--- a/finus_nat/configs/agents/diary_agent.yml
+++ b/finus_nat/configs/agents/diary_agent.yml
@@ -21,11 +21,11 @@ functions:
     tool_names:
       - kis-api-daily-trades
     verbose: false
-    use_native_tool_calling: true
+    use_native_tool_calling: false
     max_history: 8000
     parse_agent_response_max_retries: 2
     raise_on_parsing_failure: false
-    accept_direct_answer_without_react_format: false
+    accept_direct_answer_without_react_format: true
     additional_instructions: |
       당일 거래 내역을 기반으로 사용자의 매매일지의 초안을 작성합니다. 종목명, 거래 금액, 변동율, 매매 구분(매수, 매도, 보유)을 포함합니다.
       거래 근거가 필요하면 `kis-api-daily-trades`를 호출합니다. (환경 변수: KIS_URL, KIS_API_KEY, KIS_API_SECRET, KIS_ACCOUNT_NO)

--- a/finus_nat/configs/agents/monitoring_agent.yml
+++ b/finus_nat/configs/agents/monitoring_agent.yml
@@ -26,7 +26,7 @@ functions:
     raise_on_parsing_failure: false
     max_tool_calls: 20
     pass_tool_call_errors_to_agent: true
-    accept_direct_answer_without_react_format: true
+    accept_direct_answer_without_react_format: false
     additional_instructions: |
       === 에이전트 요약 ===
       포트폴리오 모니터링, 잔고, 뉴스·수급·DART 공시 점검. 잔고는 Kis Trading MCP, 뉴스·수급은 `mcp-news`, 지분공시는 `mcp-dart`를 쓰되 관찰·알림·건전성 관점으로 답합니다.

--- a/finus_nat/configs/agents/monitoring_agent.yml
+++ b/finus_nat/configs/agents/monitoring_agent.yml
@@ -20,13 +20,13 @@ functions:
       - get_user_memory
     verbose: false
     include_tool_input_schema_in_tool_description: true
-    use_native_tool_calling: true
+    use_native_tool_calling: false
     max_history: 8000
     parse_agent_response_max_retries: 5
     raise_on_parsing_failure: false
     max_tool_calls: 20
     pass_tool_call_errors_to_agent: true
-    accept_direct_answer_without_react_format: false
+    accept_direct_answer_without_react_format: true
     additional_instructions: |
       === 에이전트 요약 ===
       포트폴리오 모니터링, 잔고, 뉴스·수급·DART 공시 점검. 잔고는 Kis Trading MCP, 뉴스·수급은 `mcp-news`, 지분공시는 `mcp-dart`를 쓰되 관찰·알림·건전성 관점으로 답합니다.

--- a/finus_nat/configs/agents/news_agent.yml
+++ b/finus_nat/configs/agents/news_agent.yml
@@ -24,7 +24,7 @@ functions:
     max_history: 8000
     parse_agent_response_max_retries: 2
     raise_on_parsing_failure: false
-    accept_direct_answer_without_react_format: true
+    accept_direct_answer_without_react_format: false
     additional_instructions: |
       시장 뉴스·수급·DART 지분공시 분석가. 종목/시장 관련 질문에는 mcp-news·mcp-dart 도구로 데이터를 가져온 뒤 한국어로 요약·해석합니다.
       사용자가 성격, 선호, 투자 성향, 답변 스타일처럼 오래 유지될 정보를 말하면 `add_user_memory`에 저장하고,

--- a/finus_nat/configs/agents/news_agent.yml
+++ b/finus_nat/configs/agents/news_agent.yml
@@ -20,11 +20,11 @@ functions:
       - add_user_memory
       - get_user_memory
     verbose: false
-    use_native_tool_calling: true
+    use_native_tool_calling: false
     max_history: 8000
     parse_agent_response_max_retries: 2
     raise_on_parsing_failure: false
-    accept_direct_answer_without_react_format: false
+    accept_direct_answer_without_react_format: true
     additional_instructions: |
       시장 뉴스·수급·DART 지분공시 분석가. 종목/시장 관련 질문에는 mcp-news·mcp-dart 도구로 데이터를 가져온 뒤 한국어로 요약·해석합니다.
       사용자가 성격, 선호, 투자 성향, 답변 스타일처럼 오래 유지될 정보를 말하면 `add_user_memory`에 저장하고,

--- a/finus_nat/configs/agents/recommend_agent.yml
+++ b/finus_nat/configs/agents/recommend_agent.yml
@@ -24,7 +24,7 @@ functions:
     max_history: 8000
     parse_agent_response_max_retries: 2
     raise_on_parsing_failure: false
-    accept_direct_answer_without_react_format: true
+    accept_direct_answer_without_react_format: false
     additional_instructions: |
       직전 대화에서 섹터·비교 기준·종목 목록이 이미 정해졌다면, 사용자가 짧게만 말해도 **그 맥락을 유지**하고
       같은 주제로 도구를 쓰거나 답합니다. 이미 정해진 업종/테마를 다시 묻지 마세요.

--- a/finus_nat/configs/agents/recommend_agent.yml
+++ b/finus_nat/configs/agents/recommend_agent.yml
@@ -20,11 +20,11 @@ functions:
       - add_user_memory
       - get_user_memory
     verbose: false
-    use_native_tool_calling: true
+    use_native_tool_calling: false
     max_history: 8000
     parse_agent_response_max_retries: 2
     raise_on_parsing_failure: false
-    accept_direct_answer_without_react_format: false
+    accept_direct_answer_without_react_format: true
     additional_instructions: |
       직전 대화에서 섹터·비교 기준·종목 목록이 이미 정해졌다면, 사용자가 짧게만 말해도 **그 맥락을 유지**하고
       같은 주제로 도구를 쓰거나 답합니다. 이미 정해진 업종/테마를 다시 묻지 마세요.

--- a/finus_nat/configs/agents/strategy_agent.yml
+++ b/finus_nat/configs/agents/strategy_agent.yml
@@ -24,7 +24,7 @@ functions:
     max_history: 8000
     parse_agent_response_max_retries: 2
     raise_on_parsing_failure: false
-    accept_direct_answer_without_react_format: true
+    accept_direct_answer_without_react_format: false
     additional_instructions: |
       === 에이전트 요약 ===
       매매 규칙·시나리오·BUY/SELL/HOLD 관점의 전략 제안. 뉴스·수급(mcp-news)과 잔고·시세(Kis MCP) 결과를 근거로 한국어로 정리합니다.

--- a/finus_nat/configs/agents/strategy_agent.yml
+++ b/finus_nat/configs/agents/strategy_agent.yml
@@ -20,11 +20,11 @@ functions:
       - add_user_memory
       - get_user_memory
     verbose: false
-    use_native_tool_calling: true
+    use_native_tool_calling: false
     max_history: 8000
     parse_agent_response_max_retries: 2
     raise_on_parsing_failure: false
-    accept_direct_answer_without_react_format: false
+    accept_direct_answer_without_react_format: true
     additional_instructions: |
       === 에이전트 요약 ===
       매매 규칙·시나리오·BUY/SELL/HOLD 관점의 전략 제안. 뉴스·수급(mcp-news)과 잔고·시세(Kis MCP) 결과를 근거로 한국어로 정리합니다.

--- a/finus_nat/configs/agents/trading_agent.yml
+++ b/finus_nat/configs/agents/trading_agent.yml
@@ -30,7 +30,7 @@ functions:
     parse_agent_response_max_retries: 5
     raise_on_parsing_failure: false
     # native tool calling 사용 시 텍스트에 Action: 없어도 native API로 도구가 호출되므로 허용
-    accept_direct_answer_without_react_format: true
+    accept_direct_answer_without_react_format: false
     max_tool_calls: 10
     additional_instructions: |
       주식·채권·선물옵션·해외·ETF 등의 질문에서는 `kis-trading-mcp-tool`을 호출합니다.

--- a/finus_nat/configs/agents/trading_agent.yml
+++ b/finus_nat/configs/agents/trading_agent.yml
@@ -26,11 +26,11 @@ functions:
       - add_user_memory
       - get_user_memory
     verbose: true
-    use_native_tool_calling: true
+    use_native_tool_calling: false
     parse_agent_response_max_retries: 5
     raise_on_parsing_failure: false
-    # 도구 없이 hallucination으로 답변하는 것을 막기 위해 도구 사용을 강제
-    accept_direct_answer_without_react_format: false
+    # native tool calling 사용 시 텍스트에 Action: 없어도 native API로 도구가 호출되므로 허용
+    accept_direct_answer_without_react_format: true
     max_tool_calls: 10
     additional_instructions: |
       주식·채권·선물옵션·해외·ETF 등의 질문에서는 `kis-trading-mcp-tool`을 호출합니다.


### PR DESCRIPTION
## 📝 개요

`/api/v1/analyze?provider=nat` 호출 시 한글 종목명으로 인한 500 오류와 NAT ReAct 에이전트 도구 실행 실패 두 가지 버그를 수정합니다.

## 🚀 변경 사항

- `backend/services.py`: `_nat_conversation_id()`에서 종목명을 `urllib.parse.quote()`로 퍼센트 인코딩 — `conversation-id` 헤더의 `UnicodeEncodeError` 방지
- `backend/tests/test_services.py`: NAT conversation-id 테스트 기대값을 percent-encoded 종목명 기준으로 갱신
- `finus_nat/configs/agents/*.yml` (6개): `use_native_tool_calling: false`로 변경 — `gpt-5.4-mini`의 `multi_tool_use.parallel` 미지원 문제 회피
- `finus_nat/configs/agents/*.yml` (6개): `accept_direct_answer_without_react_format: false` 유지 — 데이터 조회 도구 사용 전 직접 답변으로 종료하지 않도록 ReAct 형식 강제

## 🔗 관련 이슈

- Related to #44

## ✅ 체크리스트

- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 🧪 검증

```bash
UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_services.py -q
# 10 passed
```

## 📸 스크린샷 (선택 사항)
