### PR TITLE
chore: backend/finus_nat Dockerfile hadolint 경고 정리

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.13-slim
 
+# 파이프 도중 실패(curl 등)를 다음 명령으로 무시하지 않도록 bash pipefail 사용
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# DL3008: python:3.13-slim의 Debian 저장소는 패키지 구버전을 주기적으로 제거해 버전 핀은 오히려 재현성을 해친다.
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gnupg && \
     curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \

--- a/finus_nat/Dockerfile
+++ b/finus_nat/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.13-slim
 
+# 파이프 도중 실패(curl 등)를 다음 명령으로 무시하지 않도록 bash pipefail 사용
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# DL3008: python:3.13-slim의 Debian 저장소는 패키지 구버전을 주기적으로 제거해 버전 핀은 오히려 재현성을 해친다.
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -28,6 +33,8 @@ RUN npm ci
 
 WORKDIR /workspace/finus_nat
 RUN uv sync --no-dev
+# DL3059: uv sync와 mem0ai 패치는 캐시 무효화 시점이 다르므로 일부러 RUN을 분리한다.
+# hadolint ignore=DL3059
 RUN python - <<'PY'
 from pathlib import Path
 


### PR DESCRIPTION
## 📝 개요
`backend/Dockerfile`과 `finus_nat/Dockerfile`에서 hadolint가 지적하던 `DL4006`(파이프 RUN의 pipefail 미설정), `DL3008`(apt-get 버전 핀 부재), `DL3059`(연속 RUN 권고) 경고를 정리합니다. 의미 있는 개선(SHELL pipefail)은 적용하고, 베이스 이미지/캐싱 구조상 합리적인 의도(apt 버전 비핀, RUN 분리)는 사유 주석과 함께 `# hadolint ignore=...`로 명시합니다.

## 🚀 변경 사항
- `backend/Dockerfile`
  - `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` 추가 → curl|bash 파이프 중간 실패가 다음 명령으로 전파되도록 (`DL4006`)
  - `apt-get install`에 `# hadolint ignore=DL3008` + 사유 주석 → `python:3.13-slim` 베이스의 Debian 저장소 특성상 버전 핀이 재현성을 오히려 해침
- `finus_nat/Dockerfile`
  - 위 두 가지 동일 적용
  - `uv sync` 와 `mem0ai` 패치 RUN 사이에 `# hadolint ignore=DL3059` + 사유 주석 → 두 RUN은 캐시 무효화 시점이 달라 의도적으로 분리됨

## 🔗 관련 이슈
- Closes #52
- Related to #48 (CI hadolint 도입 → 본 PR로 부채 정리)

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
  - 로컬: `docker run --rm -i hadolint/hadolint:v2.12.0-debian < backend/Dockerfile` → exit 0
  - 로컬: `docker run --rm -i hadolint/hadolint:v2.12.0-debian < finus_nat/Dockerfile` → exit 0
  - 두 파일 모두 기본 임계값(`info`) 기준 0건 검출 확인
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요? (해당 없음 — Dockerfile 정적 검증 정리)

## 📸 스크린샷 (선택 사항)
해당 없음.

---

### 권장 후속 작업 (별도 PR)
본 PR과 #50이 모두 main에 머지된 이후, `.github/workflows/ci.yml`의 hadolint `failure-threshold`를 현재 `error`(이슈 #48 PR에서 잠정 완화)에서 `warning`(또는 `info`)으로 다시 강화해, 신규 Dockerfile 부채가 들어오면 CI가 즉시 막도록 정렬하는 것을 권장합니다. 본 PR은 main에서 분기한 상태라 ci.yml이 아직 존재하지 않아 본 PR 범위에는 포함하지 않았습니다.