### PR TITLE
fix: MainDashboard Tooltip formatter Recharts 타입 불일치 해소

### DIFF
--- a/frontend-react/src/components/MainDashboard.tsx
+++ b/frontend-react/src/components/MainDashboard.tsx
@@ -74,7 +74,7 @@ const MainDashboard: React.FC<MainDashboardProps> = ({ trendData, report }) => {
               <Tooltip
                 cursor={{ fill: '#f8fafc' }}
                 contentStyle={{ borderRadius: '24px', border: 'none', boxShadow: '0 25px 50px -12px rgb(0 0 0 / 0.15)', padding: '20px' }}
-                formatter={(value: number) => [formatNumber(value), '']}
+                formatter={(value) => [formatNumber(Number(value)), '']}
               />
               <ReferenceLine y={0} stroke="#cbd5e1" strokeWidth={2} />
               <Bar dataKey="foreigner" radius={[6, 6, 0, 0]}>


### PR DESCRIPTION
## 📝 개요
`frontend-react/src/components/MainDashboard.tsx:77`의 Recharts `Tooltip` `formatter` 콜백 시그니처가 라이브러리 타입(`Formatter<ValueType, NameType>`)과 맞지 않아 `npx tsc --noEmit` 실행 시 TS2322 에러로 빌드가 실패하고 있었습니다. 시그니처를 라이브러리 타입에 위임하고 내부에서 `Number()`로 안전하게 변환해 빌드를 정상화합니다.

## 🚀 변경 사항
- `frontend-react/src/components/MainDashboard.tsx:77` Tooltip formatter 콜백 수정
  - 변경 전: `formatter={(value: number) => [formatNumber(value), '']}`
  - 변경 후: `formatter={(value) => [formatNumber(Number(value)), '']}`
- `value` 타입을 Recharts가 추론하도록 위임 (`ValueType | undefined`)
- 내부에서 `Number(value)`로 number 변환 → `formatNumber(num: number)` 호출 계약 유지
- 런타임 상 `TrendItem.foreigner`/`institution`은 항상 `number`이므로 동작 변경 없음

## 🔗 관련 이슈
- Closes #51
- Related to #48 (CI 도입으로 처음 노출된 기존 부채)

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요? (`cd frontend-react && npx tsc --noEmit` → 0 에러 확인)
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요? (해당 없음 — 내부 타입 수정)

## 📸 스크린샷 (선택 사항)
해당 없음. UI 렌더링은 동일.