### PR TITLE
fix: frontend-react Node 베이스 이미지를 node:24-slim으로 상향

### DIFF
--- a/frontend-react/Dockerfile
+++ b/frontend-react/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -11,6 +11,9 @@
   "author": "",
   "license": "ISC",
   "description": "",
+  "engines": {
+    "node": ">=24"
+  },
   "dependencies": {
     "axios": "^1.14.0",
     "lucide-react": "^1.7.0",


### PR DESCRIPTION
## 📝 개요
`frontend-react/Dockerfile`의 베이스 이미지가 EOL된 `node:20-slim`을 사용 중이라 현재 Active LTS인 `node:24-slim`으로 상향합니다. backend/finus_nat은 이미 Node 24를 사용 중이라 frontend만 구버전에 묶여 있던 정렬 불일치를 해소합니다. 추가로 `frontend-react/package.json`에 `engines.node` 필드를 함께 명시해 로컬 개발 환경에서도 동일한 메이저를 강제합니다.

## 🚀 변경 사항
- `frontend-react/Dockerfile:1` 베이스 이미지 변경
  - 변경 전: `FROM node:20-slim`
  - 변경 후: `FROM node:24-slim`
- `frontend-react/package.json`에 `engines.node: ">=24"` 추가
  - 로컬 npm install/dev 시 Node 메이저 불일치를 경고로 노출
  - 의도를 명시적으로 문서화

## 🔗 관련 이슈
- Closes #49
- Related to #48 (CI Node 24 정렬 작업의 런타임 이미지 후속)

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요? (`node -e "JSON.parse(...)"`로 package.json 유효성 확인)
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요? (해당 없음 — 런타임 이미지 메이저 상향)

## 📸 스크린샷 (선택 사항)
해당 없음.

---

### 권장 후속 검증 (리뷰어/머지 후)
- 로컬: `docker compose build frontend && docker compose up frontend`로 Vite dev 서버가 정상 기동하는지 확인.
- npm 6+에서 engines 위반을 강제하려면 별도 `.npmrc`에 `engine-strict=true`를 추가하는 안도 있으나, 현재 PR 범위에는 포함하지 않음.