### PR TITLE
feat: GitHub Actions CI 워크플로 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Node 20 설치 (npm 캐시 활성화)
+      - name: Node 24 설치 (npm 캐시 활성화)
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend-react/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+# PR과 main 푸시에서 검증을 자동 실행한다.
+# main 직접 푸시는 브랜치 보호로 막혀 있으므로 push 트리거는 사실상 머지 시점에만 발화한다.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# 동일 브랜치에서 새 푸시가 일어나면 이전 실행을 취소해 자원을 절약한다.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-test:
+    name: Backend pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: uv 설치 (자체 캐시 활성화)
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Python 3.13 설치
+        run: uv python install 3.13
+
+      - name: backend 의존성 동기화
+        run: uv sync --project backend
+
+      - name: backend 테스트 실행
+        run: uv run --project backend pytest backend/tests/
+
+  nat-test:
+    name: finus_nat pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: uv 설치 (자체 캐시 활성화)
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Python 3.13 설치
+        run: uv python install 3.13
+
+      - name: finus_nat 의존성 동기화
+        run: uv sync --project finus_nat
+
+      - name: finus_nat 테스트 실행
+        run: uv run --project finus_nat pytest finus_nat/tests/
+
+  frontend-typecheck:
+    name: Frontend tsc --noEmit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend-react
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Node 20 설치 (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend-react/package-lock.json
+
+      - name: npm 의존성 설치
+        run: npm ci
+
+      - name: 타입 체크
+        run: npx tsc --noEmit
+
+  docker-lint:
+    name: Dockerfile hadolint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - backend/Dockerfile
+          - finus_nat/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: hadolint 실행 - ${{ matrix.dockerfile }}
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ${{ matrix.dockerfile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,6 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
+          # warning/info(DL3008/DL4006/DL3059) 등 기존 부채는 별도 이슈로 정리.
+          # CI에서는 실제 error만 차단해 회귀를 막는다.
+          failure-threshold: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,5 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
-          # warning/info(DL3008/DL4006/DL3059) 등 기존 부채는 별도 이슈로 정리.
-          # CI에서는 실제 error만 차단해 회귀를 막는다.
-          failure-threshold: error
+          # Dockerfile 부채(#52)가 정리됐으므로 warning까지 차단해 신규 부채 유입을 막는다.
+          failure-threshold: warning

--- a/finus_nat/pyproject.toml
+++ b/finus_nat/pyproject.toml
@@ -37,3 +37,9 @@ nat_finus_nat = "nat_finus_nat.register"
 [project.scripts]
 finus-chat = "nat_finus_nat.chat_cli:main"
 
+[dependency-groups]
+dev = [
+  "pytest>=9.0,<10",
+  "pytest-asyncio>=1.3,<2",
+]
+

--- a/finus_nat/uv.lock
+++ b/finus_nat/uv.lock
@@ -952,6 +952,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1630,8 +1639,20 @@ dependencies = [
     { name = "nvidia-nat", extra = ["langchain", "mcp", "mem0ai"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "nvidia-nat", extras = ["langchain", "mcp", "mem0ai"], specifier = ">=1.6.0,<2" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0,<10" },
+    { name = "pytest-asyncio", specifier = ">=1.3,<2" },
+]
 
 [[package]]
 name = "nest-asyncio2"
@@ -2226,6 +2247,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2483,6 +2513,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/e6/0adc3b374f5c5d1eebd4f551b455c6865c449b170b17545001b208e2b153/pymilvus-2.6.11.tar.gz", hash = "sha256:a40c10322cde25184a8c3d84993a14dfb67ad2bdcfc5dff7e68b11a79ff8f6d8", size = 1583634, upload-time = "2026-03-27T06:25:46.023Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/1c/bccb331d71f824738f80f11e9b8b4da47973c903826355526ae4fa2b762f/pymilvus-2.6.11-py3-none-any.whl", hash = "sha256:a11e1718b15045361c71ca671b959900cb7e2faae863c896f6b7e87bf2e4d10a", size = 315252, upload-time = "2026-03-27T06:25:44.215Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📝 개요
PR과 main 푸시 시 backend/finus_nat 테스트, 프런트엔드 타입 체크, Dockerfile 린트를 자동 실행하는 GitHub Actions CI 워크플로(`.github/workflows/ci.yml`)를 추가합니다. 동시에 워크플로의 Node 버전을 EOL된 20에서 현재 Active LTS인 24로 맞췄습니다.

## 🚀 변경 사항
- `.github/workflows/ci.yml` 신규 추가
  - 트리거: `pull_request` + `push: main`
  - 동시성 제어: 같은 ref에 새 푸시 시 이전 실행 취소 (`cancel-in-progress: true`)
  - 4개 잡 병렬 실행:
    - `backend-test`: `astral-sh/setup-uv` + Python 3.13 + `uv run --project backend pytest backend/tests/`
    - `nat-test`: 동일 셋업 + `uv run --project finus_nat pytest finus_nat/tests/`
    - `frontend-typecheck`: Node 24 + npm 캐시 + `npm ci` + `npx tsc --noEmit`
    - `docker-lint`: matrix로 `backend/Dockerfile`, `finus_nat/Dockerfile`에 hadolint 실행
- CI Node 버전을 20 → 24(Active LTS)로 상향 (Node 20은 2026-04 EOL)

## 🔗 관련 이슈
- Closes #48
- Related to #49 (frontend-react Dockerfile의 Node 20-slim → 24-slim 후속 작업)

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요? (워크플로 자체가 검증 도구이며, 본 PR이 머지된 이후의 PR부터 자동 검증이 적용됩니다)
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요? (CI 사용법 README 안내는 후속 작업으로 분리 가능)

## 📸 스크린샷 (선택 사항)
해당 없음.

---

머지 후 권장 후속 조치: GitHub 레포 **Settings → Branches → main** 보호 규칙에서 `backend-test` / `nat-test` / `frontend-typecheck` / `docker-lint` 잡을 "Required status checks"로 지정해야 "녹색이어야만 머지 가능"이 강제됩니다.