### PR TITLE
feat: Telegram 수동 주문 기능 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ KIS_API_KEY=your_kis_api_key_here
 KIS_API_SECRET=your_kis_api_secret_here
 KIS_ACCOUNT_NO=1234567801
 KIS_URL=https://openapivts.koreainvestment.com:29443
+FINUS_KIS_TRADING_MCP_URL=http://host.docker.internal:3300/sse
+FINUS_KIS_TRADING_MCP_TRANSPORT=sse
+FINUS_KIS_TRADING_TOOL_NAME=domestic_stock
+KIS_ORDER_ENV=demo
+KIS_REAL_ORDER_ENABLED=false
 
 # Naver Search API Configuration
 NAVER_CLIENT_ID=your_naver_client_id_here

--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,6 @@ KIS_API_KEY=your_kis_api_key_here
 KIS_API_SECRET=your_kis_api_secret_here
 KIS_ACCOUNT_NO=1234567801
 KIS_URL=https://openapivts.koreainvestment.com:29443
-FINUS_KIS_TRADING_MCP_URL=http://host.docker.internal:3300/sse
-FINUS_KIS_TRADING_MCP_TRANSPORT=sse
-FINUS_KIS_TRADING_TOOL_NAME=domestic_stock
 KIS_ORDER_ENV=demo
 KIS_REAL_ORDER_ENABLED=false
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,3 @@ CLAUDE.md
 mcp-dart/data/corp-codes.json
 
 .superpowers/
-docs/superpowers/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ CLAUDE.md
 mcp-dart/data/corp-codes.json
 
 .superpowers/
+docs/code-review/

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ CLAUDE.md
 mcp-dart/data/corp-codes.json
 
 .superpowers/
-docs/superpowers/
+docs/superpowers/plans/

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 
 `/buy`와 `/sell`은 60초 동안 유효한 주문 확인 대기를 만들고, 지정가를 생략하면 시장가 주문으로 준비합니다. 주문 확인 메시지의 `확정`/`취소` 버튼 또는 `/confirm`/`/cancel` 명령으로 처리할 수 있습니다. `/confirm`은 로컬 `mcp-trading`의 `place_order` 도구를 통해 한국투자증권 Open API 현금 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령도 같은 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
 
+슬래시 명령 대신 `삼성전자 1주 시장가로 매수해줘`, `NAVER 2주 200,000원에 매도해줘`처럼 입력해도 같은 주문 확인 대기가 생성됩니다. 자연어 주문도 실제 제출 전에는 반드시 `확정` 버튼 또는 `/confirm`이 필요합니다.
+
 `mcp-trading/data/stocks.json`은 KIS 공개 코스피/코스닥 종목 마스터 기반의 종목명 해석 캐시입니다. 신규 상장 등으로 종목명이 잡히지 않으면 6자리 종목코드를 직접 입력하거나 아래 명령으로 캐시를 갱신합니다.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 /cancel        # 대기 중인 수동 주문 취소
 ```
 
-`/buy`와 `/sell`은 60초 동안 유효한 지정가 주문 확인 대기를 만들고, `/confirm`은 공식 KIS Trading MCP를 통해 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령은 계속 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
+`/buy`와 `/sell`은 60초 동안 유효한 지정가 주문 확인 대기를 만들고, `/confirm`은 로컬 `mcp-trading`의 `place_order` 도구를 통해 한국투자증권 Open API 현금 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령도 같은 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
 
 슬래시 명령이 아닌 일반 텍스트는 NAT 채팅으로 전달됩니다. Telegram 채팅은 `telegram:{chat_id}` conversation id를 사용하므로 스케줄러 분석 리포트와 대화 이력이 섞이지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,13 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 /balance        # 예수금·총자산·보유 종목 조회
 /quote <종목명> # 현재가 조회
 /trend <종목명> # 외국인·기관·개인 수급 조회
+/buy <종목명> <수량> <지정가>  # 60초 매수 확인 대기 생성
+/sell <종목명> <수량> <지정가> # 60초 매도 확인 대기 생성
+/confirm       # 대기 중인 수동 주문 실행
+/cancel        # 대기 중인 수동 주문 취소
 ```
+
+`/buy`와 `/sell`은 60초 동안 유효한 지정가 주문 확인 대기를 만들고, `/confirm`은 공식 KIS Trading MCP를 통해 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령은 계속 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
 
 슬래시 명령이 아닌 일반 텍스트는 NAT 채팅으로 전달됩니다. Telegram 채팅은 `telegram:{chat_id}` conversation id를 사용하므로 스케줄러 분석 리포트와 대화 이력이 섞이지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -165,13 +165,19 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 /balance        # 예수금·총자산·보유 종목 조회
 /quote <종목명> # 현재가 조회
 /trend <종목명> # 외국인·기관·개인 수급 조회
-/buy <종목명> <수량> <지정가>  # 60초 매수 확인 대기 생성
-/sell <종목명> <수량> <지정가> # 60초 매도 확인 대기 생성
+/buy <종목명|6자리코드> <수량> [지정가]  # 60초 매수 확인 대기 생성
+/sell <종목명|6자리코드> <수량> [지정가] # 60초 매도 확인 대기 생성
 /confirm       # 대기 중인 수동 주문 실행
 /cancel        # 대기 중인 수동 주문 취소
 ```
 
-`/buy`와 `/sell`은 60초 동안 유효한 지정가 주문 확인 대기를 만들고, `/confirm`은 로컬 `mcp-trading`의 `place_order` 도구를 통해 한국투자증권 Open API 현금 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령도 같은 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
+`/buy`와 `/sell`은 60초 동안 유효한 주문 확인 대기를 만들고, 지정가를 생략하면 시장가 주문으로 준비합니다. 주문 확인 메시지의 `확정`/`취소` 버튼 또는 `/confirm`/`/cancel` 명령으로 처리할 수 있습니다. `/confirm`은 로컬 `mcp-trading`의 `place_order` 도구를 통해 한국투자증권 Open API 현금 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령도 같은 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
+
+`mcp-trading/data/stocks.json`은 KIS 공개 코스피/코스닥 종목 마스터 기반의 종목명 해석 캐시입니다. 신규 상장 등으로 종목명이 잡히지 않으면 6자리 종목코드를 직접 입력하거나 아래 명령으로 캐시를 갱신합니다.
+
+```bash
+python3 mcp-trading/scripts/update_stock_master.py
+```
 
 슬래시 명령이 아닌 일반 텍스트는 NAT 채팅으로 전달됩니다. Telegram 채팅은 `telegram:{chat_id}` conversation id를 사용하므로 스케줄러 분석 리포트와 대화 이력이 섞이지 않습니다.
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -72,12 +72,6 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 # Telegram urgent alert settings.
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
-KIS_TRADING_MCP_URL = os.environ.get(
-    "FINUS_KIS_TRADING_MCP_URL",
-    "http://host.docker.internal:3300/sse",
-).strip()
-KIS_TRADING_MCP_TRANSPORT = os.environ.get("FINUS_KIS_TRADING_MCP_TRANSPORT", "sse").strip()
-KIS_TRADING_MCP_TOOL_NAME = os.environ.get("FINUS_KIS_TRADING_TOOL_NAME", "domestic_stock").strip()
 KIS_ORDER_ENV = os.environ.get("KIS_ORDER_ENV", "demo").strip().lower()
 KIS_REAL_ORDER_ENABLED = os.environ.get("KIS_REAL_ORDER_ENABLED", "").strip().lower() in {
     "1",

--- a/backend/config.py
+++ b/backend/config.py
@@ -72,6 +72,19 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 # Telegram urgent alert settings.
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
+KIS_TRADING_MCP_URL = os.environ.get(
+    "FINUS_KIS_TRADING_MCP_URL",
+    "http://host.docker.internal:3300/sse",
+).strip()
+KIS_TRADING_MCP_TRANSPORT = os.environ.get("FINUS_KIS_TRADING_MCP_TRANSPORT", "sse").strip()
+KIS_TRADING_MCP_TOOL_NAME = os.environ.get("FINUS_KIS_TRADING_TOOL_NAME", "domestic_stock").strip()
+KIS_ORDER_ENV = os.environ.get("KIS_ORDER_ENV", "demo").strip().lower()
+KIS_REAL_ORDER_ENABLED = os.environ.get("KIS_REAL_ORDER_ENABLED", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "y",
+}
 
 
 def is_placeholder_secret(value: str | None) -> bool:

--- a/backend/services.py
+++ b/backend/services.py
@@ -23,6 +23,18 @@ from .models import AgentReport
 logger = logging.getLogger(__name__)
 _NAT_RESPONSE_LOG_PREVIEW_CHARS = 800
 
+
+def _find_http_exception(exc: BaseException) -> HTTPException | None:
+    if isinstance(exc, HTTPException):
+        return exc
+    if isinstance(exc, BaseExceptionGroup):
+        for nested in exc.exceptions:
+            found = _find_http_exception(nested)
+            if found is not None:
+                return found
+    return None
+
+
 def _nat_conversation_id(
     stock: str,
     *,
@@ -352,6 +364,9 @@ async def run_mcp_tool(
     except HTTPException:
         raise
     except Exception as exc:
+        http_exc = _find_http_exception(exc)
+        if http_exc is not None:
+            raise http_exc from exc
         logger.exception("MCP call_tool failed for %s", tool_name)
         raise HTTPException(
             status_code=500,

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -33,6 +33,16 @@ ALERT_COMMAND_HELP = "사용법: /alerts urgent | all | off | status"
 BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> [지정가]"
 SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> [지정가]"
 ORDER_EXPIRES_AFTER = timedelta(seconds=60)
+ORDER_CONFIRM_CALLBACK = "order:confirm"
+ORDER_CANCEL_CALLBACK = "order:cancel"
+ORDER_CONFIRM_REPLY_MARKUP = {
+    "inline_keyboard": [
+        [
+            {"text": "✅ 확정", "callback_data": ORDER_CONFIRM_CALLBACK},
+            {"text": "❌ 취소", "callback_data": ORDER_CANCEL_CALLBACK},
+        ]
+    ]
+}
 TELEGRAM_INTERACTIVE_HELP = "\n".join(
     [
         "사용 가능한 명령:",
@@ -112,6 +122,11 @@ class TelegramCommandHandler:
         self.pending_orders: dict[str, PendingOrder] = {}
 
     async def handle_update(self, update: dict[str, Any]) -> None:
+        callback_query = update.get("callback_query") or {}
+        if callback_query:
+            await self._handle_callback_query(callback_query)
+            return
+
         message = update.get("message") or {}
         chat = message.get("chat") or {}
         if str(chat.get("id", "")).strip() != self.notifier.chat_id:
@@ -155,10 +170,45 @@ class TelegramCommandHandler:
 
         await self._handle_chat_fallback(text, str(chat.get("id", "")).strip())
 
-    async def _send_text_or_raise(self, text: str) -> None:
-        sent = await self.notifier.send_text(text)
+    async def _send_text_or_raise(
+        self,
+        text: str,
+        *,
+        reply_markup: dict[str, Any] | None = None,
+    ) -> None:
+        sent = await self.notifier.send_text(text, reply_markup=reply_markup)
         if sent is False:
             raise RuntimeError("telegram send failed")
+
+    async def _handle_callback_query(self, callback_query: dict[str, Any]) -> None:
+        message = callback_query.get("message") or {}
+        chat = message.get("chat") or {}
+        chat_id = str(chat.get("id", "")).strip()
+        if chat_id != self.notifier.chat_id:
+            return
+
+        callback_query_id = str(callback_query.get("id", "")).strip()
+        data = str(callback_query.get("data") or "").strip()
+        if data == ORDER_CONFIRM_CALLBACK:
+            await self._answer_callback_query(callback_query_id)
+            await self._handle_confirm(chat_id)
+            return
+        if data == ORDER_CANCEL_CALLBACK:
+            await self._answer_callback_query(callback_query_id)
+            await self._handle_cancel(chat_id)
+            return
+
+        await self._answer_callback_query(callback_query_id, text="지원하지 않는 버튼입니다.")
+
+    async def _answer_callback_query(
+        self,
+        callback_query_id: str,
+        *,
+        text: str | None = None,
+    ) -> None:
+        if not callback_query_id:
+            return
+        await self.notifier.answer_callback_query(callback_query_id, text=text)
 
     def _matches_command(self, command: str, bot_username: str, expected: str) -> bool:
         if command != expected:
@@ -270,7 +320,8 @@ class TelegramCommandHandler:
         )
         self.pending_orders[chat_id] = order
         await self._send_text_or_raise(
-            self._format_order_prompt(order, str(quote_result), str(balance_result))
+            self._format_order_prompt(order, str(quote_result), str(balance_result)),
+            reply_markup=ORDER_CONFIRM_REPLY_MARKUP,
         )
 
     async def _handle_cancel(self, chat_id: str) -> None:

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -267,10 +267,15 @@ class TelegramCommandHandler:
             await self._send_text_or_raise(f"주문 실패: {_short_error(exc)}")
             return
 
-        if self.trade_recorder is not None:
-            self.trade_recorder.record(result)
         self.pending_orders.pop(chat_id, None)
-        await self._send_text_or_raise(f"주문 완료: {result.message}")
+        record_warning = ""
+        if self.trade_recorder is not None:
+            try:
+                self.trade_recorder.record(result)
+            except Exception as exc:
+                logger.warning("Trade history recording failed: %s", exc)
+                record_warning = f"\n거래 이력 기록 실패: {_short_error(exc)}"
+        await self._send_text_or_raise(f"주문 완료: {result.message}{record_warning}")
 
     def _parse_order_argument(self, argument: str) -> tuple[str, int, int] | None:
         parts = argument.split()

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -21,6 +21,7 @@ from .telegram_notifier import TELEGRAM_ALERT_MODES, TelegramNotifier, telegram_
 from .trading_orders import (
     KST,
     McpTradingOrderGateway,
+    OrderType,
     PendingOrder,
     TradeRecorder,
     is_korean_market_open,
@@ -29,8 +30,8 @@ from .trading_orders import (
 logger = logging.getLogger(__name__)
 
 ALERT_COMMAND_HELP = "사용법: /alerts urgent | all | off | status"
-BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> <지정가>"
-SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> <지정가>"
+BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> [지정가]"
+SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> [지정가]"
 ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 TELEGRAM_INTERACTIVE_HELP = "\n".join(
     [
@@ -39,8 +40,8 @@ TELEGRAM_INTERACTIVE_HELP = "\n".join(
         "/balance - 예수금·총자산·보유 종목 조회",
         "/quote <종목명> - 현재가 조회",
         "/trend <종목명> - 외국인·기관·개인 수급 조회",
-        "/buy <종목명> <수량> <지정가> - 지정가 매수 주문 준비",
-        "/sell <종목명> <수량> <지정가> - 지정가 매도 주문 준비",
+        "/buy <종목명> <수량> [지정가] - 매수 주문 준비",
+        "/sell <종목명> <수량> [지정가] - 매도 주문 준비",
         "/confirm - 대기 주문 확정",
         "/cancel - 대기 주문 취소",
         "일반 문장은 NAT에게 바로 질문합니다.",
@@ -219,7 +220,7 @@ class TelegramCommandHandler:
             await self._send_text_or_raise(usage)
             return
 
-        stock_name, quantity, price = parsed
+        stock_name, quantity, price, order_type = parsed
         now = self.now_factory()
         if not is_korean_market_open(now):
             await self._send_text_or_raise(
@@ -265,6 +266,7 @@ class TelegramCommandHandler:
             quantity=quantity,
             price=price,
             created_at=now,
+            order_type=order_type,
         )
         self.pending_orders[chat_id] = order
         await self._send_text_or_raise(
@@ -316,22 +318,37 @@ class TelegramCommandHandler:
                 record_warning = f"\n거래 이력 기록 실패: {_short_error(exc)}"
         await self._send_text_or_raise(f"주문 완료: {result.message}{record_warning}")
 
-    def _parse_order_argument(self, argument: str) -> tuple[str, int, int] | None:
+    def _parse_order_argument(self, argument: str) -> tuple[str, int, int, OrderType] | None:
         parts = argument.split()
-        if len(parts) < 3:
+        if len(parts) < 2:
             return None
-        stock_name = " ".join(parts[:-2]).strip()
-        raw_quantity, raw_price = parts[-2:]
+
+        last_value = self._parse_positive_int(parts[-1])
+        if last_value is None:
+            return None
+
+        previous_value = self._parse_positive_int(parts[-2]) if len(parts) >= 3 else None
+        if previous_value is None:
+            stock_name = " ".join(parts[:-1]).strip()
+            quantity = last_value
+            price = 0
+            order_type: OrderType = "MARKET"
+        else:
+            stock_name = " ".join(parts[:-2]).strip()
+            quantity = previous_value
+            price = last_value
+            order_type = "LIMIT"
+
         if not stock_name:
             return None
+        return stock_name, quantity, price, order_type
+
+    def _parse_positive_int(self, raw_value: str) -> int | None:
         try:
-            quantity = int(raw_quantity.replace(",", ""))
-            price = int(raw_price.replace(",", ""))
+            value = int(raw_value.replace(",", ""))
         except ValueError:
             return None
-        if quantity <= 0 or price <= 0:
-            return None
-        return stock_name, quantity, price
+        return value if value > 0 else None
 
     def _drop_expired_pending_order(self, chat_id: str, now: datetime) -> None:
         order = self.pending_orders.get(chat_id)
@@ -356,14 +373,20 @@ class TelegramCommandHandler:
         balance_result: str,
     ) -> str:
         side_text = "매수" if order.side == "BUY" else "매도"
-        amount = order.quantity * order.price
         lines = [
             f"{order.stock_name} {side_text} 주문 확인",
             f"종목코드: {order.stock_code}",
             f"수량: {order.quantity:,}주",
-            f"지정가: {order.price:,}원",
-            f"주문금액: {amount:,}원",
+            f"주문유형: {'시장가' if order.order_type == 'MARKET' else '지정가'}",
         ]
+        if order.order_type == "LIMIT":
+            amount = order.quantity * order.price
+            lines.extend(
+                [
+                    f"지정가: {order.price:,}원",
+                    f"주문금액: {amount:,}원",
+                ]
+            )
 
         current_price = self._first_line_containing(
             str(quote_result),

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 ALERT_COMMAND_HELP = "사용법: /alerts urgent | all | off | status"
 BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> <지정가>"
 SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> <지정가>"
+CONFIRM_PLACEHOLDER_MESSAGE = "주문 확정 기능은 아직 연결되지 않았습니다."
+CANCEL_PLACEHOLDER_MESSAGE = "주문 취소 기능은 아직 연결되지 않았습니다."
 ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 TELEGRAM_INTERACTIVE_HELP = "\n".join(
     [
@@ -114,6 +116,12 @@ class TelegramCommandHandler:
             return
         if self._matches_command(command, bot_username, "/sell"):
             await self._handle_order_command("SELL", argument, str(chat.get("id", "")).strip())
+            return
+        if self._matches_command(command, bot_username, "/confirm"):
+            await self._send_text_or_raise(CONFIRM_PLACEHOLDER_MESSAGE)
+            return
+        if self._matches_command(command, bot_username, "/cancel"):
+            await self._send_text_or_raise(CANCEL_PLACEHOLDER_MESSAGE)
             return
         if text.startswith("/"):
             await self._send_text_or_raise(TELEGRAM_INTERACTIVE_HELP)
@@ -237,9 +245,12 @@ class TelegramCommandHandler:
 
     def _parse_order_argument(self, argument: str) -> tuple[str, int, int] | None:
         parts = argument.split()
-        if len(parts) != 3:
+        if len(parts) < 3:
             return None
-        stock_name, raw_quantity, raw_price = parts
+        stock_name = " ".join(parts[:-2]).strip()
+        raw_quantity, raw_price = parts[-2:]
+        if not stock_name:
+            return None
         try:
             quantity = int(raw_quantity.replace(",", ""))
             price = int(raw_price.replace(",", ""))
@@ -286,14 +297,14 @@ class TelegramCommandHandler:
             ("현재가", "price", "Price"),
         )
         if current_price:
-            lines.append(f"현재가: {current_price}")
+            lines.append(current_price)
 
         balance = self._first_line_containing(
             str(balance_result),
             ("주문가능", "예수금", "총자산", "balance"),
         )
         if balance:
-            lines.append(f"잔고: {balance}")
+            lines.append(balance)
 
         lines.extend(
             [

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -6,12 +6,28 @@ from datetime import datetime, timedelta
 from typing import Any, Callable
 
 import httpx
+from sqlmodel import Session
 
-from .config import TRADING_MCP_PARAMS
+from .config import (
+    KIS_ORDER_ENV,
+    KIS_REAL_ORDER_ENABLED,
+    KIS_TRADING_MCP_TOOL_NAME,
+    KIS_TRADING_MCP_TRANSPORT,
+    KIS_TRADING_MCP_URL,
+    TRADING_MCP_PARAMS,
+)
+from .database import engine
 from .redis_state import RedisSchedulerState, redis_state
 from .services import llm_chat, run_mcp_tool
 from .telegram_notifier import TELEGRAM_ALERT_MODES, TelegramNotifier, telegram_notifier
-from .trading_orders import KST, PendingOrder, is_korean_market_open
+from .trading_orders import (
+    KST,
+    OfficialKisMcpOrderGateway,
+    PendingOrder,
+    TradeRecorder,
+    call_official_kis_mcp,
+    is_korean_market_open,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +76,27 @@ def _telegram_command_parts(text: str) -> tuple[str, str, str]:
     command, _, argument = text.partition(" ")
     command_name, separator, bot_username = command.partition("@")
     return command_name.lower(), bot_username.lower() if separator else "", argument.strip()
+
+
+def _create_order_gateway() -> OfficialKisMcpOrderGateway:
+    transport = (
+        KIS_TRADING_MCP_TRANSPORT
+        if KIS_TRADING_MCP_TRANSPORT in {"sse", "streamable-http"}
+        else "sse"
+    )
+    order_env = "real" if KIS_ORDER_ENV == "real" else "demo"
+    return OfficialKisMcpOrderGateway(
+        mcp_url=KIS_TRADING_MCP_URL,
+        mcp_transport=transport,
+        tool_name=KIS_TRADING_MCP_TOOL_NAME,
+        order_env=order_env,
+        real_order_enabled=KIS_REAL_ORDER_ENABLED,
+        remote_runner=call_official_kis_mcp,
+    )
+
+
+def _create_trade_recorder() -> TradeRecorder:
+    return TradeRecorder(lambda: Session(engine))
 
 
 class TelegramCommandHandler:
@@ -406,7 +443,13 @@ class TelegramCommandPoller:
         handler: TelegramCommandHandler | None = None,
     ):
         self.notifier = notifier
-        self.handler = handler or TelegramCommandHandler(notifier=notifier)
+        if handler is None:
+            handler = TelegramCommandHandler(
+                notifier=notifier,
+                order_gateway=_create_order_gateway(),
+                trade_recorder=_create_trade_recorder(),
+            )
+        self.handler = handler
         self.offset: int | None = None
 
     async def run(self) -> None:

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -18,8 +18,6 @@ logger = logging.getLogger(__name__)
 ALERT_COMMAND_HELP = "사용법: /alerts urgent | all | off | status"
 BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> <지정가>"
 SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> <지정가>"
-CONFIRM_PLACEHOLDER_MESSAGE = "주문 확정 기능은 아직 연결되지 않았습니다."
-CANCEL_PLACEHOLDER_MESSAGE = "주문 취소 기능은 아직 연결되지 않았습니다."
 ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 TELEGRAM_INTERACTIVE_HELP = "\n".join(
     [
@@ -118,10 +116,10 @@ class TelegramCommandHandler:
             await self._handle_order_command("SELL", argument, str(chat.get("id", "")).strip())
             return
         if self._matches_command(command, bot_username, "/confirm"):
-            await self._send_text_or_raise(CONFIRM_PLACEHOLDER_MESSAGE)
+            await self._handle_confirm(str(chat.get("id", "")).strip())
             return
         if self._matches_command(command, bot_username, "/cancel"):
-            await self._send_text_or_raise(CANCEL_PLACEHOLDER_MESSAGE)
+            await self._handle_cancel(str(chat.get("id", "")).strip())
             return
         if text.startswith("/"):
             await self._send_text_or_raise(TELEGRAM_INTERACTIVE_HELP)
@@ -242,6 +240,37 @@ class TelegramCommandHandler:
         await self._send_text_or_raise(
             self._format_order_prompt(order, str(quote_result), str(balance_result))
         )
+
+    async def _handle_cancel(self, chat_id: str) -> None:
+        self._drop_expired_pending_order(chat_id, self.now_factory())
+        if chat_id not in self.pending_orders:
+            await self._send_text_or_raise("취소할 대기 주문이 없습니다.")
+            return
+
+        self.pending_orders.pop(chat_id, None)
+        await self._send_text_or_raise("대기 주문을 취소했습니다.")
+
+    async def _handle_confirm(self, chat_id: str) -> None:
+        self._drop_expired_pending_order(chat_id, self.now_factory())
+        order = self.pending_orders.get(chat_id)
+        if order is None:
+            await self._send_text_or_raise("확정할 대기 주문이 없습니다.")
+            return
+        if self.order_gateway is None:
+            await self._send_text_or_raise("주문 실행 설정이 준비되지 않았습니다.")
+            return
+
+        await self.notifier.send_chat_action("typing")
+        try:
+            result = await self.order_gateway.place_order(order)
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 실패: {_short_error(exc)}")
+            return
+
+        if self.trade_recorder is not None:
+            self.trade_recorder.record(result)
+        self.pending_orders.pop(chat_id, None)
+        await self._send_text_or_raise(f"주문 완료: {result.message}")
 
     def _parse_order_argument(self, argument: str) -> tuple[str, int, int] | None:
         parts = argument.split()

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
+import re
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
 from typing import Any, Callable
 
 import httpx
@@ -9,10 +11,14 @@ from .config import TRADING_MCP_PARAMS
 from .redis_state import RedisSchedulerState, redis_state
 from .services import llm_chat, run_mcp_tool
 from .telegram_notifier import TELEGRAM_ALERT_MODES, TelegramNotifier, telegram_notifier
+from .trading_orders import KST, PendingOrder, is_korean_market_open
 
 logger = logging.getLogger(__name__)
 
 ALERT_COMMAND_HELP = "사용법: /alerts urgent | all | off | status"
+BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> <지정가>"
+SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> <지정가>"
+ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 TELEGRAM_INTERACTIVE_HELP = "\n".join(
     [
         "사용 가능한 명령:",
@@ -20,6 +26,10 @@ TELEGRAM_INTERACTIVE_HELP = "\n".join(
         "/balance - 예수금·총자산·보유 종목 조회",
         "/quote <종목명> - 현재가 조회",
         "/trend <종목명> - 외국인·기관·개인 수급 조회",
+        "/buy <종목명> <수량> <지정가> - 지정가 매수 주문 준비",
+        "/sell <종목명> <수량> <지정가> - 지정가 매도 주문 준비",
+        "/confirm - 대기 주문 확정",
+        "/cancel - 대기 주문 취소",
         "일반 문장은 NAT에게 바로 질문합니다.",
     ]
 )
@@ -60,11 +70,18 @@ class TelegramCommandHandler:
         state_factory: Callable[[], Any] = redis_state,
         mcp_runner: Callable[[Any, str, dict[str, Any]], Any] = run_mcp_tool,
         llm_runner: Callable[..., Any] = llm_chat,
+        order_gateway: Any | None = None,
+        trade_recorder: Any | None = None,
+        now_factory: Callable[[], datetime] | None = None,
     ):
         self.notifier = notifier
         self.state_factory = state_factory
         self.mcp_runner = mcp_runner
         self.llm_runner = llm_runner
+        self.order_gateway = order_gateway
+        self.trade_recorder = trade_recorder
+        self.now_factory = now_factory or (lambda: datetime.now(KST))
+        self.pending_orders: dict[str, PendingOrder] = {}
 
     async def handle_update(self, update: dict[str, Any]) -> None:
         message = update.get("message") or {}
@@ -91,6 +108,12 @@ class TelegramCommandHandler:
             return
         if self._matches_command(command, bot_username, "/trend"):
             await self._handle_trend(argument)
+            return
+        if self._matches_command(command, bot_username, "/buy"):
+            await self._handle_order_command("BUY", argument, str(chat.get("id", "")).strip())
+            return
+        if self._matches_command(command, bot_username, "/sell"):
+            await self._handle_order_command("SELL", argument, str(chat.get("id", "")).strip())
             return
         if text.startswith("/"):
             await self._send_text_or_raise(TELEGRAM_INTERACTIVE_HELP)
@@ -155,6 +178,139 @@ class TelegramCommandHandler:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
         await self._send_text_or_raise(_telegram_text(str(result)))
+
+    async def _handle_order_command(self, side: str, argument: str, chat_id: str) -> None:
+        usage = BUY_COMMAND_HELP if side == "BUY" else SELL_COMMAND_HELP
+        parsed = self._parse_order_argument(argument)
+        if parsed is None:
+            await self._send_text_or_raise(usage)
+            return
+
+        stock_name, quantity, price = parsed
+        now = self.now_factory()
+        if not is_korean_market_open(now):
+            await self._send_text_or_raise(
+                "주문 불가: 현재 장 운영 시간이 아닙니다. (평일 09:00~15:30)"
+            )
+            return
+
+        self._drop_expired_pending_order(chat_id, now)
+        if chat_id in self.pending_orders:
+            await self._send_text_or_raise(
+                "이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요."
+            )
+            return
+
+        await self.notifier.send_chat_action("typing")
+        try:
+            resolved = await self.mcp_runner(
+                TRADING_MCP_PARAMS,
+                "resolve_stock_code",
+                {"stock_name": stock_name},
+            )
+            stock_code = self._extract_stock_code(str(resolved)) or stock_name
+            quote_result, balance_result = await asyncio.gather(
+                self.mcp_runner(
+                    TRADING_MCP_PARAMS,
+                    "get_stock_quote",
+                    {"stock_name": stock_name},
+                ),
+                self.mcp_runner(TRADING_MCP_PARAMS, "get_balance", {}),
+            )
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 준비 실패: {_short_error(exc)}")
+            return
+
+        order = PendingOrder(
+            chat_id=chat_id,
+            stock_name=stock_name,
+            stock_code=stock_code,
+            side=side,
+            quantity=quantity,
+            price=price,
+            created_at=now,
+        )
+        self.pending_orders[chat_id] = order
+        await self._send_text_or_raise(
+            self._format_order_prompt(order, str(quote_result), str(balance_result))
+        )
+
+    def _parse_order_argument(self, argument: str) -> tuple[str, int, int] | None:
+        parts = argument.split()
+        if len(parts) != 3:
+            return None
+        stock_name, raw_quantity, raw_price = parts
+        try:
+            quantity = int(raw_quantity.replace(",", ""))
+            price = int(raw_price.replace(",", ""))
+        except ValueError:
+            return None
+        if quantity <= 0 or price <= 0:
+            return None
+        return stock_name, quantity, price
+
+    def _drop_expired_pending_order(self, chat_id: str, now: datetime) -> None:
+        order = self.pending_orders.get(chat_id)
+        if order is None:
+            return
+        created_at = order.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=KST)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=KST)
+        if now.astimezone(KST) - created_at.astimezone(KST) > ORDER_EXPIRES_AFTER:
+            self.pending_orders.pop(chat_id, None)
+
+    def _extract_stock_code(self, text: str) -> str | None:
+        match = re.search(r"\b(\d{6})\b", text)
+        return match.group(1) if match else None
+
+    def _format_order_prompt(
+        self,
+        order: PendingOrder,
+        quote_result: str,
+        balance_result: str,
+    ) -> str:
+        side_text = "매수" if order.side == "BUY" else "매도"
+        amount = order.quantity * order.price
+        lines = [
+            f"{order.stock_name} {side_text} 주문 확인",
+            f"종목코드: {order.stock_code}",
+            f"수량: {order.quantity:,}주",
+            f"지정가: {order.price:,}원",
+            f"주문금액: {amount:,}원",
+        ]
+
+        current_price = self._first_line_containing(
+            str(quote_result),
+            ("현재가", "price", "Price"),
+        )
+        if current_price:
+            lines.append(f"현재가: {current_price}")
+
+        balance = self._first_line_containing(
+            str(balance_result),
+            ("주문가능", "예수금", "총자산", "balance"),
+        )
+        if balance:
+            lines.append(f"잔고: {balance}")
+
+        lines.extend(
+            [
+                "",
+                "/confirm 입력 시 대기 주문을 확정합니다.",
+                "/cancel 입력 시 대기 주문을 취소합니다.",
+                "이 주문은 60초 후 만료됩니다.",
+            ]
+        )
+        return "\n".join(lines)
+
+    def _first_line_containing(self, text: str, needles: tuple[str, ...]) -> str | None:
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped and any(needle in stripped for needle in needles):
+                return stripped
+        return None
 
     async def _handle_trend(self, argument: str) -> None:
         if not argument:

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 ALERT_COMMAND_HELP = "사용법: /alerts urgent | all | off | status"
 BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> [지정가]"
 SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> [지정가]"
+NATURAL_ORDER_HELP = "자연어 주문을 해석할 수 없습니다. /buy 또는 /sell 형식으로 입력하세요."
 ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 ORDER_CONFIRM_CALLBACK = "order:confirm"
 ORDER_CANCEL_CALLBACK = "order:cancel"
@@ -166,6 +167,20 @@ class TelegramCommandHandler:
             return
         if text.startswith("/"):
             await self._send_text_or_raise(TELEGRAM_INTERACTIVE_HELP)
+            return
+
+        if self._looks_like_natural_order(text):
+            natural_order = self._parse_natural_order_text(text)
+            if natural_order is None:
+                await self._send_text_or_raise(NATURAL_ORDER_HELP)
+                return
+
+            side, order_argument = natural_order
+            await self._handle_order_command(
+                side,
+                order_argument,
+                str(chat.get("id", "")).strip(),
+            )
             return
 
         await self._handle_chat_fallback(text, str(chat.get("id", "")).strip())
@@ -393,6 +408,51 @@ class TelegramCommandHandler:
         if not stock_name:
             return None
         return stock_name, quantity, price, order_type
+
+    def _looks_like_natural_order(self, text: str) -> bool:
+        return (
+            ("매수" in text or "매도" in text)
+            and re.search(r"\d[\d,]*\s*주", text) is not None
+        )
+
+    def _parse_natural_order_text(self, text: str) -> tuple[str, str] | None:
+        buy_count = text.count("매수")
+        sell_count = text.count("매도")
+        if buy_count + sell_count != 1:
+            return None
+        side = "BUY" if buy_count == 1 else "SELL"
+
+        quantity_match = re.search(r"(?P<quantity>\d[\d,]*)\s*주", text)
+        if quantity_match is None:
+            return None
+        quantity = self._parse_positive_int(quantity_match.group("quantity"))
+        if quantity is None:
+            return None
+
+        has_market = "시장가" in text
+        price_matches = list(re.finditer(r"(?P<price>\d[\d,]*)\s*원", text))
+        if has_market and price_matches:
+            return None
+        price = 0
+        if price_matches:
+            price = self._parse_positive_int(price_matches[-1].group("price")) or 0
+            if price <= 0:
+                return None
+
+        stock_name = text[: quantity_match.start()].strip()
+        if not stock_name:
+            side_word = "매수" if side == "BUY" else "매도"
+            side_index = text.find(side_word)
+            if side_index < quantity_match.start():
+                stock_name = text[
+                    side_index + len(side_word) : quantity_match.start()
+                ].strip()
+        if not stock_name:
+            return None
+
+        if price > 0:
+            return side, f"{stock_name} {quantity} {price}"
+        return side, f"{stock_name} {quantity}"
 
     def _parse_positive_int(self, raw_value: str) -> int | None:
         try:

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import re
+import secrets
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Any, Callable
@@ -36,14 +37,7 @@ NATURAL_ORDER_HELP = "자연어 주문을 해석할 수 없습니다. /buy 또�
 ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 ORDER_CONFIRM_CALLBACK = "order:confirm"
 ORDER_CANCEL_CALLBACK = "order:cancel"
-ORDER_CONFIRM_REPLY_MARKUP = {
-    "inline_keyboard": [
-        [
-            {"text": "✅ 확정", "callback_data": ORDER_CONFIRM_CALLBACK},
-            {"text": "❌ 취소", "callback_data": ORDER_CANCEL_CALLBACK},
-        ]
-    ]
-}
+ORDER_STALE_CALLBACK_TEXT = "이전 주문 버튼입니다. 최신 주문 메시지에서 다시 선택하세요."
 TELEGRAM_INTERACTIVE_HELP = "\n".join(
     [
         "사용 가능한 명령:",
@@ -204,16 +198,46 @@ class TelegramCommandHandler:
 
         callback_query_id = str(callback_query.get("id", "")).strip()
         data = str(callback_query.get("data") or "").strip()
-        if data == ORDER_CONFIRM_CALLBACK:
-            await self._answer_callback_query(callback_query_id)
-            await self._handle_confirm(chat_id)
+        if data == ORDER_CONFIRM_CALLBACK or data.startswith(f"{ORDER_CONFIRM_CALLBACK}:"):
+            await self._handle_order_callback(
+                callback_query_id,
+                chat_id,
+                "confirm",
+                data,
+            )
             return
-        if data == ORDER_CANCEL_CALLBACK:
-            await self._answer_callback_query(callback_query_id)
-            await self._handle_cancel(chat_id)
+        if data == ORDER_CANCEL_CALLBACK or data.startswith(f"{ORDER_CANCEL_CALLBACK}:"):
+            await self._handle_order_callback(
+                callback_query_id,
+                chat_id,
+                "cancel",
+                data,
+            )
             return
 
         await self._answer_callback_query(callback_query_id, text="지원하지 않는 버튼입니다.")
+
+    async def _handle_order_callback(
+        self,
+        callback_query_id: str,
+        chat_id: str,
+        action: str,
+        data: str,
+    ) -> None:
+        order = self.pending_orders.get(chat_id)
+        token = self._extract_order_callback_token(data)
+        if order is None or not token or token != order.callback_token:
+            await self._answer_callback_query(
+                callback_query_id,
+                text=ORDER_STALE_CALLBACK_TEXT,
+            )
+            return
+
+        await self._answer_callback_query(callback_query_id)
+        if action == "confirm":
+            await self._handle_confirm(chat_id)
+            return
+        await self._handle_cancel(chat_id)
 
     async def _answer_callback_query(
         self,
@@ -332,11 +356,12 @@ class TelegramCommandHandler:
             price=price,
             created_at=now,
             order_type=order_type,
+            callback_token=secrets.token_urlsafe(8),
         )
         self.pending_orders[chat_id] = order
         await self._send_text_or_raise(
             self._format_order_prompt(order, str(quote_result), str(balance_result)),
-            reply_markup=ORDER_CONFIRM_REPLY_MARKUP,
+            reply_markup=self._order_reply_markup(order),
         )
 
     async def _handle_cancel(self, chat_id: str) -> None:
@@ -476,6 +501,34 @@ class TelegramCommandHandler:
     def _extract_stock_code(self, text: str) -> str | None:
         match = re.search(r"\b(\d{6})\b", text)
         return match.group(1) if match else None
+
+    def _extract_order_callback_token(self, data: str) -> str | None:
+        if data in {ORDER_CONFIRM_CALLBACK, ORDER_CANCEL_CALLBACK}:
+            return None
+        _, separator, token = data.rpartition(":")
+        if not separator:
+            return None
+        return token.strip() or None
+
+    def _order_reply_markup(self, order: PendingOrder) -> dict[str, Any]:
+        return {
+            "inline_keyboard": [
+                [
+                    {
+                        "text": "✅ 확정",
+                        "callback_data": (
+                            f"{ORDER_CONFIRM_CALLBACK}:{order.callback_token}"
+                        ),
+                    },
+                    {
+                        "text": "❌ 취소",
+                        "callback_data": (
+                            f"{ORDER_CANCEL_CALLBACK}:{order.callback_token}"
+                        ),
+                    },
+                ]
+            ]
+        }
 
     def _format_order_prompt(
         self,

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -12,9 +12,6 @@ from sqlmodel import Session
 from .config import (
     KIS_ORDER_ENV,
     KIS_REAL_ORDER_ENABLED,
-    KIS_TRADING_MCP_TOOL_NAME,
-    KIS_TRADING_MCP_TRANSPORT,
-    KIS_TRADING_MCP_URL,
     TRADING_MCP_PARAMS,
 )
 from .database import engine
@@ -23,10 +20,9 @@ from .services import llm_chat, run_mcp_tool
 from .telegram_notifier import TELEGRAM_ALERT_MODES, TelegramNotifier, telegram_notifier
 from .trading_orders import (
     KST,
-    OfficialKisMcpOrderGateway,
+    McpTradingOrderGateway,
     PendingOrder,
     TradeRecorder,
-    call_official_kis_mcp,
     is_korean_market_open,
 )
 
@@ -79,20 +75,13 @@ def _telegram_command_parts(text: str) -> tuple[str, str, str]:
     return command_name.lower(), bot_username.lower() if separator else "", argument.strip()
 
 
-def _create_order_gateway() -> OfficialKisMcpOrderGateway:
-    transport = (
-        KIS_TRADING_MCP_TRANSPORT
-        if KIS_TRADING_MCP_TRANSPORT in {"sse", "streamable-http"}
-        else "sse"
-    )
+def _create_order_gateway() -> McpTradingOrderGateway:
     order_env = "real" if KIS_ORDER_ENV == "real" else "demo"
-    return OfficialKisMcpOrderGateway(
-        mcp_url=KIS_TRADING_MCP_URL,
-        mcp_transport=transport,
-        tool_name=KIS_TRADING_MCP_TOOL_NAME,
+    return McpTradingOrderGateway(
+        server_params=TRADING_MCP_PARAMS,
+        mcp_runner=run_mcp_tool,
         order_env=order_env,
         real_order_enabled=KIS_REAL_ORDER_ENABLED,
-        remote_runner=call_official_kis_mcp,
     )
 
 

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any, Callable
 
 import httpx
+from fastapi import HTTPException
 from sqlmodel import Session
 
 from .config import (
@@ -251,7 +252,10 @@ class TelegramCommandHandler:
                 "resolve_stock_code",
                 {"stock_name": stock_name},
             )
-            stock_code = self._extract_stock_code(str(resolved)) or stock_name
+            stock_code = self._extract_stock_code(str(resolved))
+            if stock_code is None:
+                await self._send_text_or_raise("주문 준비 실패: 종목코드를 확인할 수 없습니다.")
+                return
             quote_result, balance_result = await asyncio.gather(
                 self.mcp_runner(
                     TRADING_MCP_PARAMS,
@@ -301,7 +305,16 @@ class TelegramCommandHandler:
         try:
             result = await self.order_gateway.place_order(order)
         except Exception as exc:
-            await self._send_text_or_raise(f"주문 실패: {_short_error(exc)}")
+            if isinstance(exc, HTTPException) and exc.status_code == 403:
+                await self._send_text_or_raise(f"주문 실패: {_short_error(exc)}")
+                return
+
+            self.pending_orders.pop(chat_id, None)
+            await self._send_text_or_raise(
+                "주문 실패 또는 상태 확인 필요: "
+                f"{_short_error(exc)}\n"
+                "중복 주문 방지를 위해 대기 주문을 제거했습니다."
+            )
             return
 
         self.pending_orders.pop(chat_id, None)

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -139,15 +139,42 @@ class TelegramNotifier:
             logger.error("Telegram alert send failed for %s/%s: %s", source, stock, exc)
             return False
 
-    async def send_text(self, text: str) -> bool:
+    async def send_text(
+        self,
+        text: str,
+        *,
+        reply_markup: dict[str, Any] | None = None,
+    ) -> bool:
         if not self.enabled:
             return False
 
         try:
-            await self._post_message(text[:4000])
+            await self._post_message(text[:4000], reply_markup=reply_markup)
             return True
         except Exception as exc:
             logger.error("Telegram message send failed: %s", exc)
+            return False
+
+    async def answer_callback_query(
+        self,
+        callback_query_id: str,
+        *,
+        text: str | None = None,
+    ) -> bool:
+        if not self.enabled:
+            return False
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/answerCallbackQuery"
+        payload = {"callback_query_id": callback_query_id}
+        if text:
+            payload["text"] = text
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(url, json=payload)
+                response.raise_for_status()
+            return True
+        except Exception as exc:
+            logger.error("Telegram callback answer failed: %s", exc)
             return False
 
     async def send_chat_action(self, action: str = "typing") -> bool:
@@ -187,17 +214,22 @@ class TelegramNotifier:
             logger.error("Telegram bot username lookup failed: %s", exc)
             return ""
 
-    async def _post_message(self, text: str) -> None:
+    async def _post_message(
+        self,
+        text: str,
+        *,
+        reply_markup: dict[str, Any] | None = None,
+    ) -> None:
         url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
+        payload = {
+            "chat_id": self.chat_id,
+            "text": text,
+            "disable_web_page_preview": True,
+        }
+        if reply_markup is not None:
+            payload["reply_markup"] = reply_markup
         async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.post(
-                url,
-                json={
-                    "chat_id": self.chat_id,
-                    "text": text,
-                    "disable_web_page_preview": True,
-                },
-            )
+            response = await client.post(url, json=payload)
             response.raise_for_status()
 
 

--- a/backend/tests/test_market_data_routes.py
+++ b/backend/tests/test_market_data_routes.py
@@ -70,3 +70,28 @@ def test_get_trading_trend_response_shape_and_tool_route(monkeypatch):
     assert captured["tool_name"] == "get_investor_trading"
     assert captured["arguments"] == {"stock_name": "삼성전자"}
     assert captured["params"] == TRADING_MCP_PARAMS
+
+
+def test_get_trading_balance_response_shape_and_tool_route(monkeypatch):
+    captured = {}
+
+    async def mock_run_mcp_tool(params, tool_name, arguments):
+        captured["params"] = params
+        captured["tool_name"] = tool_name
+        captured["arguments"] = arguments
+        return "[계좌 잔고 현황]"
+
+    monkeypatch.setattr("backend.main.run_mcp_tool", mock_run_mcp_tool)
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/trading/balance")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "success",
+        "message": None,
+        "data": {"report": "[계좌 잔고 현황]"},
+    }
+    assert captured["tool_name"] == "get_balance"
+    assert captured["arguments"] == {}
+    assert captured["params"] == TRADING_MCP_PARAMS

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -173,6 +173,21 @@ def test_analysis_from_nat_text_defaults_telegram_urgency_fields():
     assert data["telegram_alert"] is False
 
 
+def test_find_http_exception_unwraps_nested_exception_group():
+    http_exc = HTTPException(status_code=500, detail="잔고 조회 에러 발생: 인증 실패")
+    grouped = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [
+            ExceptionGroup(
+                "unhandled errors in a TaskGroup",
+                [http_exc],
+            )
+        ],
+    )
+
+    assert services._find_http_exception(grouped) is http_exc
+
+
 def test_analysis_from_nat_text_parses_telegram_urgency_fields():
     data = services.analysis_from_nat_text(
         (

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -14,6 +14,7 @@ from backend.telegram_commands import (
     TelegramCommandHandler,
     TelegramCommandPoller,
 )
+from backend.trading_orders import OrderExecutionResult, PendingOrder
 
 KST = ZoneInfo("Asia/Seoul")
 
@@ -49,6 +50,34 @@ class FakeNotifier:
     async def load_bot_username(self):
         self.loaded_bot_username = True
         return self.bot_username
+
+
+class FakeOrderGateway:
+    def __init__(self, *, error=None):
+        self.error = error
+        self.orders = []
+
+    async def place_order(self, order):
+        self.orders.append(order)
+        if self.error is not None:
+            raise self.error
+        return OrderExecutionResult(
+            stock_code=order.stock_code,
+            stock_name=order.stock_name,
+            side=order.side,
+            quantity=order.quantity,
+            price=order.price,
+            message="주문 접수",
+            raw_result="{}",
+        )
+
+
+class FakeTradeRecorder:
+    def __init__(self):
+        self.results = []
+
+    def record(self, result):
+        self.results.append(result)
 
 
 @pytest.mark.asyncio
@@ -355,7 +384,80 @@ async def test_buy_command_accepts_stock_name_with_spaces():
 
 
 @pytest.mark.asyncio
-async def test_confirm_after_pending_order_replies_with_placeholder_not_help():
+async def test_cancel_removes_pending_order():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+    assert "대기 주문을 취소했습니다." in notifier.messages[-1]
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_pending_order_replies():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+    assert notifier.messages[-1] == "취소할 대기 주문이 없습니다."
+
+
+@pytest.mark.asyncio
+async def test_confirm_executes_gateway_and_records_trade():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    recorder = FakeTradeRecorder()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        trade_recorder=recorder,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert len(gateway.orders) == 1
+    assert isinstance(gateway.orders[0], PendingOrder)
+    assert len(recorder.results) == 1
+    assert recorder.results[0].stock_code == "005930"
+    assert notifier.actions == ["typing", "typing"]
+    assert "주문 완료" in notifier.messages[-1]
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_confirm_without_gateway_keeps_pending_order():
     async def mcp_runner(server_params, tool_name, arguments):
         if tool_name == "resolve_stock_code":
             return "삼성전자 (005930, KOSPI)"
@@ -377,19 +479,37 @@ async def test_confirm_after_pending_order_replies_with_placeholder_not_help():
     )
     await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
 
-    assert notifier.messages[-1] == "주문 확정 기능은 아직 연결되지 않았습니다."
-    assert notifier.messages[-1] != TELEGRAM_INTERACTIVE_HELP
+    assert notifier.messages[-1] == "주문 실행 설정이 준비되지 않았습니다."
+    assert "123" in handler.pending_orders
 
 
 @pytest.mark.asyncio
-async def test_cancel_replies_with_placeholder_not_help():
+async def test_confirm_gateway_failure_keeps_pending_order():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway(error=RuntimeError("gateway down"))
     notifier = FakeNotifier()
-    handler = TelegramCommandHandler(notifier=notifier)
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
 
-    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
 
-    assert notifier.messages[-1] == "주문 취소 기능은 아직 연결되지 않았습니다."
-    assert notifier.messages[-1] != TELEGRAM_INTERACTIVE_HELP
+    assert notifier.messages[-1] == "주문 실패: gateway down"
+    assert "123" in handler.pending_orders
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -3,6 +3,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+import backend.telegram_commands as telegram_commands
 from backend.config import TRADING_MCP_PARAMS
 from backend.telegram_commands import (
     BUY_COMMAND_HELP,
@@ -690,6 +691,62 @@ async def test_alerts_command_ignores_other_chats():
 
     assert state.mode == "urgent"
     assert notifier.messages == []
+
+
+def test_poller_default_handler_uses_order_gateway_and_trade_recorder_factories(monkeypatch):
+    gateway = object()
+    recorder = object()
+    notifier = FakeNotifier()
+
+    monkeypatch.setattr(telegram_commands, "_create_order_gateway", lambda: gateway)
+    monkeypatch.setattr(telegram_commands, "_create_trade_recorder", lambda: recorder)
+
+    poller = TelegramCommandPoller(notifier=notifier)
+
+    assert poller.handler.order_gateway is gateway
+    assert poller.handler.trade_recorder is recorder
+
+
+def test_poller_explicit_handler_does_not_call_dependency_factories(monkeypatch):
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    def fail_factory():
+        raise AssertionError("factory must not be called for explicit handler")
+
+    monkeypatch.setattr(telegram_commands, "_create_order_gateway", fail_factory)
+    monkeypatch.setattr(telegram_commands, "_create_trade_recorder", fail_factory)
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=handler)
+
+    assert poller.handler is handler
+
+
+def test_create_order_gateway_normalizes_transport_and_order_env(monkeypatch):
+    captured = {}
+
+    class FakeGateway:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(telegram_commands, "OfficialKisMcpOrderGateway", FakeGateway)
+    monkeypatch.setattr(telegram_commands, "KIS_TRADING_MCP_TRANSPORT", "stdio")
+    monkeypatch.setattr(telegram_commands, "KIS_ORDER_ENV", "sandbox")
+    monkeypatch.setattr(telegram_commands, "KIS_TRADING_MCP_URL", "http://kis.example/sse")
+    monkeypatch.setattr(telegram_commands, "KIS_TRADING_MCP_TOOL_NAME", "domestic_stock")
+    monkeypatch.setattr(telegram_commands, "KIS_REAL_ORDER_ENABLED", True)
+
+    gateway = telegram_commands._create_order_gateway()
+
+    assert isinstance(gateway, FakeGateway)
+    assert captured == {
+        "mcp_url": "http://kis.example/sse",
+        "mcp_transport": "sse",
+        "tool_name": "domestic_stock",
+        "order_env": "demo",
+        "real_order_enabled": True,
+        "remote_runner": telegram_commands.call_official_kis_mcp,
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -793,30 +793,25 @@ def test_poller_explicit_handler_does_not_call_dependency_factories(monkeypatch)
     assert poller.handler is handler
 
 
-def test_create_order_gateway_normalizes_transport_and_order_env(monkeypatch):
+def test_create_order_gateway_uses_local_mcp_trading(monkeypatch):
     captured = {}
 
     class FakeGateway:
         def __init__(self, **kwargs):
             captured.update(kwargs)
 
-    monkeypatch.setattr(telegram_commands, "OfficialKisMcpOrderGateway", FakeGateway)
-    monkeypatch.setattr(telegram_commands, "KIS_TRADING_MCP_TRANSPORT", "stdio")
+    monkeypatch.setattr(telegram_commands, "McpTradingOrderGateway", FakeGateway)
     monkeypatch.setattr(telegram_commands, "KIS_ORDER_ENV", "sandbox")
-    monkeypatch.setattr(telegram_commands, "KIS_TRADING_MCP_URL", "http://kis.example/sse")
-    monkeypatch.setattr(telegram_commands, "KIS_TRADING_MCP_TOOL_NAME", "domestic_stock")
     monkeypatch.setattr(telegram_commands, "KIS_REAL_ORDER_ENABLED", True)
 
     gateway = telegram_commands._create_order_gateway()
 
     assert isinstance(gateway, FakeGateway)
     assert captured == {
-        "mcp_url": "http://kis.example/sse",
-        "mcp_transport": "sse",
-        "tool_name": "domestic_stock",
+        "server_params": TRADING_MCP_PARAMS,
+        "mcp_runner": telegram_commands.run_mcp_tool,
         "order_env": "demo",
         "real_order_enabled": True,
-        "remote_runner": telegram_commands.call_official_kis_mcp,
     }
 
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1,7 +1,11 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 import pytest
 
 from backend.config import TRADING_MCP_PARAMS
 from backend.telegram_commands import (
+    BUY_COMMAND_HELP,
     QUOTE_COMMAND_HELP,
     TELEGRAM_INTERACTIVE_HELP,
     TELEGRAM_MESSAGE_LIMIT,
@@ -10,6 +14,8 @@ from backend.telegram_commands import (
     TelegramCommandHandler,
     TelegramCommandPoller,
 )
+
+KST = ZoneInfo("Asia/Seoul")
 
 
 class FakeState:
@@ -95,6 +101,10 @@ async def test_help_command_replies_with_supported_commands():
     assert "/balance - 예수금·총자산·보유 종목 조회" in notifier.messages[-1]
     assert "/quote <종목명> - 현재가 조회" in notifier.messages[-1]
     assert "/trend <종목명> - 외국인·기관·개인 수급 조회" in notifier.messages[-1]
+    assert "/buy <종목명> <수량> <지정가> - 지정가 매수 주문 준비" in notifier.messages[-1]
+    assert "/sell <종목명> <수량> <지정가> - 지정가 매도 주문 준비" in notifier.messages[-1]
+    assert "/confirm - 대기 주문 확정" in notifier.messages[-1]
+    assert "/cancel - 대기 주문 취소" in notifier.messages[-1]
     assert "일반 문장은 NAT에게 바로 질문합니다." in notifier.messages[-1]
 
 
@@ -264,6 +274,117 @@ async def test_quote_and_trend_missing_args_reply_with_usage():
     await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/trend"}})
 
     assert notifier.messages == [QUOTE_COMMAND_HELP, TREND_COMMAND_HELP]
+
+
+@pytest.mark.asyncio
+async def test_buy_command_creates_pending_order_and_prompts_confirmation():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 10 75,000"}}
+    )
+
+    assert calls == [
+        (TRADING_MCP_PARAMS, "resolve_stock_code", {"stock_name": "삼성전자"}),
+        (TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": "삼성전자"}),
+        (TRADING_MCP_PARAMS, "get_balance", {}),
+    ]
+    assert "삼성전자 매수 주문 확인" in notifier.messages[-1]
+    assert "/confirm" in notifier.messages[-1]
+    assert "/cancel" in notifier.messages[-1]
+    assert handler.pending_orders["123"].stock_name == "삼성전자"
+    assert handler.pending_orders["123"].stock_code == "005930"
+    assert handler.pending_orders["123"].side == "BUY"
+    assert handler.pending_orders["123"].quantity == 10
+    assert handler.pending_orders["123"].price == 75000
+
+
+@pytest.mark.asyncio
+async def test_sell_command_rejects_market_closed():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        return "should not be called"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 8, 59, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/sell 삼성전자 10 75,000"}}
+    )
+
+    assert notifier.messages == ["주문 불가: 현재 장 운영 시간이 아닙니다. (평일 09:00~15:30)"]
+    assert handler.pending_orders == {}
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_buy_command_rejects_invalid_args_with_usage():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 x 75000"}}
+    )
+
+    assert notifier.messages == [BUY_COMMAND_HELP]
+
+
+@pytest.mark.asyncio
+async def test_sell_command_rejects_duplicate_pending_order():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/sell 삼성전자 1 75000"}}
+    )
+
+    assert (
+        notifier.messages[-1]
+        == "이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요."
+    )
+    assert handler.pending_orders["123"].side == "BUY"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -353,8 +353,18 @@ async def test_buy_command_creates_pending_order_and_prompts_confirmation():
     assert notifier.reply_markups[-1] == {
         "inline_keyboard": [
             [
-                {"text": "✅ 확정", "callback_data": "order:confirm"},
-                {"text": "❌ 취소", "callback_data": "order:cancel"},
+                {
+                    "text": "✅ 확정",
+                    "callback_data": (
+                        f"order:confirm:{handler.pending_orders['123'].callback_token}"
+                    ),
+                },
+                {
+                    "text": "❌ 취소",
+                    "callback_data": (
+                        f"order:cancel:{handler.pending_orders['123'].callback_token}"
+                    ),
+                },
             ]
         ]
     }
@@ -454,8 +464,18 @@ async def test_natural_language_market_buy_creates_pending_order_without_nat():
     assert notifier.reply_markups[-1] == {
         "inline_keyboard": [
             [
-                {"text": "✅ 확정", "callback_data": "order:confirm"},
-                {"text": "❌ 취소", "callback_data": "order:cancel"},
+                {
+                    "text": "✅ 확정",
+                    "callback_data": (
+                        f"order:confirm:{handler.pending_orders['123'].callback_token}"
+                    ),
+                },
+                {
+                    "text": "❌ 취소",
+                    "callback_data": (
+                        f"order:cancel:{handler.pending_orders['123'].callback_token}"
+                    ),
+                },
             ]
         ]
     }
@@ -652,11 +672,12 @@ async def test_cancel_button_removes_pending_order():
     await handler.handle_update(
         {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
     )
+    callback_data = notifier.reply_markups[-1]["inline_keyboard"][0][1]["callback_data"]
     await handler.handle_update(
         {
             "callback_query": {
                 "id": "callback-1",
-                "data": "order:cancel",
+                "data": callback_data,
                 "message": {"chat": {"id": 123}},
             }
         }
@@ -738,11 +759,12 @@ async def test_confirm_button_executes_gateway_and_records_trade():
     await handler.handle_update(
         {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
     )
+    callback_data = notifier.reply_markups[-1]["inline_keyboard"][0][0]["callback_data"]
     await handler.handle_update(
         {
             "callback_query": {
                 "id": "callback-2",
-                "data": "order:confirm",
+                "data": callback_data,
                 "message": {"chat": {"id": 123}},
             }
         }
@@ -753,6 +775,46 @@ async def test_confirm_button_executes_gateway_and_records_trade():
     assert len(recorder.results) == 1
     assert "주문 완료" in notifier.messages[-1]
     assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_tokenless_old_confirm_button_does_not_execute_current_pending_order():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "old-callback",
+                "data": "order:confirm",
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert notifier.callback_answers == [
+        ("old-callback", "이전 주문 버튼입니다. 최신 주문 메시지에서 다시 선택하세요.")
+    ]
+    assert gateway.orders == []
+    assert "123" in handler.pending_orders
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
+from fastapi import HTTPException
 
 import backend.telegram_commands as telegram_commands
 from backend.config import TRADING_MCP_PARAMS
@@ -388,6 +389,34 @@ async def test_buy_command_accepts_stock_name_with_spaces():
 
 
 @pytest.mark.asyncio
+async def test_buy_command_rejects_unresolved_stock_code_before_quote_and_balance():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "종목을 찾지 못했습니다"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 알수없는종목 1 75000"}}
+    )
+
+    assert calls == [
+        (TRADING_MCP_PARAMS, "resolve_stock_code", {"stock_name": "알수없는종목"})
+    ]
+    assert notifier.messages[-1] == "주문 준비 실패: 종목코드를 확인할 수 없습니다."
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
 async def test_cancel_removes_pending_order():
     async def mcp_runner(server_params, tool_name, arguments):
         if tool_name == "resolve_stock_code":
@@ -523,7 +552,7 @@ async def test_confirm_without_gateway_keeps_pending_order():
 
 
 @pytest.mark.asyncio
-async def test_confirm_gateway_failure_keeps_pending_order():
+async def test_confirm_gateway_ambiguous_failure_clears_pending_order_and_blocks_retry():
     async def mcp_runner(server_params, tool_name, arguments):
         if tool_name == "resolve_stock_code":
             return "삼성전자 (005930, KOSPI)"
@@ -546,8 +575,50 @@ async def test_confirm_gateway_failure_keeps_pending_order():
         {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
     )
     await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
 
-    assert notifier.messages[-1] == "주문 실패: gateway down"
+    assert len(gateway.orders) == 1
+    assert notifier.messages[-2] == (
+        "주문 실패 또는 상태 확인 필요: gateway down\n"
+        "중복 주문 방지를 위해 대기 주문을 제거했습니다."
+    )
+    assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_confirm_real_order_guard_failure_keeps_pending_order():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway(
+        error=HTTPException(
+            status_code=403,
+            detail="실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다.",
+        )
+    )
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert notifier.messages[-1] == (
+        "주문 실패: 실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다."
+    )
     assert "123" in handler.pending_orders
 
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -309,11 +309,87 @@ async def test_buy_command_creates_pending_order_and_prompts_confirmation():
     assert "삼성전자 매수 주문 확인" in notifier.messages[-1]
     assert "/confirm" in notifier.messages[-1]
     assert "/cancel" in notifier.messages[-1]
+    assert "현재가: 현재가" not in notifier.messages[-1]
+    assert "잔고: 주문가능금액" not in notifier.messages[-1]
     assert handler.pending_orders["123"].stock_name == "삼성전자"
     assert handler.pending_orders["123"].stock_code == "005930"
     assert handler.pending_orders["123"].side == "BUY"
     assert handler.pending_orders["123"].quantity == 10
     assert handler.pending_orders["123"].price == 75000
+
+
+@pytest.mark.asyncio
+async def test_buy_command_accepts_stock_name_with_spaces():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "LG 화학 (051910, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 75,000원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy LG 화학 10 75000"}}
+    )
+
+    assert calls[0] == (
+        TRADING_MCP_PARAMS,
+        "resolve_stock_code",
+        {"stock_name": "LG 화학"},
+    )
+    assert "LG 화학 매수 주문 확인" in notifier.messages[-1]
+    assert handler.pending_orders["123"].stock_name == "LG 화학"
+    assert handler.pending_orders["123"].quantity == 10
+    assert handler.pending_orders["123"].price == 75000
+
+
+@pytest.mark.asyncio
+async def test_confirm_after_pending_order_replies_with_placeholder_not_help():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert notifier.messages[-1] == "주문 확정 기능은 아직 연결되지 않았습니다."
+    assert notifier.messages[-1] != TELEGRAM_INTERACTIVE_HELP
+
+
+@pytest.mark.asyncio
+async def test_cancel_replies_with_placeholder_not_help():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+    assert notifier.messages[-1] == "주문 취소 기능은 아직 연결되지 않았습니다."
+    assert notifier.messages[-1] != TELEGRAM_INTERACTIVE_HELP
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -135,8 +135,8 @@ async def test_help_command_replies_with_supported_commands():
     assert "/balance - 예수금·총자산·보유 종목 조회" in notifier.messages[-1]
     assert "/quote <종목명> - 현재가 조회" in notifier.messages[-1]
     assert "/trend <종목명> - 외국인·기관·개인 수급 조회" in notifier.messages[-1]
-    assert "/buy <종목명> <수량> <지정가> - 지정가 매수 주문 준비" in notifier.messages[-1]
-    assert "/sell <종목명> <수량> <지정가> - 지정가 매도 주문 준비" in notifier.messages[-1]
+    assert "/buy <종목명> <수량> [지정가] - 매수 주문 준비" in notifier.messages[-1]
+    assert "/sell <종목명> <수량> [지정가] - 매도 주문 준비" in notifier.messages[-1]
     assert "/confirm - 대기 주문 확정" in notifier.messages[-1]
     assert "/cancel - 대기 주문 취소" in notifier.messages[-1]
     assert "일반 문장은 NAT에게 바로 질문합니다." in notifier.messages[-1]
@@ -350,6 +350,51 @@ async def test_buy_command_creates_pending_order_and_prompts_confirmation():
     assert handler.pending_orders["123"].side == "BUY"
     assert handler.pending_orders["123"].quantity == 10
     assert handler.pending_orders["123"].price == 75000
+    assert handler.pending_orders["123"].order_type == "LIMIT"
+
+
+@pytest.mark.asyncio
+async def test_buy_command_without_price_creates_market_order_and_prompts_confirmation():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 10"}}
+    )
+
+    assert calls == [
+        (TRADING_MCP_PARAMS, "resolve_stock_code", {"stock_name": "삼성전자"}),
+        (TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": "삼성전자"}),
+        (TRADING_MCP_PARAMS, "get_balance", {}),
+    ]
+    assert "삼성전자 매수 주문 확인" in notifier.messages[-1]
+    assert "주문유형: 시장가" in notifier.messages[-1]
+    assert "지정가:" not in notifier.messages[-1]
+    assert "주문금액:" not in notifier.messages[-1]
+    assert "/confirm" in notifier.messages[-1]
+    assert "/cancel" in notifier.messages[-1]
+    assert handler.pending_orders["123"].stock_name == "삼성전자"
+    assert handler.pending_orders["123"].stock_code == "005930"
+    assert handler.pending_orders["123"].side == "BUY"
+    assert handler.pending_orders["123"].quantity == 10
+    assert handler.pending_orders["123"].price == 0
+    assert handler.pending_orders["123"].order_type == "MARKET"
 
 
 @pytest.mark.asyncio
@@ -386,6 +431,7 @@ async def test_buy_command_accepts_stock_name_with_spaces():
     assert handler.pending_orders["123"].stock_name == "LG 화학"
     assert handler.pending_orders["123"].quantity == 10
     assert handler.pending_orders["123"].price == 75000
+    assert handler.pending_orders["123"].order_type == "LIMIT"
 
 
 @pytest.mark.asyncio
@@ -654,9 +700,7 @@ async def test_buy_command_rejects_invalid_args_with_usage():
         now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
     )
 
-    await handler.handle_update(
-        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 x 75000"}}
-    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 x"}})
 
     assert notifier.messages == [BUY_COMMAND_HELP]
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -413,6 +413,133 @@ async def test_buy_command_without_price_creates_market_order_and_prompts_confir
 
 
 @pytest.mark.asyncio
+async def test_natural_language_market_buy_creates_pending_order_without_nat():
+    calls = []
+    nat_calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    async def fake_llm_runner(provider, text, *, conversation_id=None):
+        nat_calls.append((provider, text, conversation_id))
+        raise AssertionError("natural language order must not call NAT")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        llm_runner=fake_llm_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "삼성전자 1주 시장가로 매수해줘"}}
+    )
+
+    assert nat_calls == []
+    assert calls == [
+        (TRADING_MCP_PARAMS, "resolve_stock_code", {"stock_name": "삼성전자"}),
+        (TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": "삼성전자"}),
+        (TRADING_MCP_PARAMS, "get_balance", {}),
+    ]
+    assert "삼성전자 매수 주문 확인" in notifier.messages[-1]
+    assert "주문유형: 시장가" in notifier.messages[-1]
+    assert notifier.reply_markups[-1] == {
+        "inline_keyboard": [
+            [
+                {"text": "✅ 확정", "callback_data": "order:confirm"},
+                {"text": "❌ 취소", "callback_data": "order:cancel"},
+            ]
+        ]
+    }
+    assert handler.pending_orders["123"].stock_name == "삼성전자"
+    assert handler.pending_orders["123"].side == "BUY"
+    assert handler.pending_orders["123"].quantity == 1
+    assert handler.pending_orders["123"].price == 0
+    assert handler.pending_orders["123"].order_type == "MARKET"
+
+
+@pytest.mark.asyncio
+async def test_natural_language_limit_sell_creates_pending_order_without_nat():
+    calls = []
+    nat_calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "NAVER (035420, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 200,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    async def fake_llm_runner(provider, text, *, conversation_id=None):
+        nat_calls.append((provider, text, conversation_id))
+        raise AssertionError("natural language order must not call NAT")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        llm_runner=fake_llm_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "NAVER 2주 200,000원에 매도해줘"}}
+    )
+
+    assert nat_calls == []
+    assert calls[0] == (
+        TRADING_MCP_PARAMS,
+        "resolve_stock_code",
+        {"stock_name": "NAVER"},
+    )
+    assert "NAVER 매도 주문 확인" in notifier.messages[-1]
+    assert "주문유형: 지정가" in notifier.messages[-1]
+    assert "지정가: 200,000원" in notifier.messages[-1]
+    assert handler.pending_orders["123"].stock_name == "NAVER"
+    assert handler.pending_orders["123"].side == "SELL"
+    assert handler.pending_orders["123"].quantity == 2
+    assert handler.pending_orders["123"].price == 200000
+    assert handler.pending_orders["123"].order_type == "LIMIT"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_natural_language_order_replies_with_usage_without_nat():
+    nat_calls = []
+
+    async def fake_llm_runner(provider, text, *, conversation_id=None):
+        nat_calls.append((provider, text, conversation_id))
+        raise AssertionError("ambiguous natural language order must not call NAT")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        llm_runner=fake_llm_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "삼성전자 1주 시장가 75000원에 매수해줘"}}
+    )
+
+    assert nat_calls == []
+    assert notifier.messages == [
+        "자연어 주문을 해석할 수 없습니다. /buy 또는 /sell 형식으로 입력하세요."
+    ]
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
 async def test_buy_command_accepts_stock_name_with_spaces():
     calls = []
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -39,14 +39,21 @@ class FakeNotifier:
         self.bot_username = bot_username
         self.loaded_bot_username = False
         self.messages = []
+        self.reply_markups = []
         self.actions = []
+        self.callback_answers = []
 
-    async def send_text(self, text):
+    async def send_text(self, text, *, reply_markup=None):
         self.messages.append(text)
+        self.reply_markups.append(reply_markup)
         return self.send_text_result
 
     async def send_chat_action(self, action="typing"):
         self.actions.append(action)
+        return True
+
+    async def answer_callback_query(self, callback_query_id, text=None):
+        self.callback_answers.append((callback_query_id, text))
         return True
 
     async def load_bot_username(self):
@@ -343,6 +350,14 @@ async def test_buy_command_creates_pending_order_and_prompts_confirmation():
     assert "삼성전자 매수 주문 확인" in notifier.messages[-1]
     assert "/confirm" in notifier.messages[-1]
     assert "/cancel" in notifier.messages[-1]
+    assert notifier.reply_markups[-1] == {
+        "inline_keyboard": [
+            [
+                {"text": "✅ 확정", "callback_data": "order:confirm"},
+                {"text": "❌ 취소", "callback_data": "order:cancel"},
+            ]
+        ]
+    }
     assert "현재가: 현재가" not in notifier.messages[-1]
     assert "잔고: 주문가능금액" not in notifier.messages[-1]
     assert handler.pending_orders["123"].stock_name == "삼성전자"
@@ -490,6 +505,42 @@ async def test_cancel_removes_pending_order():
 
 
 @pytest.mark.asyncio
+async def test_cancel_button_removes_pending_order():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "callback-1",
+                "data": "order:cancel",
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert notifier.callback_answers == [("callback-1", None)]
+    assert "대기 주문을 취소했습니다." in notifier.messages[-1]
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
 async def test_cancel_without_pending_order_replies():
     notifier = FakeNotifier()
     handler = TelegramCommandHandler(notifier=notifier)
@@ -531,6 +582,48 @@ async def test_confirm_executes_gateway_and_records_trade():
     assert len(recorder.results) == 1
     assert recorder.results[0].stock_code == "005930"
     assert notifier.actions == ["typing", "typing"]
+    assert "주문 완료" in notifier.messages[-1]
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_confirm_button_executes_gateway_and_records_trade():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    recorder = FakeTradeRecorder()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        trade_recorder=recorder,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "callback-2",
+                "data": "order:confirm",
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert notifier.callback_answers == [("callback-2", None)]
+    assert len(gateway.orders) == 1
+    assert len(recorder.results) == 1
     assert "주문 완료" in notifier.messages[-1]
     assert handler.pending_orders == {}
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -73,11 +73,14 @@ class FakeOrderGateway:
 
 
 class FakeTradeRecorder:
-    def __init__(self):
+    def __init__(self, *, error=None):
+        self.error = error
         self.results = []
 
     def record(self, result):
         self.results.append(result)
+        if self.error is not None:
+            raise self.error
 
 
 @pytest.mark.asyncio
@@ -453,6 +456,41 @@ async def test_confirm_executes_gateway_and_records_trade():
     assert recorder.results[0].stock_code == "005930"
     assert notifier.actions == ["typing", "typing"]
     assert "주문 완료" in notifier.messages[-1]
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_confirm_gateway_success_recorder_failure_clears_pending_order():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    recorder = FakeTradeRecorder(error=RuntimeError("db commit failed"))
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        trade_recorder=recorder,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert len(gateway.orders) == 1
+    assert len(recorder.results) == 1
+    assert notifier.messages[-2] == "주문 완료: 주문 접수\n거래 이력 기록 실패: db commit failed"
+    assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
     assert handler.pending_orders == {}
 
 

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -138,6 +138,85 @@ def test_telegram_error_log_redacts_bot_token(caplog):
 
 
 @pytest.mark.asyncio
+async def test_send_text_posts_reply_markup(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def post(self, url, *, json):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    reply_markup = {
+        "inline_keyboard": [
+            [{"text": "확정", "callback_data": "order:confirm"}],
+        ]
+    }
+    monkeypatch.setattr("backend.telegram_notifier.httpx.AsyncClient", FakeAsyncClient)
+    notifier = TelegramNotifier("token", "123")
+
+    result = await notifier.send_text("주문 확인", reply_markup=reply_markup)
+
+    assert result is True
+    assert captured["url"] == "https://api.telegram.org/bottoken/sendMessage"
+    assert captured["json"] == {
+        "chat_id": "123",
+        "text": "주문 확인",
+        "disable_web_page_preview": True,
+        "reply_markup": reply_markup,
+    }
+
+
+@pytest.mark.asyncio
+async def test_answer_callback_query_posts_payload(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def post(self, url, *, json):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr("backend.telegram_notifier.httpx.AsyncClient", FakeAsyncClient)
+    notifier = TelegramNotifier("token", "123")
+
+    result = await notifier.answer_callback_query("callback-1", text="처리했습니다.")
+
+    assert result is True
+    assert captured["url"] == "https://api.telegram.org/bottoken/answerCallbackQuery"
+    assert captured["json"] == {
+        "callback_query_id": "callback-1",
+        "text": "처리했습니다.",
+    }
+
+
+@pytest.mark.asyncio
 async def test_send_chat_action_posts_typing_payload(monkeypatch):
     captured = {}
 

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -8,6 +8,8 @@ from backend.trading_orders import (
     OfficialKisMcpOrderGateway,
     OrderExecutionResult,
     PendingOrder,
+    _mcp_first_text_or_error,
+    call_official_kis_mcp,
     is_korean_market_open,
 )
 
@@ -138,3 +140,45 @@ async def test_demo_order_calls_mcp_runner_and_returns_normalized_result():
         message="주문 접수",
         raw_result='{"msg1":"주문 접수"}',
     )
+
+
+class _FakeTextBlock:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeMcpResult:
+    def __init__(self, *, content, is_error=False):
+        self.content = content
+        self.isError = is_error
+
+
+def test_mcp_first_text_or_error_returns_first_text_block():
+    result = _FakeMcpResult(content=[_FakeTextBlock("주문 접수"), _FakeTextBlock("ignored")])
+
+    assert _mcp_first_text_or_error(result) == "주문 접수"
+
+
+def test_mcp_first_text_or_error_raises_bad_gateway_for_error_result():
+    result = _FakeMcpResult(content=[_FakeTextBlock("KIS rejected order")], is_error=True)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _mcp_first_text_or_error(result)
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "KIS rejected order"
+
+
+@pytest.mark.asyncio
+async def test_call_official_kis_mcp_rejects_unsupported_transport_without_network():
+    with pytest.raises(HTTPException) as exc_info:
+        await call_official_kis_mcp(
+            transport="stdio",
+            url="http://127.0.0.1:3300/sse",
+            tool_name="domestic_stock",
+            arguments={},
+            timeout_sec=1.0,
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "지원하지 않는 KIS MCP transport" in str(exc_info.value.detail)

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -50,12 +50,16 @@ def test_trade_recorder_creates_trade_history_and_commits():
         def __init__(self):
             self.added = []
             self.committed = False
+            self.closed = False
 
         def add(self, item):
             self.added.append(item)
 
         def commit(self):
             self.committed = True
+
+        def close(self):
+            self.closed = True
 
     session = FakeSession()
     recorder = TradeRecorder(lambda: session)
@@ -79,6 +83,46 @@ def test_trade_recorder_creates_trade_history_and_commits():
     assert trade.quantity == 3
     assert trade.price == 75000.0
     assert session.committed is True
+    assert session.closed is True
+
+
+def test_trade_recorder_rolls_back_and_closes_when_commit_fails():
+    class FakeSession:
+        def __init__(self):
+            self.added = []
+            self.rolled_back = False
+            self.closed = False
+
+        def add(self, item):
+            self.added.append(item)
+
+        def commit(self):
+            raise RuntimeError("commit failed")
+
+        def rollback(self):
+            self.rolled_back = True
+
+        def close(self):
+            self.closed = True
+
+    session = FakeSession()
+    recorder = TradeRecorder(lambda: session)
+    result = OrderExecutionResult(
+        stock_code="005930",
+        stock_name="삼성전자",
+        side="BUY",
+        quantity=3,
+        price=75000,
+        message="주문 접수",
+        raw_result="{}",
+    )
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        recorder.record(result)
+
+    assert len(session.added) == 1
+    assert session.rolled_back is True
+    assert session.closed is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -204,6 +204,59 @@ async def test_demo_order_calls_local_mcp_runner_and_returns_normalized_result()
         side="SELL",
         quantity=5,
         price=76000,
+        order_type="LIMIT",
         message="주문 접수",
         raw_result='{"msg1":"주문 접수"}',
     )
+
+
+@pytest.mark.asyncio
+async def test_market_order_calls_local_mcp_runner_with_order_type():
+    calls = []
+
+    async def fake_mcp_runner(server_params, tool_name, arguments):
+        calls.append(
+            {
+                "server_params": server_params,
+                "tool_name": tool_name,
+                "arguments": arguments,
+            }
+        )
+        return '{"msg1":"시장가 주문 접수"}'
+
+    gateway = McpTradingOrderGateway(
+        server_params="trading-params",
+        mcp_runner=fake_mcp_runner,
+        order_env="demo",
+        real_order_enabled=False,
+    )
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="BUY",
+        quantity=5,
+        price=0,
+        order_type="MARKET",
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    result = await gateway.place_order(order)
+
+    assert calls == [
+        {
+            "server_params": "trading-params",
+            "tool_name": "place_order",
+            "arguments": {
+                "stock_name": "삼성전자",
+                "stock_code": "005930",
+                "side": "BUY",
+                "quantity": 5,
+                "price": 0,
+                "order_type": "MARKET",
+                "order_env": "demo",
+            },
+        }
+    ]
+    assert result.order_type == "MARKET"
+    assert result.price == 0

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi import HTTPException
+
+from backend.trading_orders import (
+    OfficialKisMcpOrderGateway,
+    PendingOrder,
+    is_korean_market_open,
+)
+
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def test_market_open_during_weekday_regular_session():
+    now = datetime(2026, 5, 20, 10, 0, tzinfo=KST)
+
+    assert is_korean_market_open(now) is True
+
+
+def test_market_closed_before_open():
+    now = datetime(2026, 5, 20, 8, 59, tzinfo=KST)
+
+    assert is_korean_market_open(now) is False
+
+
+def test_market_closed_after_close():
+    now = datetime(2026, 5, 20, 15, 31, tzinfo=KST)
+
+    assert is_korean_market_open(now) is False
+
+
+def test_market_closed_on_weekend():
+    now = datetime(2026, 5, 23, 10, 0, tzinfo=KST)
+
+    assert is_korean_market_open(now) is False
+
+
+@pytest.mark.asyncio
+async def test_real_order_without_explicit_opt_in_is_blocked_before_mcp_call():
+    calls = []
+
+    async def fake_remote_runner(*, transport, url, tool_name, arguments, timeout_sec):
+        calls.append((transport, url, tool_name, arguments, timeout_sec))
+        return "should not be called"
+
+    gateway = OfficialKisMcpOrderGateway(
+        mcp_url="http://127.0.0.1:3300/sse",
+        mcp_transport="sse",
+        tool_name="domestic_stock",
+        order_env="real",
+        real_order_enabled=False,
+        remote_runner=fake_remote_runner,
+    )
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="BUY",
+        quantity=10,
+        price=75000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await gateway.place_order(order)
+
+    assert exc_info.value.status_code == 403
+    assert "실계좌 주문" in str(exc_info.value.detail)
+    assert calls == []

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -1,19 +1,14 @@
-import asyncio
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-import httpx
 import pytest
 from fastapi import HTTPException
 
-import backend.trading_orders as trading_orders
 from backend.trading_orders import (
-    OfficialKisMcpOrderGateway,
+    McpTradingOrderGateway,
     OrderExecutionResult,
     PendingOrder,
     TradeRecorder,
-    _mcp_first_text_or_error,
-    call_official_kis_mcp,
     is_korean_market_open,
 )
 
@@ -129,17 +124,15 @@ def test_trade_recorder_rolls_back_and_closes_when_commit_fails():
 async def test_real_order_without_explicit_opt_in_is_blocked_before_mcp_call():
     calls = []
 
-    async def fake_remote_runner(*, transport, url, tool_name, arguments, timeout_sec):
-        calls.append((transport, url, tool_name, arguments, timeout_sec))
+    async def fake_mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
         return "should not be called"
 
-    gateway = OfficialKisMcpOrderGateway(
-        mcp_url="http://127.0.0.1:3300/sse",
-        mcp_transport="sse",
-        tool_name="domestic_stock",
+    gateway = McpTradingOrderGateway(
+        server_params="trading-params",
+        mcp_runner=fake_mcp_runner,
         order_env="real",
         real_order_enabled=False,
-        remote_runner=fake_remote_runner,
     )
     order = PendingOrder(
         chat_id="123",
@@ -160,29 +153,24 @@ async def test_real_order_without_explicit_opt_in_is_blocked_before_mcp_call():
 
 
 @pytest.mark.asyncio
-async def test_demo_order_calls_mcp_runner_and_returns_normalized_result():
+async def test_demo_order_calls_local_mcp_runner_and_returns_normalized_result():
     calls = []
 
-    async def fake_remote_runner(*, transport, url, tool_name, arguments, timeout_sec):
+    async def fake_mcp_runner(server_params, tool_name, arguments):
         calls.append(
             {
-                "transport": transport,
-                "url": url,
+                "server_params": server_params,
                 "tool_name": tool_name,
                 "arguments": arguments,
-                "timeout_sec": timeout_sec,
             }
         )
         return '{"msg1":"주문 접수"}'
 
-    gateway = OfficialKisMcpOrderGateway(
-        mcp_url="http://127.0.0.1:3300/sse",
-        mcp_transport="sse",
-        tool_name="domestic_stock",
+    gateway = McpTradingOrderGateway(
+        server_params="trading-params",
+        mcp_runner=fake_mcp_runner,
         order_env="demo",
         real_order_enabled=False,
-        remote_runner=fake_remote_runner,
-        timeout_sec=30.0,
     )
     order = PendingOrder(
         chat_id="123",
@@ -198,21 +186,16 @@ async def test_demo_order_calls_mcp_runner_and_returns_normalized_result():
 
     assert calls == [
         {
-            "transport": "sse",
-            "url": "http://127.0.0.1:3300/sse",
-            "tool_name": "domestic_stock",
+            "server_params": "trading-params",
+            "tool_name": "place_order",
             "arguments": {
-                "api_type": "order_cash",
-                "params": {
-                    "env_dv": "demo",
-                    "pdno": "005930",
-                    "ord_dvsn": "01",
-                    "ord_qty": "5",
-                    "ord_unpr": "76000",
-                    "buy_sell": "sell",
-                },
+                "stock_name": "삼성전자",
+                "stock_code": "005930",
+                "side": "SELL",
+                "quantity": 5,
+                "price": 76000,
+                "order_env": "demo",
             },
-            "timeout_sec": 30.0,
         }
     ]
     assert result == OrderExecutionResult(
@@ -224,229 +207,3 @@ async def test_demo_order_calls_mcp_runner_and_returns_normalized_result():
         message="주문 접수",
         raw_result='{"msg1":"주문 접수"}',
     )
-
-
-class _FakeTextBlock:
-    def __init__(self, text):
-        self.text = text
-
-
-class _FakeMcpResult:
-    def __init__(self, *, content, is_error=False):
-        self.content = content
-        self.isError = is_error
-
-
-def test_mcp_first_text_or_error_returns_first_text_block():
-    result = _FakeMcpResult(content=[_FakeTextBlock("주문 접수"), _FakeTextBlock("ignored")])
-
-    assert _mcp_first_text_or_error(result) == "주문 접수"
-
-
-def test_mcp_first_text_or_error_raises_bad_gateway_for_error_result():
-    result = _FakeMcpResult(content=[_FakeTextBlock("KIS rejected order")], is_error=True)
-
-    with pytest.raises(HTTPException) as exc_info:
-        _mcp_first_text_or_error(result)
-
-    assert exc_info.value.status_code == 502
-    assert exc_info.value.detail == "KIS rejected order"
-
-
-def test_mcp_first_text_or_error_raises_bad_gateway_for_empty_success_content():
-    result = _FakeMcpResult(content=[])
-
-    with pytest.raises(HTTPException) as exc_info:
-        _mcp_first_text_or_error(result)
-
-    assert exc_info.value.status_code == 502
-    assert exc_info.value.detail == "KIS MCP 주문 응답이 비어 있습니다."
-
-
-@pytest.mark.asyncio
-async def test_call_official_kis_mcp_rejects_unsupported_transport_without_network():
-    with pytest.raises(HTTPException) as exc_info:
-        await call_official_kis_mcp(
-            transport="stdio",
-            url="http://127.0.0.1:3300/sse",
-            tool_name="domestic_stock",
-            arguments={},
-            timeout_sec=1.0,
-        )
-
-    assert exc_info.value.status_code == 500
-    assert "지원하지 않는 KIS MCP transport" in str(exc_info.value.detail)
-
-
-@pytest.mark.asyncio
-async def test_call_official_kis_mcp_wraps_timeout_as_gateway_timeout(monkeypatch):
-    async def fake_inner(**_kwargs):
-        raise TimeoutError
-
-    monkeypatch.setattr(
-        trading_orders,
-        "_call_official_kis_mcp_inner",
-        fake_inner,
-        raising=False,
-    )
-
-    with pytest.raises(HTTPException) as exc_info:
-        await call_official_kis_mcp(
-            transport="sse",
-            url="http://127.0.0.1:3300/sse",
-            tool_name="domestic_stock",
-            arguments={},
-            timeout_sec=1.0,
-        )
-
-    assert exc_info.value.status_code == 504
-    assert exc_info.value.detail == "KIS MCP 주문 요청 시간이 초과되었습니다."
-
-
-@pytest.mark.asyncio
-async def test_call_official_kis_mcp_wraps_httpx_timeout_as_gateway_timeout(monkeypatch):
-    async def fake_inner(**_kwargs):
-        raise httpx.ReadTimeout("read timed out")
-
-    monkeypatch.setattr(
-        trading_orders,
-        "_call_official_kis_mcp_inner",
-        fake_inner,
-        raising=False,
-    )
-
-    with pytest.raises(HTTPException) as exc_info:
-        await call_official_kis_mcp(
-            transport="sse",
-            url="http://127.0.0.1:3300/sse",
-            tool_name="domestic_stock",
-            arguments={},
-            timeout_sec=1.0,
-        )
-
-    assert exc_info.value.status_code == 504
-    assert exc_info.value.detail == "KIS MCP 주문 요청 시간이 초과되었습니다."
-
-
-@pytest.mark.asyncio
-async def test_call_official_kis_mcp_propagates_cancellation(monkeypatch):
-    async def fake_inner(**_kwargs):
-        raise asyncio.CancelledError
-
-    monkeypatch.setattr(
-        trading_orders,
-        "_call_official_kis_mcp_inner",
-        fake_inner,
-        raising=False,
-    )
-
-    with pytest.raises(asyncio.CancelledError):
-        await call_official_kis_mcp(
-            transport="sse",
-            url="http://127.0.0.1:3300/sse",
-            tool_name="domestic_stock",
-            arguments={},
-            timeout_sec=1.0,
-        )
-
-
-@pytest.mark.asyncio
-async def test_call_official_kis_mcp_passes_timeout_to_streamable_http_client(monkeypatch):
-    client_timeouts = []
-    streamable_calls = []
-    session_calls = []
-
-    class FakeAsyncClient:
-        def __init__(self, *, timeout):
-            self.timeout = timeout
-            client_timeouts.append(timeout)
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class FakeStreamableClient:
-        def __init__(self, *, url, http_client):
-            self.url = url
-            self.http_client = http_client
-
-        async def __aenter__(self):
-            streamable_calls.append(
-                {
-                    "url": self.url,
-                    "timeout": self.http_client.timeout,
-                }
-            )
-            return "read", "write", lambda: "session-id"
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class FakeClientSession:
-        def __init__(self, read, write):
-            session_calls.append((read, write))
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def initialize(self):
-            return None
-
-        async def call_tool(self, tool_name, arguments):
-            session_calls.append((tool_name, arguments))
-            return _FakeMcpResult(content=[_FakeTextBlock("주문 접수")])
-
-    monkeypatch.setattr(trading_orders.httpx, "AsyncClient", FakeAsyncClient)
-    monkeypatch.setattr(trading_orders, "streamable_http_client", FakeStreamableClient)
-    monkeypatch.setattr(trading_orders, "ClientSession", FakeClientSession)
-
-    result = await call_official_kis_mcp(
-        transport="streamable-http",
-        url="http://127.0.0.1:3300/mcp",
-        tool_name="domestic_stock",
-        arguments={"api_type": "order_cash"},
-        timeout_sec=7.5,
-    )
-
-    assert result == "주문 접수"
-    assert client_timeouts == [7.5]
-    assert streamable_calls == [
-        {
-            "url": "http://127.0.0.1:3300/mcp",
-            "timeout": 7.5,
-        }
-    ]
-    assert session_calls == [
-        ("read", "write"),
-        ("domestic_stock", {"api_type": "order_cash"}),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_call_official_kis_mcp_wraps_transport_error_as_bad_gateway(monkeypatch):
-    async def fake_inner(**_kwargs):
-        raise httpx.TransportError("connection failed")
-
-    monkeypatch.setattr(
-        trading_orders,
-        "_call_official_kis_mcp_inner",
-        fake_inner,
-        raising=False,
-    )
-
-    with pytest.raises(HTTPException) as exc_info:
-        await call_official_kis_mcp(
-            transport="sse",
-            url="http://127.0.0.1:3300/sse",
-            tool_name="domestic_stock",
-            arguments={},
-            timeout_sec=1.0,
-        )
-
-    assert exc_info.value.status_code == 502
-    assert exc_info.value.detail == "KIS MCP 주문 요청에 실패했습니다."

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 
 from backend.trading_orders import (
     OfficialKisMcpOrderGateway,
+    OrderExecutionResult,
     PendingOrder,
     is_korean_market_open,
 )
@@ -70,3 +71,70 @@ async def test_real_order_without_explicit_opt_in_is_blocked_before_mcp_call():
     assert exc_info.value.status_code == 403
     assert "실계좌 주문" in str(exc_info.value.detail)
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_demo_order_calls_mcp_runner_and_returns_normalized_result():
+    calls = []
+
+    async def fake_remote_runner(*, transport, url, tool_name, arguments, timeout_sec):
+        calls.append(
+            {
+                "transport": transport,
+                "url": url,
+                "tool_name": tool_name,
+                "arguments": arguments,
+                "timeout_sec": timeout_sec,
+            }
+        )
+        return '{"msg1":"주문 접수"}'
+
+    gateway = OfficialKisMcpOrderGateway(
+        mcp_url="http://127.0.0.1:3300/sse",
+        mcp_transport="sse",
+        tool_name="domestic_stock",
+        order_env="demo",
+        real_order_enabled=False,
+        remote_runner=fake_remote_runner,
+        timeout_sec=30.0,
+    )
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="SELL",
+        quantity=5,
+        price=76000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    result = await gateway.place_order(order)
+
+    assert calls == [
+        {
+            "transport": "sse",
+            "url": "http://127.0.0.1:3300/sse",
+            "tool_name": "domestic_stock",
+            "arguments": {
+                "api_type": "order_cash",
+                "params": {
+                    "env_dv": "demo",
+                    "pdno": "005930",
+                    "ord_dvsn": "01",
+                    "ord_qty": "5",
+                    "ord_unpr": "76000",
+                    "buy_sell": "sell",
+                },
+            },
+            "timeout_sec": 30.0,
+        }
+    ]
+    assert result == OrderExecutionResult(
+        stock_code="005930",
+        stock_name="삼성전자",
+        side="SELL",
+        quantity=5,
+        price=76000,
+        message="주문 접수",
+        raw_result='{"msg1":"주문 접수"}',
+    )

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -219,6 +220,53 @@ async def test_call_official_kis_mcp_wraps_timeout_as_gateway_timeout(monkeypatc
 
     assert exc_info.value.status_code == 504
     assert exc_info.value.detail == "KIS MCP 주문 요청 시간이 초과되었습니다."
+
+
+@pytest.mark.asyncio
+async def test_call_official_kis_mcp_wraps_httpx_timeout_as_gateway_timeout(monkeypatch):
+    async def fake_inner(**_kwargs):
+        raise httpx.ReadTimeout("read timed out")
+
+    monkeypatch.setattr(
+        trading_orders,
+        "_call_official_kis_mcp_inner",
+        fake_inner,
+        raising=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await call_official_kis_mcp(
+            transport="sse",
+            url="http://127.0.0.1:3300/sse",
+            tool_name="domestic_stock",
+            arguments={},
+            timeout_sec=1.0,
+        )
+
+    assert exc_info.value.status_code == 504
+    assert exc_info.value.detail == "KIS MCP 주문 요청 시간이 초과되었습니다."
+
+
+@pytest.mark.asyncio
+async def test_call_official_kis_mcp_propagates_cancellation(monkeypatch):
+    async def fake_inner(**_kwargs):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        trading_orders,
+        "_call_official_kis_mcp_inner",
+        fake_inner,
+        raising=False,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await call_official_kis_mcp(
+            transport="sse",
+            url="http://127.0.0.1:3300/sse",
+            tool_name="domestic_stock",
+            arguments={},
+            timeout_sec=1.0,
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -11,6 +11,7 @@ from backend.trading_orders import (
     OfficialKisMcpOrderGateway,
     OrderExecutionResult,
     PendingOrder,
+    TradeRecorder,
     _mcp_first_text_or_error,
     call_official_kis_mcp,
     is_korean_market_open,
@@ -42,6 +43,42 @@ def test_market_closed_on_weekend():
     now = datetime(2026, 5, 23, 10, 0, tzinfo=KST)
 
     assert is_korean_market_open(now) is False
+
+
+def test_trade_recorder_creates_trade_history_and_commits():
+    class FakeSession:
+        def __init__(self):
+            self.added = []
+            self.committed = False
+
+        def add(self, item):
+            self.added.append(item)
+
+        def commit(self):
+            self.committed = True
+
+    session = FakeSession()
+    recorder = TradeRecorder(lambda: session)
+    result = OrderExecutionResult(
+        stock_code="005930",
+        stock_name="삼성전자",
+        side="BUY",
+        quantity=3,
+        price=75000,
+        message="주문 접수",
+        raw_result="{}",
+    )
+
+    recorder.record(result)
+
+    assert len(session.added) == 1
+    trade = session.added[0]
+    assert trade.stock_code == "005930"
+    assert trade.stock_name == "삼성전자"
+    assert trade.trade_type == "BUY"
+    assert trade.quantity == 3
+    assert trade.price == 75000.0
+    assert session.committed is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
+import httpx
 import pytest
 from fastapi import HTTPException
 
+import backend.trading_orders as trading_orders
 from backend.trading_orders import (
     OfficialKisMcpOrderGateway,
     OrderExecutionResult,
@@ -169,6 +171,16 @@ def test_mcp_first_text_or_error_raises_bad_gateway_for_error_result():
     assert exc_info.value.detail == "KIS rejected order"
 
 
+def test_mcp_first_text_or_error_raises_bad_gateway_for_empty_success_content():
+    result = _FakeMcpResult(content=[])
+
+    with pytest.raises(HTTPException) as exc_info:
+        _mcp_first_text_or_error(result)
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "KIS MCP 주문 응답이 비어 있습니다."
+
+
 @pytest.mark.asyncio
 async def test_call_official_kis_mcp_rejects_unsupported_transport_without_network():
     with pytest.raises(HTTPException) as exc_info:
@@ -182,3 +194,53 @@ async def test_call_official_kis_mcp_rejects_unsupported_transport_without_netwo
 
     assert exc_info.value.status_code == 500
     assert "지원하지 않는 KIS MCP transport" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_call_official_kis_mcp_wraps_timeout_as_gateway_timeout(monkeypatch):
+    async def fake_inner(**_kwargs):
+        raise TimeoutError
+
+    monkeypatch.setattr(
+        trading_orders,
+        "_call_official_kis_mcp_inner",
+        fake_inner,
+        raising=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await call_official_kis_mcp(
+            transport="sse",
+            url="http://127.0.0.1:3300/sse",
+            tool_name="domestic_stock",
+            arguments={},
+            timeout_sec=1.0,
+        )
+
+    assert exc_info.value.status_code == 504
+    assert exc_info.value.detail == "KIS MCP 주문 요청 시간이 초과되었습니다."
+
+
+@pytest.mark.asyncio
+async def test_call_official_kis_mcp_wraps_transport_error_as_bad_gateway(monkeypatch):
+    async def fake_inner(**_kwargs):
+        raise httpx.TransportError("connection failed")
+
+    monkeypatch.setattr(
+        trading_orders,
+        "_call_official_kis_mcp_inner",
+        fake_inner,
+        raising=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await call_official_kis_mcp(
+            transport="sse",
+            url="http://127.0.0.1:3300/sse",
+            tool_name="domestic_stock",
+            arguments={},
+            timeout_sec=1.0,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "KIS MCP 주문 요청에 실패했습니다."

--- a/backend/tests/test_trading_orders.py
+++ b/backend/tests/test_trading_orders.py
@@ -270,6 +270,83 @@ async def test_call_official_kis_mcp_propagates_cancellation(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_call_official_kis_mcp_passes_timeout_to_streamable_http_client(monkeypatch):
+    client_timeouts = []
+    streamable_calls = []
+    session_calls = []
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+            client_timeouts.append(timeout)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeStreamableClient:
+        def __init__(self, *, url, http_client):
+            self.url = url
+            self.http_client = http_client
+
+        async def __aenter__(self):
+            streamable_calls.append(
+                {
+                    "url": self.url,
+                    "timeout": self.http_client.timeout,
+                }
+            )
+            return "read", "write", lambda: "session-id"
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeClientSession:
+        def __init__(self, read, write):
+            session_calls.append((read, write))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, tool_name, arguments):
+            session_calls.append((tool_name, arguments))
+            return _FakeMcpResult(content=[_FakeTextBlock("주문 접수")])
+
+    monkeypatch.setattr(trading_orders.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(trading_orders, "streamable_http_client", FakeStreamableClient)
+    monkeypatch.setattr(trading_orders, "ClientSession", FakeClientSession)
+
+    result = await call_official_kis_mcp(
+        transport="streamable-http",
+        url="http://127.0.0.1:3300/mcp",
+        tool_name="domestic_stock",
+        arguments={"api_type": "order_cash"},
+        timeout_sec=7.5,
+    )
+
+    assert result == "주문 접수"
+    assert client_timeouts == [7.5]
+    assert streamable_calls == [
+        {
+            "url": "http://127.0.0.1:3300/mcp",
+            "timeout": 7.5,
+        }
+    ]
+    assert session_calls == [
+        ("read", "write"),
+        ("domestic_stock", {"api_type": "order_cash"}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_call_official_kis_mcp_wraps_transport_error_as_bad_gateway(monkeypatch):
     async def fake_inner(**_kwargs):
         raise httpx.TransportError("connection failed")

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -49,16 +49,26 @@ class TradeRecorder:
         from .models import TradeHistory
 
         session = self.session_factory()
-        session.add(
-            TradeHistory(
-                stock_code=result.stock_code,
-                stock_name=result.stock_name,
-                trade_type=result.side,
-                quantity=result.quantity,
-                price=float(result.price),
+        try:
+            session.add(
+                TradeHistory(
+                    stock_code=result.stock_code,
+                    stock_name=result.stock_name,
+                    trade_type=result.side,
+                    quantity=result.quantity,
+                    price=float(result.price),
+                )
             )
-        )
-        session.commit()
+            session.commit()
+        except Exception:
+            rollback = getattr(session, "rollback", None)
+            if callable(rollback):
+                rollback()
+            raise
+        finally:
+            close = getattr(session, "close", None)
+            if callable(close):
+                close()
 
 
 RemoteMcpRunner = Callable[..., Awaitable[str]]

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from datetime import datetime, time
@@ -69,6 +70,11 @@ def _mcp_first_text_or_error(result: Any) -> str:
             status_code=502,
             detail=text or "KIS MCP 주문 실행 실패",
         )
+    if not str(text or "").strip():
+        raise HTTPException(
+            status_code=502,
+            detail="KIS MCP 주문 응답이 비어 있습니다.",
+        )
 
     return text
 
@@ -85,6 +91,68 @@ async def call_official_kis_mcp(
     arguments: dict[str, Any],
     timeout_sec: float,
 ) -> str:
+    try:
+        return await asyncio.wait_for(
+            _call_official_kis_mcp_inner(
+                transport=transport,
+                url=url,
+                tool_name=tool_name,
+                arguments=arguments,
+                timeout_sec=timeout_sec,
+            ),
+            timeout=timeout_sec,
+        )
+    except asyncio.CancelledError:
+        raise
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=504,
+            detail="KIS MCP 주문 요청 시간이 초과되었습니다.",
+        ) from exc
+    except HTTPException:
+        raise
+    except BaseExceptionGroup as exc:
+        if _exception_group_contains(exc, asyncio.CancelledError):
+            raise
+        if _exception_group_contains(exc, TimeoutError):
+            raise HTTPException(
+                status_code=504,
+                detail="KIS MCP 주문 요청 시간이 초과되었습니다.",
+            ) from exc
+        if _exception_group_contains(exc, (httpx.HTTPError, OSError)):
+            raise HTTPException(
+                status_code=502,
+                detail="KIS MCP 주문 요청에 실패했습니다.",
+            ) from exc
+        raise
+    except (httpx.HTTPError, OSError) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="KIS MCP 주문 요청에 실패했습니다.",
+        ) from exc
+
+
+def _exception_group_contains(
+    exc: BaseExceptionGroup,
+    types: type[BaseException] | tuple[type[BaseException], ...],
+) -> bool:
+    for inner in exc.exceptions:
+        if isinstance(inner, BaseExceptionGroup):
+            if _exception_group_contains(inner, types):
+                return True
+        elif isinstance(inner, types):
+            return True
+    return False
+
+
+async def _call_official_kis_mcp_inner(
+    *,
+    transport: str,
+    url: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    timeout_sec: float,
+) -> str:
     if transport == "sse":
         conn = _sse_connect_timeout(timeout_sec)
         async with sse_client(url=url, timeout=conn, sse_read_timeout=timeout_sec) as (read, write):
@@ -93,7 +161,7 @@ async def call_official_kis_mcp(
                 return _mcp_first_text_or_error(await session.call_tool(tool_name, arguments))
 
     if transport == "streamable-http":
-        async with httpx.AsyncClient() as http_client:
+        async with httpx.AsyncClient(timeout=timeout_sec) as http_client:
             async with streamable_http_client(url=url, http_client=http_client) as (read, write, _get_sid):
                 async with ClientSession(read, write) as session:
                     await session.initialize()

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime, time
-from typing import Awaitable, Callable, Literal
+from typing import Any, Awaitable, Callable, Literal
 from zoneinfo import ZoneInfo
 
+import httpx
 from fastapi import HTTPException
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamable_http_client
 
 
 KST = ZoneInfo("Asia/Seoul")
@@ -37,6 +41,8 @@ class OrderExecutionResult:
 
 
 RemoteMcpRunner = Callable[..., Awaitable[str]]
+_SSE_CONNECT_FLOOR = 5.0
+_SSE_CONNECT_CAP = 30.0
 
 
 def is_korean_market_open(now: datetime | None = None) -> bool:
@@ -48,6 +54,55 @@ def is_korean_market_open(now: datetime | None = None) -> bool:
     if current.weekday() >= 5:
         return False
     return time(9, 0) <= current.time() <= time(15, 30)
+
+
+def _mcp_first_text_or_error(result: Any) -> str:
+    blocks = getattr(result, "content", None) or []
+    if blocks:
+        block0 = blocks[0]
+        text = getattr(block0, "text", str(block0))
+    else:
+        text = ""
+
+    if getattr(result, "isError", False):
+        raise HTTPException(
+            status_code=502,
+            detail=text or "KIS MCP 주문 실행 실패",
+        )
+
+    return text
+
+
+def _sse_connect_timeout(operation_timeout: float) -> float:
+    return min(_SSE_CONNECT_CAP, max(_SSE_CONNECT_FLOOR, operation_timeout * 0.25))
+
+
+async def call_official_kis_mcp(
+    *,
+    transport: str,
+    url: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    timeout_sec: float,
+) -> str:
+    if transport == "sse":
+        conn = _sse_connect_timeout(timeout_sec)
+        async with sse_client(url=url, timeout=conn, sse_read_timeout=timeout_sec) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                return _mcp_first_text_or_error(await session.call_tool(tool_name, arguments))
+
+    if transport == "streamable-http":
+        async with httpx.AsyncClient() as http_client:
+            async with streamable_http_client(url=url, http_client=http_client) as (read, write, _get_sid):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    return _mcp_first_text_or_error(await session.call_tool(tool_name, arguments))
+
+    raise HTTPException(
+        status_code=500,
+        detail=f"지원하지 않는 KIS MCP transport입니다: {transport}",
+    )
 
 
 class OfficialKisMcpOrderGateway:

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -104,7 +104,7 @@ async def call_official_kis_mcp(
         )
     except asyncio.CancelledError:
         raise
-    except TimeoutError as exc:
+    except (TimeoutError, httpx.TimeoutException) as exc:
         raise HTTPException(
             status_code=504,
             detail="KIS MCP 주문 요청 시간이 초과되었습니다.",
@@ -114,7 +114,7 @@ async def call_official_kis_mcp(
     except BaseExceptionGroup as exc:
         if _exception_group_contains(exc, asyncio.CancelledError):
             raise
-        if _exception_group_contains(exc, TimeoutError):
+        if _exception_group_contains(exc, (TimeoutError, httpx.TimeoutException)):
             raise HTTPException(
                 status_code=504,
                 detail="KIS MCP 주문 요청 시간이 초과되었습니다.",

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, time
+from typing import Awaitable, Callable, Literal
+from zoneinfo import ZoneInfo
+
+from fastapi import HTTPException
+
+
+KST = ZoneInfo("Asia/Seoul")
+OrderSide = Literal["BUY", "SELL"]
+McpTransport = Literal["sse", "streamable-http"]
+
+
+@dataclass(frozen=True)
+class PendingOrder:
+    chat_id: str
+    stock_name: str
+    stock_code: str
+    side: OrderSide
+    quantity: int
+    price: int
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class OrderExecutionResult:
+    stock_code: str
+    stock_name: str
+    side: OrderSide
+    quantity: int
+    price: int
+    message: str
+    raw_result: str
+
+
+RemoteMcpRunner = Callable[..., Awaitable[str]]
+
+
+def is_korean_market_open(now: datetime | None = None) -> bool:
+    current = now or datetime.now(KST)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=KST)
+    current = current.astimezone(KST)
+
+    if current.weekday() >= 5:
+        return False
+    return time(9, 0) <= current.time() <= time(15, 30)
+
+
+class OfficialKisMcpOrderGateway:
+    def __init__(
+        self,
+        *,
+        mcp_url: str,
+        mcp_transport: McpTransport,
+        tool_name: str,
+        order_env: Literal["real", "demo"],
+        real_order_enabled: bool,
+        remote_runner: RemoteMcpRunner,
+        timeout_sec: float = 180.0,
+    ):
+        self.mcp_url = mcp_url
+        self.mcp_transport = mcp_transport
+        self.tool_name = tool_name
+        self.order_env = order_env
+        self.real_order_enabled = real_order_enabled
+        self.remote_runner = remote_runner
+        self.timeout_sec = timeout_sec
+
+    async def place_order(self, order: PendingOrder) -> OrderExecutionResult:
+        if self.order_env == "real" and not self.real_order_enabled:
+            raise HTTPException(
+                status_code=403,
+                detail="실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다.",
+            )
+
+        raw_result = await self.remote_runner(
+            transport=self.mcp_transport,
+            url=self.mcp_url,
+            tool_name=self.tool_name,
+            arguments={
+                "api_type": "order_cash",
+                "params": {
+                    "env_dv": self.order_env,
+                    "pdno": order.stock_code,
+                    "ord_dvsn": "01",
+                    "ord_qty": str(order.quantity),
+                    "ord_unpr": str(order.price),
+                    "buy_sell": order.side.lower(),
+                },
+            },
+            timeout_sec=self.timeout_sec,
+        )
+
+        return OrderExecutionResult(
+            stock_code=order.stock_code,
+            stock_name=order.stock_name,
+            side=order.side,
+            quantity=order.quantity,
+            price=order.price,
+            message=_extract_order_message(raw_result),
+            raw_result=raw_result,
+        )
+
+
+def _extract_order_message(raw_result: str) -> str:
+    text = str(raw_result or "").strip()
+    if not text:
+        return "주문 요청이 접수되었습니다."
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return text[:500]
+
+    if isinstance(data, dict):
+        for key in ("msg1", "message", "rt_msg", "output"):
+            value = data.get(key)
+            if value:
+                return str(value)[:500]
+    return text[:500]

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -41,6 +41,26 @@ class OrderExecutionResult:
     raw_result: str
 
 
+class TradeRecorder:
+    def __init__(self, session_factory: Callable[[], Any]):
+        self.session_factory = session_factory
+
+    def record(self, result: OrderExecutionResult) -> None:
+        from .models import TradeHistory
+
+        session = self.session_factory()
+        session.add(
+            TradeHistory(
+                stock_code=result.stock_code,
+                stock_name=result.stock_name,
+                trade_type=result.side,
+                quantity=result.quantity,
+                price=float(result.price),
+            )
+        )
+        session.commit()
+
+
 RemoteMcpRunner = Callable[..., Awaitable[str]]
 _SSE_CONNECT_FLOOR = 5.0
 _SSE_CONNECT_CAP = 30.0

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 
 KST = ZoneInfo("Asia/Seoul")
 OrderSide = Literal["BUY", "SELL"]
+OrderType = Literal["LIMIT", "MARKET"]
 
 
 @dataclass(frozen=True)
@@ -22,6 +23,7 @@ class PendingOrder:
     quantity: int
     price: int
     created_at: datetime
+    order_type: OrderType = "LIMIT"
 
 
 @dataclass(frozen=True)
@@ -33,6 +35,7 @@ class OrderExecutionResult:
     price: int
     message: str
     raw_result: str
+    order_type: OrderType = "LIMIT"
 
 
 class TradeRecorder:
@@ -100,17 +103,21 @@ class McpTradingOrderGateway:
                 detail="실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다.",
             )
 
+        arguments: dict[str, Any] = {
+            "stock_name": order.stock_name,
+            "stock_code": order.stock_code,
+            "side": order.side,
+            "quantity": order.quantity,
+            "price": order.price,
+            "order_env": self.order_env,
+        }
+        if order.order_type == "MARKET":
+            arguments["order_type"] = "MARKET"
+
         raw_result = await self.mcp_runner(
             self.server_params,
             "place_order",
-            {
-                "stock_name": order.stock_name,
-                "stock_code": order.stock_code,
-                "side": order.side,
-                "quantity": order.quantity,
-                "price": order.price,
-                "order_env": self.order_env,
-            },
+            arguments,
         )
 
         return OrderExecutionResult(
@@ -121,6 +128,7 @@ class McpTradingOrderGateway:
             price=order.price,
             message=_extract_order_message(raw_result),
             raw_result=raw_result,
+            order_type=order.order_type,
         )
 
 

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -24,6 +24,7 @@ class PendingOrder:
     price: int
     created_at: datetime
     order_type: OrderType = "LIMIT"
+    callback_token: str = ""
 
 
 @dataclass(frozen=True)

--- a/backend/trading_orders.py
+++ b/backend/trading_orders.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
-import asyncio
 import json
 from dataclasses import dataclass
 from datetime import datetime, time
 from typing import Any, Awaitable, Callable, Literal
 from zoneinfo import ZoneInfo
 
-import httpx
 from fastapi import HTTPException
-from mcp import ClientSession
-from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamable_http_client
 
 
 KST = ZoneInfo("Asia/Seoul")
 OrderSide = Literal["BUY", "SELL"]
-McpTransport = Literal["sse", "streamable-http"]
 
 
 @dataclass(frozen=True)
@@ -71,9 +65,7 @@ class TradeRecorder:
                 close()
 
 
-RemoteMcpRunner = Callable[..., Awaitable[str]]
-_SSE_CONNECT_FLOOR = 5.0
-_SSE_CONNECT_CAP = 30.0
+McpRunner = Callable[[Any, str, dict[str, Any]], Awaitable[str]]
 
 
 def is_korean_market_open(now: datetime | None = None) -> bool:
@@ -87,141 +79,19 @@ def is_korean_market_open(now: datetime | None = None) -> bool:
     return time(9, 0) <= current.time() <= time(15, 30)
 
 
-def _mcp_first_text_or_error(result: Any) -> str:
-    blocks = getattr(result, "content", None) or []
-    if blocks:
-        block0 = blocks[0]
-        text = getattr(block0, "text", str(block0))
-    else:
-        text = ""
-
-    if getattr(result, "isError", False):
-        raise HTTPException(
-            status_code=502,
-            detail=text or "KIS MCP 주문 실행 실패",
-        )
-    if not str(text or "").strip():
-        raise HTTPException(
-            status_code=502,
-            detail="KIS MCP 주문 응답이 비어 있습니다.",
-        )
-
-    return text
-
-
-def _sse_connect_timeout(operation_timeout: float) -> float:
-    return min(_SSE_CONNECT_CAP, max(_SSE_CONNECT_FLOOR, operation_timeout * 0.25))
-
-
-async def call_official_kis_mcp(
-    *,
-    transport: str,
-    url: str,
-    tool_name: str,
-    arguments: dict[str, Any],
-    timeout_sec: float,
-) -> str:
-    try:
-        return await asyncio.wait_for(
-            _call_official_kis_mcp_inner(
-                transport=transport,
-                url=url,
-                tool_name=tool_name,
-                arguments=arguments,
-                timeout_sec=timeout_sec,
-            ),
-            timeout=timeout_sec,
-        )
-    except asyncio.CancelledError:
-        raise
-    except (TimeoutError, httpx.TimeoutException) as exc:
-        raise HTTPException(
-            status_code=504,
-            detail="KIS MCP 주문 요청 시간이 초과되었습니다.",
-        ) from exc
-    except HTTPException:
-        raise
-    except BaseExceptionGroup as exc:
-        if _exception_group_contains(exc, asyncio.CancelledError):
-            raise
-        if _exception_group_contains(exc, (TimeoutError, httpx.TimeoutException)):
-            raise HTTPException(
-                status_code=504,
-                detail="KIS MCP 주문 요청 시간이 초과되었습니다.",
-            ) from exc
-        if _exception_group_contains(exc, (httpx.HTTPError, OSError)):
-            raise HTTPException(
-                status_code=502,
-                detail="KIS MCP 주문 요청에 실패했습니다.",
-            ) from exc
-        raise
-    except (httpx.HTTPError, OSError) as exc:
-        raise HTTPException(
-            status_code=502,
-            detail="KIS MCP 주문 요청에 실패했습니다.",
-        ) from exc
-
-
-def _exception_group_contains(
-    exc: BaseExceptionGroup,
-    types: type[BaseException] | tuple[type[BaseException], ...],
-) -> bool:
-    for inner in exc.exceptions:
-        if isinstance(inner, BaseExceptionGroup):
-            if _exception_group_contains(inner, types):
-                return True
-        elif isinstance(inner, types):
-            return True
-    return False
-
-
-async def _call_official_kis_mcp_inner(
-    *,
-    transport: str,
-    url: str,
-    tool_name: str,
-    arguments: dict[str, Any],
-    timeout_sec: float,
-) -> str:
-    if transport == "sse":
-        conn = _sse_connect_timeout(timeout_sec)
-        async with sse_client(url=url, timeout=conn, sse_read_timeout=timeout_sec) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                return _mcp_first_text_or_error(await session.call_tool(tool_name, arguments))
-
-    if transport == "streamable-http":
-        async with httpx.AsyncClient(timeout=timeout_sec) as http_client:
-            async with streamable_http_client(url=url, http_client=http_client) as (read, write, _get_sid):
-                async with ClientSession(read, write) as session:
-                    await session.initialize()
-                    return _mcp_first_text_or_error(await session.call_tool(tool_name, arguments))
-
-    raise HTTPException(
-        status_code=500,
-        detail=f"지원하지 않는 KIS MCP transport입니다: {transport}",
-    )
-
-
-class OfficialKisMcpOrderGateway:
+class McpTradingOrderGateway:
     def __init__(
         self,
         *,
-        mcp_url: str,
-        mcp_transport: McpTransport,
-        tool_name: str,
+        server_params: Any,
+        mcp_runner: McpRunner,
         order_env: Literal["real", "demo"],
         real_order_enabled: bool,
-        remote_runner: RemoteMcpRunner,
-        timeout_sec: float = 180.0,
     ):
-        self.mcp_url = mcp_url
-        self.mcp_transport = mcp_transport
-        self.tool_name = tool_name
+        self.server_params = server_params
+        self.mcp_runner = mcp_runner
         self.order_env = order_env
         self.real_order_enabled = real_order_enabled
-        self.remote_runner = remote_runner
-        self.timeout_sec = timeout_sec
 
     async def place_order(self, order: PendingOrder) -> OrderExecutionResult:
         if self.order_env == "real" and not self.real_order_enabled:
@@ -230,22 +100,17 @@ class OfficialKisMcpOrderGateway:
                 detail="실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다.",
             )
 
-        raw_result = await self.remote_runner(
-            transport=self.mcp_transport,
-            url=self.mcp_url,
-            tool_name=self.tool_name,
-            arguments={
-                "api_type": "order_cash",
-                "params": {
-                    "env_dv": self.order_env,
-                    "pdno": order.stock_code,
-                    "ord_dvsn": "01",
-                    "ord_qty": str(order.quantity),
-                    "ord_unpr": str(order.price),
-                    "buy_sell": order.side.lower(),
-                },
+        raw_result = await self.mcp_runner(
+            self.server_params,
+            "place_order",
+            {
+                "stock_name": order.stock_name,
+                "stock_code": order.stock_code,
+                "side": order.side,
+                "quantity": order.quantity,
+                "price": order.price,
+                "order_env": self.order_env,
             },
-            timeout_sec=self.timeout_sec,
         )
 
         return OrderExecutionResult(

--- a/docs/superpowers/plans/2026-05-18-telegram-interactive-commands.md
+++ b/docs/superpowers/plans/2026-05-18-telegram-interactive-commands.md
@@ -1,0 +1,765 @@
+# Telegram Interactive Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #41 by adding Telegram MCP lookup commands and NAT chat fallback while preserving PR #38 NAT conversation-id isolation and existing `/alerts` behavior.
+
+**Architecture:** Keep `backend/telegram_commands.py` as the Telegram interaction boundary. Extend `TelegramCommandHandler` with small private helpers, inject MCP/NAT runners for tests, and keep `TelegramCommandPoller` offset semantics unchanged. Use `TelegramNotifier` only for Telegram API delivery helpers and do not mix this path into scheduler reports or `/api/v1/ws`.
+
+**Tech Stack:** FastAPI backend modules, `httpx`, Telegram Bot API, MCP stdio client through existing `run_mcp_tool`, NAT chat through existing `llm_chat`, `pytest`, `pytest-asyncio`, `uv`.
+
+---
+
+## File Structure
+
+- Modify `backend/telegram_commands.py`
+  - Add command constants and message truncation helper.
+  - Add optional `mcp_runner` and `llm_runner` dependencies.
+  - Route `/help`, `/balance`, `/quote`, `/trend`, unknown slash commands, and free-form NAT chat.
+  - Preserve existing `/alerts` behavior and poller offset rule.
+
+- Modify `backend/telegram_notifier.py`
+  - Add `send_chat_action(action: str = "typing")` for slow Telegram work.
+  - Keep `send_text()` behavior compatible with existing tests.
+
+- Modify `backend/tests/test_telegram_commands.py`
+  - Extend `FakeNotifier` for chat actions.
+  - Add handler tests for help, MCP commands, missing args, unknown slash commands, NAT fallback, and failure UX.
+  - Keep current `/alerts` and offset tests.
+
+- Modify `backend/tests/test_telegram_notifier.py`
+  - Add a small unit test for `send_chat_action()` HTTP payload.
+
+- Modify `README.md`
+  - Add the new Telegram interactive commands next to the existing `/alerts` section after implementation is passing.
+
+---
+
+### Task 1: Add MCP Telegram Commands
+
+**Files:**
+- Modify: `backend/telegram_commands.py`
+- Modify: `backend/tests/test_telegram_commands.py`
+- Modify: `backend/tests/test_telegram_notifier.py`
+- Modify: `backend/telegram_notifier.py`
+- Commit: `feat: 텔레그램 MCP 조회 명령 추가`
+
+- [ ] **Step 1: Add failing tests for help and command routing**
+
+Edit `backend/tests/test_telegram_commands.py`.
+
+Update `FakeNotifier`:
+
+```python
+class FakeNotifier:
+    def __init__(self, chat_id="123"):
+        self.chat_id = chat_id
+        self.messages = []
+        self.actions = []
+
+    async def send_text(self, text):
+        self.messages.append(text)
+        return True
+
+    async def send_chat_action(self, action="typing"):
+        self.actions.append(action)
+        return True
+```
+
+Add these tests below the existing `/alerts` tests:
+
+```python
+@pytest.mark.asyncio
+async def test_help_command_replies_with_supported_commands():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/help"}})
+
+    assert "/alerts urgent|all|off|status" in notifier.messages[-1]
+    assert "/balance" in notifier.messages[-1]
+    assert "/quote <종목명>" in notifier.messages[-1]
+    assert "/trend <종목명>" in notifier.messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_unknown_slash_command_replies_with_help():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/unknown"}})
+
+    assert "/help" in notifier.messages[-1]
+    assert "/balance" in notifier.messages[-1]
+```
+
+- [ ] **Step 2: Run help tests and verify failure**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_help_command_replies_with_supported_commands backend/tests/test_telegram_commands.py::test_unknown_slash_command_replies_with_help -q
+```
+
+Expected: FAIL because `TelegramCommandHandler` returns for non-`/alerts` text.
+
+- [ ] **Step 3: Add help constants and routing**
+
+Edit `backend/telegram_commands.py`.
+
+Add imports:
+
+```python
+from .config import TRADING_MCP_PARAMS
+from .services import run_mcp_tool
+```
+
+Add constants below `ALERT_COMMAND_HELP`:
+
+```python
+TELEGRAM_INTERACTIVE_HELP = "\n".join(
+    [
+        "사용 가능한 명령:",
+        "/alerts urgent|all|off|status - Telegram 알림 모드 변경",
+        "/balance - 예수금·총자산·보유 종목 조회",
+        "/quote <종목명> - 현재가 조회",
+        "/trend <종목명> - 외국인·기관·개인 수급 조회",
+        "일반 문장은 NAT에게 바로 질문합니다.",
+    ]
+)
+QUOTE_COMMAND_HELP = "사용법: /quote <종목명>"
+TREND_COMMAND_HELP = "사용법: /trend <종목명>"
+TELEGRAM_MESSAGE_LIMIT = 4000
+TELEGRAM_TRUNCATION_SUFFIX = "...(이하 생략)"
+```
+
+Add helper functions above `TelegramCommandHandler`:
+
+```python
+def _telegram_text(text: str) -> str:
+    value = (text or "").strip()
+    if len(value) <= TELEGRAM_MESSAGE_LIMIT:
+        return value
+    keep = TELEGRAM_MESSAGE_LIMIT - len(TELEGRAM_TRUNCATION_SUFFIX)
+    return f"{value[:keep]}{TELEGRAM_TRUNCATION_SUFFIX}"
+
+
+def _short_error(exc: Exception) -> str:
+    detail = getattr(exc, "detail", None)
+    text = str(detail if detail is not None else exc).strip()
+    return _telegram_text(text)[:300] or exc.__class__.__name__
+```
+
+Update `handle_update()` routing:
+
+```python
+        text = (message.get("text") or "").strip()
+        if not text:
+            return
+
+        if text.startswith("/alerts"):
+            await self._handle_alerts(text)
+            return
+        if text == "/help" or text.startswith("/help "):
+            await self.notifier.send_text(TELEGRAM_INTERACTIVE_HELP)
+            return
+        if text == "/balance" or text.startswith("/balance "):
+            await self._handle_balance()
+            return
+        if text == "/quote" or text.startswith("/quote "):
+            await self._handle_quote(text)
+            return
+        if text == "/trend" or text.startswith("/trend "):
+            await self._handle_trend(text)
+            return
+        if text.startswith("/"):
+            await self.notifier.send_text(TELEGRAM_INTERACTIVE_HELP)
+            return
+```
+
+Move the existing `/alerts` body into a new method:
+
+```python
+    async def _handle_alerts(self, text: str) -> None:
+        parts = text.split()
+        action = parts[1].lower() if len(parts) > 1 else "status"
+        async with self._state() as state:
+            if action == "status":
+                mode = await state.get_telegram_alert_mode()
+                await self.notifier.send_text(f"현재 Telegram 알림 모드: {mode}")
+                return
+
+            if action not in TELEGRAM_ALERT_MODES:
+                await self.notifier.send_text(ALERT_COMMAND_HELP)
+                return
+
+            await state.set_telegram_alert_mode(action)
+            await self.notifier.send_text(f"Telegram 알림 모드가 {action}(으)로 변경되었습니다.")
+```
+
+- [ ] **Step 4: Run help tests and verify pass**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_help_command_replies_with_supported_commands backend/tests/test_telegram_commands.py::test_unknown_slash_command_replies_with_help -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add failing tests for MCP commands**
+
+Edit `backend/tests/test_telegram_commands.py`.
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_balance_command_calls_mcp_runner():
+    calls = []
+
+    async def fake_mcp_runner(params, tool_name, arguments):
+        calls.append((params, tool_name, arguments))
+        return "잔고 결과"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=fake_mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/balance"}})
+
+    assert calls[0][1:] == ("get_balance", {})
+    assert notifier.actions == ["typing"]
+    assert notifier.messages[-1] == "잔고 결과"
+
+
+@pytest.mark.asyncio
+async def test_quote_command_calls_mcp_runner_with_stock_name():
+    calls = []
+
+    async def fake_mcp_runner(params, tool_name, arguments):
+        calls.append((params, tool_name, arguments))
+        return "현재가 결과"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=fake_mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/quote 삼성전자"}})
+
+    assert calls[0][1:] == ("get_stock_quote", {"stock_name": "삼성전자"})
+    assert notifier.actions == ["typing"]
+    assert notifier.messages[-1] == "현재가 결과"
+
+
+@pytest.mark.asyncio
+async def test_trend_command_calls_mcp_runner_with_stock_name():
+    calls = []
+
+    async def fake_mcp_runner(params, tool_name, arguments):
+        calls.append((params, tool_name, arguments))
+        return "수급 결과"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=fake_mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/trend 삼성전자"}})
+
+    assert calls[0][1:] == ("get_investor_trading", {"stock_name": "삼성전자"})
+    assert notifier.actions == ["typing"]
+    assert notifier.messages[-1] == "수급 결과"
+
+
+@pytest.mark.asyncio
+async def test_quote_and_trend_missing_args_reply_with_usage():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/quote"}})
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/trend"}})
+
+    assert notifier.messages[-2] == "사용법: /quote <종목명>"
+    assert notifier.messages[-1] == "사용법: /trend <종목명>"
+```
+
+- [ ] **Step 6: Run MCP tests and verify failure**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_balance_command_calls_mcp_runner backend/tests/test_telegram_commands.py::test_quote_command_calls_mcp_runner_with_stock_name backend/tests/test_telegram_commands.py::test_trend_command_calls_mcp_runner_with_stock_name backend/tests/test_telegram_commands.py::test_quote_and_trend_missing_args_reply_with_usage -q
+```
+
+Expected: FAIL because `TelegramCommandHandler.__init__()` does not accept `mcp_runner` and command helpers do not exist.
+
+- [ ] **Step 7: Implement MCP runner injection and helpers**
+
+Edit `backend/telegram_commands.py`.
+
+Update `TelegramCommandHandler.__init__()`:
+
+```python
+    def __init__(
+        self,
+        *,
+        notifier: TelegramNotifier,
+        state_factory: Callable[[], Any] = redis_state,
+        mcp_runner: Callable[[Any, str, dict[str, Any]], Any] = run_mcp_tool,
+    ):
+        self.notifier = notifier
+        self.state_factory = state_factory
+        self.mcp_runner = mcp_runner
+```
+
+Add helper methods inside `TelegramCommandHandler`:
+
+```python
+    async def _handle_balance(self) -> None:
+        await self.notifier.send_chat_action("typing")
+        try:
+            result = await self.mcp_runner(TRADING_MCP_PARAMS, "get_balance", {})
+        except Exception as exc:
+            await self.notifier.send_text(f"조회 실패: {_short_error(exc)}")
+            return
+        await self.notifier.send_text(_telegram_text(str(result)))
+
+    async def _handle_quote(self, text: str) -> None:
+        parts = text.split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            await self.notifier.send_text(QUOTE_COMMAND_HELP)
+            return
+        stock = parts[1].strip()
+        await self.notifier.send_chat_action("typing")
+        try:
+            result = await self.mcp_runner(
+                TRADING_MCP_PARAMS,
+                "get_stock_quote",
+                {"stock_name": stock},
+            )
+        except Exception as exc:
+            await self.notifier.send_text(f"조회 실패: {_short_error(exc)}")
+            return
+        await self.notifier.send_text(_telegram_text(str(result)))
+
+    async def _handle_trend(self, text: str) -> None:
+        parts = text.split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            await self.notifier.send_text(TREND_COMMAND_HELP)
+            return
+        stock = parts[1].strip()
+        await self.notifier.send_chat_action("typing")
+        try:
+            result = await self.mcp_runner(
+                TRADING_MCP_PARAMS,
+                "get_investor_trading",
+                {"stock_name": stock},
+            )
+        except Exception as exc:
+            await self.notifier.send_text(f"조회 실패: {_short_error(exc)}")
+            return
+        await self.notifier.send_text(_telegram_text(str(result)))
+```
+
+- [ ] **Step 8: Add failing notifier chat action test**
+
+Edit `backend/tests/test_telegram_notifier.py`.
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_send_chat_action_posts_typing_payload(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, json):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr("backend.telegram_notifier.httpx.AsyncClient", FakeClient)
+
+    notifier = TelegramNotifier("token", "123")
+
+    assert await notifier.send_chat_action() is True
+    assert captured["url"] == "https://api.telegram.org/bottoken/sendChatAction"
+    assert captured["json"] == {"chat_id": "123", "action": "typing"}
+```
+
+- [ ] **Step 9: Run notifier chat action test and verify failure**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_notifier.py::test_send_chat_action_posts_typing_payload -q
+```
+
+Expected: FAIL because `send_chat_action()` does not exist.
+
+- [ ] **Step 10: Implement notifier chat action**
+
+Edit `backend/telegram_notifier.py`.
+
+Add method below `send_text()`:
+
+```python
+    async def send_chat_action(self, action: str = "typing") -> bool:
+        if not self.enabled:
+            return False
+
+        try:
+            url = f"https://api.telegram.org/bot{self.bot_token}/sendChatAction"
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    url,
+                    json={
+                        "chat_id": self.chat_id,
+                        "action": action,
+                    },
+                )
+                response.raise_for_status()
+            return True
+        except Exception as exc:
+            logger.error("Telegram chat action send failed: %s", exc)
+            return False
+```
+
+- [ ] **Step 11: Add MCP failure and truncation tests**
+
+Edit `backend/tests/test_telegram_commands.py`.
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_mcp_failure_replies_with_short_failure_message():
+    async def failing_mcp_runner(params, tool_name, arguments):
+        raise RuntimeError("kis unavailable")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=failing_mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/balance"}})
+
+    assert notifier.messages[-1] == "조회 실패: kis unavailable"
+
+
+@pytest.mark.asyncio
+async def test_mcp_result_is_truncated_for_telegram_limit():
+    async def fake_mcp_runner(params, tool_name, arguments):
+        return "가" * 4100
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=fake_mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/balance"}})
+
+    assert len(notifier.messages[-1]) == 4000
+    assert notifier.messages[-1].endswith("...(이하 생략)")
+```
+
+- [ ] **Step 12: Run Task 1 focused tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Commit Task 1**
+
+Run:
+
+```bash
+git status --short
+git diff -- backend/telegram_commands.py backend/telegram_notifier.py backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py
+git add backend/telegram_commands.py backend/telegram_notifier.py backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py
+git commit -m "feat: 텔레그램 MCP 조회 명령 추가" -m "- /help, /balance, /quote, /trend 라우팅 추가" -m "- MCP 조회 실패와 긴 메시지 응답 처리 추가"
+```
+
+Expected: one atomic commit containing only MCP command support and notifier chat action support.
+
+---
+
+### Task 2: Add NAT Chat Fallback
+
+**Files:**
+- Modify: `backend/telegram_commands.py`
+- Modify: `backend/tests/test_telegram_commands.py`
+- Commit: `feat: 텔레그램 NAT 채팅 fallback 추가`
+
+- [ ] **Step 1: Add failing tests for NAT fallback routing**
+
+Edit `backend/tests/test_telegram_commands.py`.
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_regular_text_calls_nat_with_telegram_conversation_id():
+    calls = []
+
+    async def fake_llm_runner(provider, text, *, conversation_id=None):
+        calls.append((provider, text, conversation_id))
+        return "NAT 응답"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, llm_runner=fake_llm_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "삼성전자 오늘 어때?"}})
+
+    assert calls == [("nat", "삼성전자 오늘 어때?", "telegram:123")]
+    assert notifier.actions == ["typing"]
+    assert notifier.messages[-1] == "NAT 응답"
+
+
+@pytest.mark.asyncio
+async def test_regular_text_uses_actual_chat_id_in_conversation_id():
+    calls = []
+
+    async def fake_llm_runner(provider, text, *, conversation_id=None):
+        calls.append(conversation_id)
+        return "ok"
+
+    notifier = FakeNotifier(chat_id="456")
+    handler = TelegramCommandHandler(notifier=notifier, llm_runner=fake_llm_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 456}, "text": "계속 봐줘"}})
+
+    assert calls == ["telegram:456"]
+```
+
+- [ ] **Step 2: Run NAT routing tests and verify failure**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_regular_text_calls_nat_with_telegram_conversation_id backend/tests/test_telegram_commands.py::test_regular_text_uses_actual_chat_id_in_conversation_id -q
+```
+
+Expected: FAIL because `TelegramCommandHandler.__init__()` does not accept `llm_runner` and regular text is not routed.
+
+- [ ] **Step 3: Implement NAT runner injection and fallback**
+
+Edit `backend/telegram_commands.py`.
+
+Add import:
+
+```python
+from .services import llm_chat, run_mcp_tool
+```
+
+Update `TelegramCommandHandler.__init__()`:
+
+```python
+    def __init__(
+        self,
+        *,
+        notifier: TelegramNotifier,
+        state_factory: Callable[[], Any] = redis_state,
+        mcp_runner: Callable[[Any, str, dict[str, Any]], Any] = run_mcp_tool,
+        llm_runner: Callable[..., Any] = llm_chat,
+    ):
+        self.notifier = notifier
+        self.state_factory = state_factory
+        self.mcp_runner = mcp_runner
+        self.llm_runner = llm_runner
+```
+
+At the end of `handle_update()`, after unknown slash command handling, add:
+
+```python
+        await self._handle_chat_fallback(text, str(chat.get("id", "")).strip())
+```
+
+Add helper method:
+
+```python
+    async def _handle_chat_fallback(self, text: str, chat_id: str) -> None:
+        await self.notifier.send_chat_action("typing")
+        try:
+            result = await self.llm_runner(
+                "nat",
+                text,
+                conversation_id=f"telegram:{chat_id}",
+            )
+        except Exception as exc:
+            await self.notifier.send_text(f"응답 생성 실패: {_short_error(exc)}")
+            return
+        await self.notifier.send_text(_telegram_text(str(result)))
+```
+
+- [ ] **Step 4: Add NAT failure and truncation tests**
+
+Edit `backend/tests/test_telegram_commands.py`.
+
+Add:
+
+```python
+@pytest.mark.asyncio
+async def test_nat_failure_replies_with_short_failure_message():
+    async def failing_llm_runner(provider, text, *, conversation_id=None):
+        raise RuntimeError("nat unavailable")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, llm_runner=failing_llm_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "질문"}})
+
+    assert notifier.messages[-1] == "응답 생성 실패: nat unavailable"
+
+
+@pytest.mark.asyncio
+async def test_nat_response_is_truncated_for_telegram_limit():
+    async def fake_llm_runner(provider, text, *, conversation_id=None):
+        return "나" * 4100
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, llm_runner=fake_llm_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "긴 답변 줘"}})
+
+    assert len(notifier.messages[-1]) == 4000
+    assert notifier.messages[-1].endswith("...(이하 생략)")
+```
+
+- [ ] **Step 5: Run Task 2 focused tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git status --short
+git diff -- backend/telegram_commands.py backend/tests/test_telegram_commands.py
+git add backend/telegram_commands.py backend/tests/test_telegram_commands.py
+git commit -m "feat: 텔레그램 NAT 채팅 fallback 추가" -m "- 일반 텍스트 NAT 라우팅 추가" -m "- telegram:{chat_id} conversation-id 전달 검증 추가"
+```
+
+Expected: one atomic commit containing only NAT fallback behavior and tests.
+
+---
+
+### Task 3: Document Telegram Interactive Commands
+
+**Files:**
+- Modify: `README.md`
+- Commit: `docs: 텔레그램 인터랙티브 명령 문서화`
+
+- [ ] **Step 1: Update README after implementation passes**
+
+Edit `README.md` in the existing Telegram section. Replace the command list block with:
+
+```text
+/alerts urgent  # high/critical 긴급 분석만 전송
+/alerts all     # NAT 분석이 실행될 때마다 전송
+/alerts off     # Telegram 분석 알림 중지
+/alerts status  # 현재 알림 모드 확인
+/help           # 사용 가능한 Telegram 명령 확인
+/balance        # 예수금·총자산·보유 종목 조회
+/quote <종목명> # 현재가 조회
+/trend <종목명> # 외국인·기관·개인 수급 조회
+```
+
+Add this short paragraph after the block:
+
+```markdown
+슬래시 명령이 아닌 일반 텍스트는 NAT 채팅으로 전달됩니다. Telegram 채팅은 `telegram:{chat_id}` conversation id를 사용하므로 스케줄러 분석 리포트와 대화 이력이 섞이지 않습니다.
+```
+
+- [ ] **Step 2: Verify README diff**
+
+Run:
+
+```bash
+git diff -- README.md
+```
+
+Expected: diff only updates the Telegram command documentation.
+
+- [ ] **Step 3: Commit Task 3**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: 텔레그램 인터랙티브 명령 문서화" -m "- /help, MCP 조회 명령 사용법 추가" -m "- Telegram NAT chat conversation-id 경계 설명"
+```
+
+Expected: one docs-only commit.
+
+---
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify only; no planned file changes.
+
+- [ ] **Step 1: Run focused Telegram regression suite**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run service regression tests for PR #38 compatibility**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_services.py -q
+```
+
+Expected: PASS, including NAT `conversation_id` tests.
+
+- [ ] **Step 3: Inspect commit split**
+
+Run:
+
+```bash
+git log --oneline --decorate -6
+git status --short --branch
+```
+
+Expected:
+
+- Branch is `feat/issue-41-telegram-interactive-commands`.
+- Working tree is clean.
+- Commits are separated into spec, plan, MCP implementation, NAT fallback implementation, and README docs.
+
+- [ ] **Step 4: Prepare PR draft only after user asks**
+
+When the user asks to open a PR, read `.github/PULL_REQUEST_TEMPLATE.md`, inspect the final diff against `main`, print the full PR draft first, and create the PR only after approval.
+
+Run for diff context:
+
+```bash
+git diff --stat main...HEAD
+git diff main...HEAD -- backend/telegram_commands.py backend/telegram_notifier.py backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py README.md
+```
+
+Expected: diff matches issue #41 scope only.

--- a/docs/superpowers/plans/2026-05-20-telegram-manual-trading.md
+++ b/docs/superpowers/plans/2026-05-20-telegram-manual-trading.md
@@ -1,5 +1,7 @@
 # Telegram Manual Trading Implementation Plan
 
+> Superseded: 공식 KIS Trading MCP 실행 계획은 로컬 `mcp-trading` 주문 실행 계획으로 대체되었습니다. 현재 기준 문서는 `docs/superpowers/plans/2026-05-20-telegram-mcp-trading-order-replacement.md`입니다.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add Telegram `/buy`, `/sell`, `/confirm`, and `/cancel` commands that place confirmed manual stock orders through official KIS Trading MCP and record successful orders in `TradeHistory`.

--- a/docs/superpowers/plans/2026-05-20-telegram-manual-trading.md
+++ b/docs/superpowers/plans/2026-05-20-telegram-manual-trading.md
@@ -1,0 +1,1089 @@
+# Telegram Manual Trading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Telegram `/buy`, `/sell`, `/confirm`, and `/cancel` commands that place confirmed manual stock orders through official KIS Trading MCP and record successful orders in `TradeHistory`.
+
+**Architecture:** Keep local `mcp-trading` for existing read commands and add a narrow backend order gateway for official KIS Trading MCP order execution. `TelegramCommandHandler` owns parsing, pending-order state, market-hours checks, confirmation UX, and calls injected gateway/recorder dependencies so tests stay isolated.
+
+**Tech Stack:** Python 3.11+, FastAPI backend, SQLModel, pytest/pytest-asyncio, MCP Python client, official KIS Trading MCP over SSE or streamable HTTP.
+
+---
+
+## File Structure
+
+- Create `backend/trading_orders.py`
+  - Defines `PendingOrder`, `OrderExecutionResult`, `OfficialKisMcpOrderGateway`, `TradeRecorder`, parsing helpers, market-hours helper, and MCP result normalization for order execution.
+- Modify `backend/config.py`
+  - Adds official KIS MCP URL/transport/tool-name/order environment settings and `KIS_REAL_ORDER_ENABLED`.
+- Modify `backend/telegram_commands.py`
+  - Adds `/buy`, `/sell`, `/confirm`, `/cancel`, in-memory pending orders, and dependency injection for order gateway/time/recorder.
+- Modify `backend/tests/test_telegram_commands.py`
+  - Adds focused Telegram command tests for the new flow.
+- Create `backend/tests/test_trading_orders.py`
+  - Tests gateway guard/config normalization and market-hours/pending-order helpers without real KIS calls.
+- Modify `README.md` only if implementation adds new required environment variables.
+
+## Task 1: Trading Order Domain Helpers
+
+**Files:**
+- Create: `backend/trading_orders.py`
+- Test: `backend/tests/test_trading_orders.py`
+
+- [ ] **Step 1: Write failing tests for market hours and real-order guard**
+
+Add this file:
+
+```python
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi import HTTPException
+
+from backend.trading_orders import (
+    OfficialKisMcpOrderGateway,
+    PendingOrder,
+    is_korean_market_open,
+)
+
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def test_market_open_during_weekday_regular_session():
+    now = datetime(2026, 5, 20, 10, 0, tzinfo=KST)
+
+    assert is_korean_market_open(now) is True
+
+
+def test_market_closed_before_open():
+    now = datetime(2026, 5, 20, 8, 59, tzinfo=KST)
+
+    assert is_korean_market_open(now) is False
+
+
+def test_market_closed_after_close():
+    now = datetime(2026, 5, 20, 15, 31, tzinfo=KST)
+
+    assert is_korean_market_open(now) is False
+
+
+def test_market_closed_on_weekend():
+    now = datetime(2026, 5, 23, 10, 0, tzinfo=KST)
+
+    assert is_korean_market_open(now) is False
+
+
+@pytest.mark.asyncio
+async def test_real_order_without_explicit_opt_in_is_blocked_before_mcp_call():
+    calls = []
+
+    async def fake_remote_runner(*, transport, url, tool_name, arguments, timeout_sec):
+        calls.append((transport, url, tool_name, arguments, timeout_sec))
+        return "should not be called"
+
+    gateway = OfficialKisMcpOrderGateway(
+        mcp_url="http://127.0.0.1:3300/sse",
+        mcp_transport="sse",
+        tool_name="domestic_stock",
+        order_env="real",
+        real_order_enabled=False,
+        remote_runner=fake_remote_runner,
+    )
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="BUY",
+        quantity=10,
+        price=75000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await gateway.place_order(order)
+
+    assert exc_info.value.status_code == 403
+    assert "실계좌 주문" in str(exc_info.value.detail)
+    assert calls == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py -q
+```
+
+Expected: FAIL because `backend.trading_orders` does not exist.
+
+- [ ] **Step 3: Implement minimal helper module**
+
+Create `backend/trading_orders.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, time
+from typing import Any, Awaitable, Callable, Literal
+from zoneinfo import ZoneInfo
+
+from fastapi import HTTPException
+
+
+KST = ZoneInfo("Asia/Seoul")
+OrderSide = Literal["BUY", "SELL"]
+McpTransport = Literal["sse", "streamable-http"]
+
+
+@dataclass(frozen=True)
+class PendingOrder:
+    chat_id: str
+    stock_name: str
+    stock_code: str
+    side: OrderSide
+    quantity: int
+    price: int
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class OrderExecutionResult:
+    stock_code: str
+    stock_name: str
+    side: OrderSide
+    quantity: int
+    price: int
+    message: str
+    raw_result: str
+
+
+RemoteMcpRunner = Callable[..., Awaitable[str]]
+
+
+def is_korean_market_open(now: datetime | None = None) -> bool:
+    current = now or datetime.now(KST)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=KST)
+    current = current.astimezone(KST)
+    if current.weekday() >= 5:
+        return False
+    return time(9, 0) <= current.time() <= time(15, 30)
+
+
+class OfficialKisMcpOrderGateway:
+    def __init__(
+        self,
+        *,
+        mcp_url: str,
+        mcp_transport: McpTransport,
+        tool_name: str,
+        order_env: Literal["real", "demo"],
+        real_order_enabled: bool,
+        remote_runner: RemoteMcpRunner,
+        timeout_sec: float = 180.0,
+    ):
+        self.mcp_url = mcp_url
+        self.mcp_transport = mcp_transport
+        self.tool_name = tool_name
+        self.order_env = order_env
+        self.real_order_enabled = real_order_enabled
+        self.remote_runner = remote_runner
+        self.timeout_sec = timeout_sec
+
+    async def place_order(self, order: PendingOrder) -> OrderExecutionResult:
+        if self.order_env == "real" and not self.real_order_enabled:
+            raise HTTPException(
+                status_code=403,
+                detail="실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다.",
+            )
+
+        arguments = {
+            "api_type": "order_cash",
+            "params": {
+                "env_dv": self.order_env,
+                "pdno": order.stock_code,
+                "ord_dvsn": "01",
+                "ord_qty": str(order.quantity),
+                "ord_unpr": str(order.price),
+                "buy_sell": order.side.lower(),
+            },
+        }
+        raw_result = await self.remote_runner(
+            transport=self.mcp_transport,
+            url=self.mcp_url,
+            tool_name=self.tool_name,
+            arguments=arguments,
+            timeout_sec=self.timeout_sec,
+        )
+        message = _extract_order_message(raw_result)
+        return OrderExecutionResult(
+            stock_code=order.stock_code,
+            stock_name=order.stock_name,
+            side=order.side,
+            quantity=order.quantity,
+            price=order.price,
+            message=message,
+            raw_result=raw_result,
+        )
+
+
+def _extract_order_message(raw_result: str) -> str:
+    text = str(raw_result or "").strip()
+    if not text:
+        return "주문 요청이 접수되었습니다."
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return text[:500]
+    if isinstance(data, dict):
+        for key in ("msg1", "message", "rt_msg", "output"):
+            value = data.get(key)
+            if value:
+                return str(value)[:500]
+    return text[:500]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add backend/trading_orders.py backend/tests/test_trading_orders.py
+git commit -m "feat: Telegram 주문 도메인 헬퍼 추가" \
+  -m "- 장 운영 시간 판별 추가" \
+  -m "- 실계좌 주문 opt-in guard 추가"
+```
+
+## Task 2: Official KIS MCP Remote Adapter
+
+**Files:**
+- Modify: `backend/config.py`
+- Modify: `backend/trading_orders.py`
+- Test: `backend/tests/test_trading_orders.py`
+
+- [ ] **Step 1: Write failing tests for config-driven gateway and remote arguments**
+
+Append to `backend/tests/test_trading_orders.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_demo_order_calls_official_mcp_with_normalized_arguments():
+    calls = []
+
+    async def fake_remote_runner(*, transport, url, tool_name, arguments, timeout_sec):
+        calls.append(
+            {
+                "transport": transport,
+                "url": url,
+                "tool_name": tool_name,
+                "arguments": arguments,
+                "timeout_sec": timeout_sec,
+            }
+        )
+        return '{"msg1":"주문 접수"}'
+
+    gateway = OfficialKisMcpOrderGateway(
+        mcp_url="http://127.0.0.1:3300/sse",
+        mcp_transport="sse",
+        tool_name="domestic_stock",
+        order_env="demo",
+        real_order_enabled=False,
+        remote_runner=fake_remote_runner,
+        timeout_sec=30.0,
+    )
+    order = PendingOrder(
+        chat_id="123",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="SELL",
+        quantity=5,
+        price=76000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    result = await gateway.place_order(order)
+
+    assert result.message == "주문 접수"
+    assert calls == [
+        {
+            "transport": "sse",
+            "url": "http://127.0.0.1:3300/sse",
+            "tool_name": "domestic_stock",
+            "arguments": {
+                "api_type": "order_cash",
+                "params": {
+                    "env_dv": "demo",
+                    "pdno": "005930",
+                    "ord_dvsn": "01",
+                    "ord_qty": "5",
+                    "ord_unpr": "76000",
+                    "buy_sell": "sell",
+                },
+            },
+            "timeout_sec": 30.0,
+        }
+    ]
+```
+
+- [ ] **Step 2: Run focused test**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py::test_demo_order_calls_official_mcp_with_normalized_arguments -q
+```
+
+Expected: PASS if Task 1 code already includes the minimal adapter. If it fails due to official MCP field names discovered during implementation, update the expected `arguments` and gateway in the same step after confirming with `find_api_detail`.
+
+- [ ] **Step 3: Add backend config settings**
+
+Modify `backend/config.py` near Telegram settings:
+
+```python
+KIS_TRADING_MCP_URL = os.environ.get(
+    "FINUS_KIS_TRADING_MCP_URL",
+    "http://host.docker.internal:3300/sse",
+).strip()
+KIS_TRADING_MCP_TRANSPORT = os.environ.get("FINUS_KIS_TRADING_MCP_TRANSPORT", "sse").strip()
+KIS_TRADING_MCP_TOOL_NAME = os.environ.get(
+    "FINUS_KIS_TRADING_TOOL_NAME",
+    "domestic_stock",
+).strip()
+KIS_ORDER_ENV = os.environ.get("KIS_ORDER_ENV", "demo").strip().lower()
+KIS_REAL_ORDER_ENABLED = os.environ.get("KIS_REAL_ORDER_ENABLED", "false").lower() in {
+    "1",
+    "true",
+    "yes",
+    "y",
+}
+```
+
+- [ ] **Step 4: Implement remote MCP runner**
+
+Add to `backend/trading_orders.py`:
+
+```python
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamable_http_client
+```
+
+Add this function below type aliases:
+
+```python
+async def call_official_kis_mcp(
+    *,
+    transport: McpTransport,
+    url: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    timeout_sec: float,
+) -> str:
+    if transport == "sse":
+        async with sse_client(url, timeout=timeout_sec) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool(tool_name, arguments)
+                return _mcp_first_text_or_error(result)
+    if transport == "streamable-http":
+        async with streamable_http_client(url, timeout=timeout_sec) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool(tool_name, arguments)
+                return _mcp_first_text_or_error(result)
+    raise HTTPException(status_code=500, detail=f"지원하지 않는 KIS MCP transport: {transport}")
+
+
+def _mcp_first_text_or_error(result: Any) -> str:
+    block = result.content[0] if getattr(result, "content", None) else None
+    text = getattr(block, "text", str(block)) if block else ""
+    if getattr(result, "isError", False):
+        raise HTTPException(status_code=502, detail=text or "KIS MCP 주문 실행 실패")
+    return text
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add backend/config.py backend/trading_orders.py backend/tests/test_trading_orders.py
+git commit -m "feat: 공식 KIS MCP 주문 게이트웨이 추가" \
+  -m "- 공식 KIS MCP transport 설정 추가" \
+  -m "- 주문 실행 결과 정규화 추가"
+```
+
+## Task 3: Telegram Command Parsing And Pending Orders
+
+**Files:**
+- Modify: `backend/telegram_commands.py`
+- Test: `backend/tests/test_telegram_commands.py`
+
+- [ ] **Step 1: Add failing tests for order command parsing and pending state**
+
+Append to `backend/tests/test_telegram_commands.py`:
+
+```python
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from backend.trading_orders import OrderExecutionResult
+
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+class FakeOrderGateway:
+    def __init__(self, result=None, exc=None):
+        self.calls = []
+        self.result = result or OrderExecutionResult(
+            stock_code="005930",
+            stock_name="삼성전자",
+            side="BUY",
+            quantity=10,
+            price=75000,
+            message="주문 접수",
+            raw_result="주문 접수",
+        )
+        self.exc = exc
+
+    async def place_order(self, order):
+        self.calls.append(order)
+        if self.exc:
+            raise self.exc
+        return self.result
+
+
+class FakeTradeRecorder:
+    def __init__(self):
+        self.records = []
+
+    def record(self, result):
+        self.records.append(result)
+
+
+@pytest.mark.asyncio
+async def test_buy_command_creates_pending_order_and_prompts_confirmation():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "[삼성전자] 현재가 시세\n- 현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "[계좌 잔고 현황]\n- 예수금: 1,200,000원"
+        raise AssertionError(tool_name)
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 10 75000"}})
+
+    assert "삼성전자 매수 주문 확인" in notifier.messages[-1]
+    assert "/confirm" in notifier.messages[-1]
+    assert "/cancel" in notifier.messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_sell_command_rejects_market_closed():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        now_factory=lambda: datetime(2026, 5, 20, 8, 59, tzinfo=KST),
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/sell 삼성전자 1 75000"}})
+
+    assert notifier.messages[-1] == "주문 불가: 현재 장 운영 시간이 아닙니다. (평일 09:00~15:30)"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_buy_command_creates_pending_order_and_prompts_confirmation backend/tests/test_telegram_commands.py::test_sell_command_rejects_market_closed -q
+```
+
+Expected: FAIL because `TelegramCommandHandler` does not accept `now_factory` and does not route `/buy` or `/sell`.
+
+- [ ] **Step 3: Add imports and constants**
+
+Modify `backend/telegram_commands.py` imports:
+
+```python
+from datetime import datetime, timedelta
+from typing import Any, Callable
+
+from .trading_orders import (
+    KST,
+    OfficialKisMcpOrderGateway,
+    PendingOrder,
+    call_official_kis_mcp,
+    is_korean_market_open,
+)
+```
+
+Add constants near existing command help:
+
+```python
+BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> <지정가>"
+SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> <지정가>"
+ORDER_EXPIRES_AFTER = timedelta(seconds=60)
+```
+
+Update `TELEGRAM_INTERACTIVE_HELP` lines:
+
+```python
+"/buy <종목명> <수량> <지정가> - 지정가 매수 주문 준비",
+"/sell <종목명> <수량> <지정가> - 지정가 매도 주문 준비",
+"/confirm - 대기 주문 확정",
+"/cancel - 대기 주문 취소",
+```
+
+- [ ] **Step 4: Add handler dependencies and routing**
+
+Extend `TelegramCommandHandler.__init__`:
+
+```python
+        order_gateway: Any | None = None,
+        trade_recorder: Any | None = None,
+        now_factory: Callable[[], datetime] | None = None,
+```
+
+Inside `__init__`, assign:
+
+```python
+        self.order_gateway = order_gateway
+        self.trade_recorder = trade_recorder
+        self.now_factory = now_factory or (lambda: datetime.now(KST))
+        self.pending_orders: dict[str, PendingOrder] = {}
+```
+
+Add routes in `handle_update` before unknown slash handling:
+
+```python
+        if self._matches_command(command, bot_username, "/buy"):
+            await self._handle_order_command("BUY", argument, str(chat.get("id", "")).strip())
+            return
+        if self._matches_command(command, bot_username, "/sell"):
+            await self._handle_order_command("SELL", argument, str(chat.get("id", "")).strip())
+            return
+        if self._matches_command(command, bot_username, "/confirm"):
+            await self._handle_confirm(str(chat.get("id", "")).strip())
+            return
+        if self._matches_command(command, bot_username, "/cancel"):
+            await self._handle_cancel(str(chat.get("id", "")).strip())
+            return
+```
+
+- [ ] **Step 5: Implement order parsing and prompt creation**
+
+Add methods to `TelegramCommandHandler`:
+
+```python
+    async def _handle_order_command(self, side: str, argument: str, chat_id: str) -> None:
+        usage = BUY_COMMAND_HELP if side == "BUY" else SELL_COMMAND_HELP
+        parsed = self._parse_order_argument(argument)
+        if parsed is None:
+            await self._send_text_or_raise(usage)
+            return
+        stock_name, quantity, price = parsed
+        now = self.now_factory()
+        if not is_korean_market_open(now):
+            await self._send_text_or_raise("주문 불가: 현재 장 운영 시간이 아닙니다. (평일 09:00~15:30)")
+            return
+        self._drop_expired_pending_order(chat_id, now)
+        if chat_id in self.pending_orders:
+            await self._send_text_or_raise("이미 대기 중인 주문이 있습니다. /confirm 또는 /cancel로 먼저 처리하세요.")
+            return
+
+        await self.notifier.send_chat_action("typing")
+        try:
+            resolved = await self.mcp_runner(
+                TRADING_MCP_PARAMS,
+                "resolve_stock_code",
+                {"stock_name": stock_name},
+            )
+            stock_code = self._extract_stock_code(str(resolved)) or stock_name
+            quote, balance = await asyncio.gather(
+                self.mcp_runner(TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": stock_name}),
+                self.mcp_runner(TRADING_MCP_PARAMS, "get_balance", {}),
+            )
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 준비 실패: {_short_error(exc)}")
+            return
+
+        order = PendingOrder(
+            chat_id=chat_id,
+            stock_name=stock_name,
+            stock_code=stock_code,
+            side=side,
+            quantity=quantity,
+            price=price,
+            created_at=now,
+        )
+        self.pending_orders[chat_id] = order
+        await self._send_text_or_raise(self._format_order_prompt(order, str(quote), str(balance)))
+
+    def _parse_order_argument(self, argument: str) -> tuple[str, int, int] | None:
+        parts = argument.split()
+        if len(parts) != 3:
+            return None
+        stock_name, quantity_text, price_text = parts
+        try:
+            quantity = int(quantity_text.replace(",", ""))
+            price = int(price_text.replace(",", ""))
+        except ValueError:
+            return None
+        if quantity <= 0 or price <= 0:
+            return None
+        return stock_name, quantity, price
+
+    def _drop_expired_pending_order(self, chat_id: str, now: datetime) -> None:
+        order = self.pending_orders.get(chat_id)
+        if order is None:
+            return
+        if now - order.created_at > ORDER_EXPIRES_AFTER:
+            self.pending_orders.pop(chat_id, None)
+
+    def _extract_stock_code(self, resolved: str) -> str | None:
+        match = re.search(r"\((\d{6}),", resolved)
+        return match.group(1) if match else None
+
+    def _format_order_prompt(self, order: PendingOrder, quote: str, balance: str) -> str:
+        side_text = "매수" if order.side == "BUY" else "매도"
+        amount = order.quantity * order.price
+        lines = [
+            f"{order.stock_name} {side_text} 주문 확인",
+            f"- 수량: {order.quantity:,}주 x {order.price:,}원 = {amount:,}원",
+        ]
+        quote_line = self._first_line_containing(quote, "현재가")
+        balance_line = self._first_line_containing(balance, "예수금")
+        if quote_line:
+            lines.append(f"- {quote_line.lstrip('- ').strip()}")
+        if balance_line:
+            lines.append(f"- {balance_line.lstrip('- ').strip()}")
+        lines.append("/confirm 으로 확정, /cancel 로 취소 (60초 내)")
+        return "\n".join(lines)
+
+    def _first_line_containing(self, text: str, needle: str) -> str | None:
+        for line in text.splitlines():
+            if needle in line:
+                return line.strip()
+        return None
+```
+
+Also add `import re` at the top.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_buy_command_creates_pending_order_and_prompts_confirmation backend/tests/test_telegram_commands.py::test_sell_command_rejects_market_closed -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add backend/telegram_commands.py backend/tests/test_telegram_commands.py
+git commit -m "feat: Telegram 주문 준비 명령 추가" \
+  -m "- buy/sell 명령 파싱 추가" \
+  -m "- 대기 주문 확인 프롬프트 추가"
+```
+
+## Task 4: Confirm, Cancel, Trade Recording
+
+**Files:**
+- Modify: `backend/trading_orders.py`
+- Modify: `backend/telegram_commands.py`
+- Test: `backend/tests/test_telegram_commands.py`
+
+- [ ] **Step 1: Add failing tests for confirm/cancel/recording**
+
+Append to `backend/tests/test_telegram_commands.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_cancel_removes_pending_order():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "- 현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "- 예수금: 1,200,000원"
+        raise AssertionError(tool_name)
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 10 75000"}})
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/cancel"}})
+
+    assert "취소" in notifier.messages[-1]
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_confirm_executes_gateway_and_records_trade():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "- 현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "- 예수금: 1,200,000원"
+        raise AssertionError(tool_name)
+
+    gateway = FakeOrderGateway()
+    recorder = FakeTradeRecorder()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        trade_recorder=recorder,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 10 75000"}})
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert len(gateway.calls) == 1
+    assert len(recorder.records) == 1
+    assert "주문 완료" in notifier.messages[-1]
+    assert handler.pending_orders == {}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_cancel_removes_pending_order backend/tests/test_telegram_commands.py::test_confirm_executes_gateway_and_records_trade -q
+```
+
+Expected: FAIL because `_handle_cancel` and `_handle_confirm` are not implemented.
+
+- [ ] **Step 3: Add trade recorder**
+
+Append to `backend/trading_orders.py`:
+
+```python
+class TradeRecorder:
+    def __init__(self, session_factory: Callable[[], Any]):
+        self.session_factory = session_factory
+
+    def record(self, result: OrderExecutionResult) -> None:
+        from .models import TradeHistory
+
+        with self.session_factory() as session:
+            trade = TradeHistory(
+                stock_code=result.stock_code,
+                stock_name=result.stock_name,
+                trade_type=result.side,
+                quantity=result.quantity,
+                price=float(result.price),
+            )
+            session.add(trade)
+            session.commit()
+```
+
+- [ ] **Step 4: Implement confirm/cancel methods**
+
+Add to `TelegramCommandHandler`:
+
+```python
+    async def _handle_cancel(self, chat_id: str) -> None:
+        self._drop_expired_pending_order(chat_id, self.now_factory())
+        if self.pending_orders.pop(chat_id, None) is None:
+            await self._send_text_or_raise("취소할 대기 주문이 없습니다.")
+            return
+        await self._send_text_or_raise("대기 주문을 취소했습니다.")
+
+    async def _handle_confirm(self, chat_id: str) -> None:
+        now = self.now_factory()
+        self._drop_expired_pending_order(chat_id, now)
+        order = self.pending_orders.get(chat_id)
+        if order is None:
+            await self._send_text_or_raise("확정할 대기 주문이 없습니다.")
+            return
+        if self.order_gateway is None:
+            await self._send_text_or_raise("주문 실행 설정이 준비되지 않았습니다.")
+            return
+
+        await self.notifier.send_chat_action("typing")
+        try:
+            result = await self.order_gateway.place_order(order)
+        except Exception as exc:
+            await self._send_text_or_raise(f"주문 실패: {_short_error(exc)}")
+            return
+
+        if self.trade_recorder is not None:
+            self.trade_recorder.record(result)
+        self.pending_orders.pop(chat_id, None)
+        await self._send_text_or_raise(f"주문 완료: {result.message}")
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_cancel_removes_pending_order backend/tests/test_telegram_commands.py::test_confirm_executes_gateway_and_records_trade -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add backend/trading_orders.py backend/telegram_commands.py backend/tests/test_telegram_commands.py
+git commit -m "feat: Telegram 주문 확정 및 취소 추가" \
+  -m "- confirm 주문 실행 흐름 추가" \
+  -m "- TradeHistory 기록 연결 추가"
+```
+
+## Task 5: Wire Production Dependencies
+
+**Files:**
+- Modify: `backend/telegram_commands.py`
+- Test: `backend/tests/test_telegram_commands.py`
+
+- [ ] **Step 1: Add imports for production dependencies**
+
+Modify `backend/telegram_commands.py` imports:
+
+```python
+from .config import (
+    KIS_ORDER_ENV,
+    KIS_REAL_ORDER_ENABLED,
+    KIS_TRADING_MCP_TOOL_NAME,
+    KIS_TRADING_MCP_TRANSPORT,
+    KIS_TRADING_MCP_URL,
+    TRADING_MCP_PARAMS,
+)
+from sqlmodel import Session
+from .database import engine
+from .trading_orders import TradeRecorder
+```
+
+- [ ] **Step 2: Add factory helpers**
+
+Add module-level helpers in `backend/telegram_commands.py` before `TelegramCommandPoller`:
+
+```python
+def _create_order_gateway() -> OfficialKisMcpOrderGateway:
+    transport = KIS_TRADING_MCP_TRANSPORT
+    if transport not in {"sse", "streamable-http"}:
+        transport = "sse"
+    order_env = "real" if KIS_ORDER_ENV == "real" else "demo"
+    return OfficialKisMcpOrderGateway(
+        mcp_url=KIS_TRADING_MCP_URL,
+        mcp_transport=transport,
+        tool_name=KIS_TRADING_MCP_TOOL_NAME,
+        order_env=order_env,
+        real_order_enabled=KIS_REAL_ORDER_ENABLED,
+        remote_runner=call_official_kis_mcp,
+    )
+
+
+def _create_trade_recorder() -> TradeRecorder:
+    return TradeRecorder(lambda: Session(engine))
+```
+
+Modify `TelegramCommandPoller.__init__` to create the default handler with production dependencies:
+
+```python
+self.handler = handler or TelegramCommandHandler(
+    notifier=notifier,
+    order_gateway=_create_order_gateway(),
+    trade_recorder=_create_trade_recorder(),
+)
+```
+
+- [ ] **Step 3: Run command tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 5**
+
+```bash
+git add backend/telegram_commands.py backend/tests/test_telegram_commands.py
+git commit -m "feat: Telegram 주문 실행 의존성 연결" \
+  -m "- 공식 KIS MCP 주문 게이트웨이 기본 연결" \
+  -m "- TradeHistory recorder 기본 연결"
+```
+
+## Task 6: Documentation And Final Verification
+
+**Files:**
+- Modify: `README.md`
+- Test: focused backend tests and syntax checks
+
+- [ ] **Step 1: Document environment variables**
+
+Add to README setup/configuration section:
+
+```markdown
+### Telegram manual order execution
+
+Telegram `/buy` and `/sell` prepare manual limit orders. `/confirm` executes the pending order through official KIS Trading MCP.
+
+Required for order execution:
+
+- `FINUS_KIS_TRADING_MCP_URL`: official KIS Trading MCP URL, for example `http://host.docker.internal:3300/sse`
+- `FINUS_KIS_TRADING_MCP_TRANSPORT`: `sse` or `streamable-http`
+- `FINUS_KIS_TRADING_TOOL_NAME`: default `domestic_stock`
+- `KIS_ORDER_ENV`: `demo` or `real`
+- `KIS_REAL_ORDER_ENABLED`: must be `true` before real-account order execution is allowed
+```
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run broader backend tests if focused tests pass**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests -q
+```
+
+Expected: PASS or only pre-existing unrelated failures. Investigate any failure touching Telegram, scheduler, config, services, or database.
+
+- [ ] **Step 4: Run diff checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors. `git status --short` should show only files intentionally changed for issue #43 and the staged spec/plan docs.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add README.md
+git commit -m "docs: Telegram 수동 주문 설정 문서화" \
+  -m "- 공식 KIS MCP 주문 실행 환경 변수 정리"
+```
+
+## Task 7: Official KIS MCP Field Verification Before Real Use
+
+**Files:**
+- Modify only if verification reveals different field names: `backend/trading_orders.py`
+- Test: `backend/tests/test_trading_orders.py`
+
+- [ ] **Step 1: Query official MCP schema in a running environment**
+
+With official KIS Trading MCP running, call `find_api_detail` for the order API through the same remote MCP transport configured for the backend.
+
+Expected detail to confirm:
+
+- domestic stock tool name is `domestic_stock`
+- domestic cash limit order `api_type`
+- side parameter name/value for buy and sell
+- environment parameter name/value for demo and real
+- required account fields, if the MCP does not inject them
+- limit-order division value
+
+- [ ] **Step 2: Reconcile implementation with schema**
+
+If the official MCP reports field names different from Task 1 assumptions, update the gateway's `arguments` builder and the expected test dictionary in `test_demo_order_calls_official_mcp_with_normalized_arguments`.
+
+- [ ] **Step 3: Run gateway tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit schema reconciliation if code changed**
+
+```bash
+git add backend/trading_orders.py backend/tests/test_trading_orders.py
+git commit -m "fix: 공식 KIS MCP 주문 파라미터 정합성 반영" \
+  -m "- find_api_detail 결과 기준 주문 payload 조정"
+```
+
+Skip this commit if no code changed.
+
+## Final Validation
+
+- [ ] Run focused tests:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q
+```
+
+- [ ] Run backend tests:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests -q
+```
+
+- [ ] Verify staged/committed scope:
+
+```bash
+git status --short
+git log --oneline -8
+```
+
+- [ ] If commits are blocked by the local environment, leave the exact staged scope visible with:
+
+```bash
+git status --short --branch
+git diff --stat
+git diff --cached --stat
+```

--- a/docs/superpowers/plans/2026-05-20-telegram-mcp-trading-order-replacement.md
+++ b/docs/superpowers/plans/2026-05-20-telegram-mcp-trading-order-replacement.md
@@ -1,0 +1,821 @@
+# Telegram mcp-trading 주문 전환 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace official KIS Trading MCP order execution with local `mcp-trading` order execution while preserving Telegram manual-order UX and safety guards.
+
+**Architecture:** `mcp-trading` becomes the single local MCP boundary for KIS Open API reads and domestic cash orders. Backend `TelegramCommandHandler` keeps parsing, pending-order state, market-hours checks, confirmation, and history recording, but its order gateway calls `run_mcp_tool(TRADING_MCP_PARAMS, "place_order", args)` instead of a remote official MCP transport.
+
+**Tech Stack:** Node.js ESM, `node:test`, MCP JavaScript SDK, axios, Python 3.11+, FastAPI, SQLModel, pytest, pytest-asyncio.
+
+---
+
+## File Structure
+
+- Create `mcp-trading/order.js`
+  - Pure order helpers: side normalization, env/url consistency, TR ID selection, account split, KIS order body creation, response formatting.
+- Create `mcp-trading/tests/order.test.js`
+  - Node unit tests for order helper behavior without network calls.
+- Modify `mcp-trading/index.js`
+  - Import order helpers, add `kisPost`, add `placeOrder`, expose `place_order` MCP tool, route tool calls.
+- Modify `mcp-trading/package.json`
+  - Add `test` script using `node --test tests/*.test.js`.
+- Modify `backend/trading_orders.py`
+  - Remove official KIS MCP remote transport code.
+  - Add `McpTradingOrderGateway` that calls the local MCP runner.
+- Modify `backend/telegram_commands.py`
+  - Replace `OfficialKisMcpOrderGateway` factory with `McpTradingOrderGateway`.
+- Modify `backend/config.py`
+  - Remove official KIS MCP URL/transport/tool settings.
+  - Keep `KIS_ORDER_ENV` and `KIS_REAL_ORDER_ENABLED`.
+- Modify `backend/tests/test_trading_orders.py`
+  - Replace official remote MCP tests with local gateway tests.
+- Modify `backend/tests/test_telegram_commands.py`
+  - Update gateway factory tests to expect `McpTradingOrderGateway`.
+- Modify `.env.example`
+  - Remove official KIS MCP envs.
+- Modify `README.md`
+  - Document local `mcp-trading` order execution and remove official MCP Docker requirement.
+
+---
+
+## Task 1: mcp-trading Order Helper Tests
+
+**Files:**
+- Create: `mcp-trading/order.js`
+- Create: `mcp-trading/tests/order.test.js`
+- Modify: `mcp-trading/package.json`
+
+- [ ] **Step 1: Write failing Node tests**
+
+Create `mcp-trading/tests/order.test.js`:
+
+```javascript
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildCashOrderBody,
+  formatOrderResult,
+  selectCashOrderTrId,
+  validateOrderEnvMatchesUrl,
+} from "../order.js";
+
+test("selectCashOrderTrId maps demo buy and sell to paper TR IDs", () => {
+  assert.equal(selectCashOrderTrId({ orderEnv: "demo", side: "BUY" }), "VTTC0012U");
+  assert.equal(selectCashOrderTrId({ orderEnv: "demo", side: "SELL" }), "VTTC0011U");
+});
+
+test("selectCashOrderTrId maps real buy and sell to production TR IDs", () => {
+  assert.equal(selectCashOrderTrId({ orderEnv: "real", side: "BUY" }), "TTTC0012U");
+  assert.equal(selectCashOrderTrId({ orderEnv: "real", side: "SELL" }), "TTTC0011U");
+});
+
+test("validateOrderEnvMatchesUrl fails closed on env and URL mismatch", () => {
+  assert.throws(
+    () => validateOrderEnvMatchesUrl({ orderEnv: "demo", kisUrl: "https://openapi.koreainvestment.com:9443" }),
+    /모의투자 주문은 모의투자 KIS_URL/,
+  );
+  assert.throws(
+    () => validateOrderEnvMatchesUrl({ orderEnv: "real", kisUrl: "https://openapivts.koreainvestment.com:29443" }),
+    /실계좌 주문은 실전 KIS_URL/,
+  );
+});
+
+test("buildCashOrderBody creates uppercase KIS order body", () => {
+  assert.deepEqual(
+    buildCashOrderBody({
+      accountNo: "1234567801",
+      stockCode: "005930",
+      quantity: 2,
+      price: 70000,
+    }),
+    {
+      CANO: "12345678",
+      ACNT_PRDT_CD: "01",
+      PDNO: "005930",
+      ORD_DVSN: "00",
+      ORD_QTY: "2",
+      ORD_UNPR: "70000",
+      EXCG_ID_DVSN_CD: "SOR",
+      SLL_TYPE: "",
+      CNDT_PRIC: "",
+    },
+  );
+});
+
+test("formatOrderResult includes order number when present", () => {
+  assert.equal(
+    formatOrderResult({
+      stockName: "삼성전자",
+      stockCode: "005930",
+      side: "BUY",
+      quantity: 1,
+      price: 70000,
+      data: { output: { ODNO: "12345", ORD_TMD: "101010" }, msg1: "주문이 완료되었습니다" },
+    }),
+    "[삼성전자] BUY 주문 접수\n- 종목코드: 005930\n- 수량/가격: 1주 / 70,000원\n- 주문번호: 12345\n- 주문시간: 101010\n- 메시지: 주문이 완료되었습니다",
+  );
+});
+```
+
+- [ ] **Step 2: Add minimal helper exports that make tests importable**
+
+Create `mcp-trading/order.js`:
+
+```javascript
+export function selectCashOrderTrId() {
+  return "";
+}
+
+export function validateOrderEnvMatchesUrl() {}
+
+export function buildCashOrderBody() {
+  return {};
+}
+
+export function formatOrderResult() {
+  return "";
+}
+```
+
+- [ ] **Step 3: Add test script**
+
+Modify `mcp-trading/package.json` scripts:
+
+```json
+"scripts": {
+  "test": "node --test tests/*.test.js"
+}
+```
+
+- [ ] **Step 4: Run tests and verify they fail for behavior**
+
+Run:
+
+```bash
+npm test --prefix mcp-trading
+```
+
+Expected: FAIL with assertion differences for TR ID, payload, or formatted text. Import errors are not expected after Step 2.
+
+- [ ] **Step 5: Implement order helpers**
+
+Replace `mcp-trading/order.js` with:
+
+```javascript
+function normalizeSide(side) {
+  const normalized = String(side ?? "").trim().toUpperCase();
+  if (normalized !== "BUY" && normalized !== "SELL") {
+    throw new Error("side는 BUY 또는 SELL이어야 합니다.");
+  }
+  return normalized;
+}
+
+function normalizeOrderEnv(orderEnv) {
+  const normalized = String(orderEnv ?? "demo").trim().toLowerCase();
+  if (normalized !== "demo" && normalized !== "real") {
+    throw new Error("order_env는 demo 또는 real이어야 합니다.");
+  }
+  return normalized;
+}
+
+function assertPositiveInteger(value, fieldName) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error(`${fieldName}는 양의 정수여야 합니다.`);
+  }
+  return number;
+}
+
+export function selectCashOrderTrId({ orderEnv, side }) {
+  const env = normalizeOrderEnv(orderEnv);
+  const normalizedSide = normalizeSide(side);
+
+  if (env === "demo") {
+    return normalizedSide === "BUY" ? "VTTC0012U" : "VTTC0011U";
+  }
+  return normalizedSide === "BUY" ? "TTTC0012U" : "TTTC0011U";
+}
+
+export function validateOrderEnvMatchesUrl({ orderEnv, kisUrl }) {
+  const env = normalizeOrderEnv(orderEnv);
+  const url = String(kisUrl ?? "");
+  const isPaperUrl = url.includes("openapivts");
+
+  if (env === "demo" && !isPaperUrl) {
+    throw new Error("모의투자 주문은 모의투자 KIS_URL(openapivts)이 필요합니다.");
+  }
+  if (env === "real" && isPaperUrl) {
+    throw new Error("실계좌 주문은 실전 KIS_URL이 필요합니다.");
+  }
+}
+
+export function buildCashOrderBody({ accountNo, stockCode, quantity, price }) {
+  const account = String(accountNo ?? "").trim();
+  const code = String(stockCode ?? "").trim();
+  const orderQuantity = assertPositiveInteger(quantity, "quantity");
+  const orderPrice = assertPositiveInteger(price, "price");
+
+  if (account.length < 10) {
+    throw new Error("KIS_ACCOUNT_NO가 올바르지 않습니다. 계좌번호 앞 8자리와 상품코드 2자리를 붙여 설정하세요.");
+  }
+  if (!/^\d{6,7}$/.test(code)) {
+    throw new Error("stock_code는 6자리 또는 7자리 종목코드여야 합니다.");
+  }
+
+  return {
+    CANO: account.substring(0, 8),
+    ACNT_PRDT_CD: account.substring(8, 10),
+    PDNO: code,
+    ORD_DVSN: "00",
+    ORD_QTY: String(orderQuantity),
+    ORD_UNPR: String(orderPrice),
+    EXCG_ID_DVSN_CD: "SOR",
+    SLL_TYPE: "",
+    CNDT_PRIC: "",
+  };
+}
+
+export function formatOrderResult({ stockName, stockCode, side, quantity, price, data }) {
+  const output = data?.output || {};
+  const message = data?.msg1 || data?.msg_cd || "주문 요청이 접수되었습니다.";
+  const orderNo = output.ODNO || "-";
+  const orderTime = output.ORD_TMD || "-";
+
+  return [
+    `[${stockName}] ${normalizeSide(side)} 주문 접수`,
+    `- 종목코드: ${stockCode}`,
+    `- 수량/가격: ${Number(quantity).toLocaleString("ko-KR")}주 / ${Number(price).toLocaleString("ko-KR")}원`,
+    `- 주문번호: ${orderNo}`,
+    `- 주문시간: ${orderTime}`,
+    `- 메시지: ${message}`,
+  ].join("\n");
+}
+```
+
+- [ ] **Step 6: Run tests and syntax check**
+
+Run:
+
+```bash
+npm test --prefix mcp-trading
+node --check mcp-trading/order.js
+```
+
+Expected: PASS for Node tests, syntax check exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp-trading/order.js mcp-trading/tests/order.test.js mcp-trading/package.json
+git commit -m "feat: mcp-trading 주문 payload 헬퍼 추가" \
+  -m "- 국내주식 현금 주문 TR ID 선택 헬퍼" \
+  -m "- KIS 주문 payload 검증 테스트"
+```
+
+---
+
+## Task 2: mcp-trading place_order Tool
+
+**Files:**
+- Modify: `mcp-trading/index.js`
+- Test: `mcp-trading/tests/order.test.js`
+
+- [ ] **Step 1: Add failing validation test for response shape**
+
+Append to `mcp-trading/tests/order.test.js`:
+
+```javascript
+test("formatOrderResult falls back when output is missing", () => {
+  assert.equal(
+    formatOrderResult({
+      stockName: "005930",
+      stockCode: "005930",
+      side: "SELL",
+      quantity: 3,
+      price: 68000,
+      data: { msg1: "정상처리 되었습니다" },
+    }),
+    "[005930] SELL 주문 접수\n- 종목코드: 005930\n- 수량/가격: 3주 / 68,000원\n- 주문번호: -\n- 주문시간: -\n- 메시지: 정상처리 되었습니다",
+  );
+});
+```
+
+- [ ] **Step 2: Import helpers in `mcp-trading/index.js`**
+
+Add after the `dotenv` import:
+
+```javascript
+import {
+  buildCashOrderBody,
+  formatOrderResult,
+  selectCashOrderTrId,
+  validateOrderEnvMatchesUrl,
+} from "./order.js";
+```
+
+- [ ] **Step 3: Add `kisPost` next to `kisGet`**
+
+Add after `kisGet`:
+
+```javascript
+async function kisPost(pathname, trId, body) {
+  const token = await getAccessToken();
+  const response = await axios.post(`${KIS_URL}${pathname}`, body, {
+    headers: {
+      "Content-Type": "application/json",
+      authorization: `Bearer ${token}`,
+      appkey: KIS_API_KEY,
+      appsecret: KIS_API_SECRET,
+      tr_id: trId,
+      custtype: "P",
+    },
+  });
+
+  const data = response.data;
+  if (data.rt_cd !== "0") {
+    throw new Error(`KIS API 오류: ${data.msg1 || data.msg_cd || "알 수 없는 오류"}`);
+  }
+  return data;
+}
+```
+
+- [ ] **Step 4: Add `placeOrder` function**
+
+Add before `server.setRequestHandler(ListToolsRequestSchema, ...)`:
+
+```javascript
+async function placeOrder(args) {
+  requireKisCredentials({ accountRequired: true });
+
+  const stockCode = String(args?.stock_code ?? "").trim() || resolveStock(args?.stock_name).code;
+  const stockName = String(args?.stock_name ?? "").trim() || stockCode;
+  const side = String(args?.side ?? "").trim().toUpperCase();
+  const orderEnv = String(args?.order_env ?? "demo").trim().toLowerCase();
+
+  validateOrderEnvMatchesUrl({ orderEnv, kisUrl: KIS_URL });
+  const trId = selectCashOrderTrId({ orderEnv, side });
+  const body = buildCashOrderBody({
+    accountNo: KIS_ACCOUNT_NO,
+    stockCode,
+    quantity: args?.quantity,
+    price: args?.price,
+  });
+
+  const data = await kisPost("/uapi/domestic-stock/v1/trading/order-cash", trId, body);
+  return formatOrderResult({
+    stockName,
+    stockCode,
+    side,
+    quantity: args?.quantity,
+    price: args?.price,
+    data,
+  });
+}
+```
+
+- [ ] **Step 5: Add tool schema**
+
+Add to the tools array:
+
+```javascript
+{
+  name: "place_order",
+  description: "한국투자증권 Open API로 국내 주식 현금 지정가 주문을 실행합니다.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      stock_name: { type: "string", description: "주식 종목명 또는 6자리 종목코드" },
+      stock_code: { type: "string", description: "KIS API용 종목코드" },
+      side: { type: "string", enum: ["BUY", "SELL"], description: "매수 또는 매도" },
+      quantity: { type: "integer", minimum: 1, description: "주문 수량" },
+      price: { type: "integer", minimum: 1, description: "지정가" },
+      order_env: { type: "string", enum: ["demo", "real"], description: "모의투자 또는 실계좌" },
+    },
+    required: ["stock_code", "side", "quantity", "price", "order_env"],
+  },
+}
+```
+
+- [ ] **Step 6: Route tool call**
+
+Add in `CallToolRequestSchema` handler before the catch block:
+
+```javascript
+if (name === "place_order") {
+  return { content: [{ type: "text", text: await placeOrder(args) }] };
+}
+```
+
+- [ ] **Step 7: Run checks**
+
+Run:
+
+```bash
+npm test --prefix mcp-trading
+node --check mcp-trading/index.js
+```
+
+Expected: PASS and syntax check exits 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mcp-trading/index.js mcp-trading/tests/order.test.js
+git commit -m "feat: mcp-trading 주문 실행 도구 추가" \
+  -m "- place_order MCP 도구 추가" \
+  -m "- KIS Open API 현금 지정가 주문 호출"
+```
+
+---
+
+## Task 3: Backend Gateway Replacement
+
+**Files:**
+- Modify: `backend/trading_orders.py`
+- Modify: `backend/telegram_commands.py`
+- Modify: `backend/tests/test_trading_orders.py`
+- Modify: `backend/tests/test_telegram_commands.py`
+
+- [ ] **Step 1: Replace gateway tests**
+
+In `backend/tests/test_trading_orders.py`, remove official transport-specific tests for SSE/streamable HTTP and add:
+
+```python
+@pytest.mark.asyncio
+async def test_mcp_trading_order_gateway_calls_place_order():
+    calls = []
+
+    async def runner(params, tool_name, arguments):
+        calls.append((params, tool_name, arguments))
+        return "주문번호 12345"
+
+    order = PendingOrder(
+        chat_id="1",
+        stock_name="삼성전자",
+        stock_code="005930",
+        side="BUY",
+        quantity=2,
+        price=70000,
+        created_at=datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+    gateway = McpTradingOrderGateway(
+        server_params="trading-params",
+        mcp_runner=runner,
+        order_env="demo",
+        real_order_enabled=False,
+    )
+
+    result = await gateway.place_order(order)
+
+    assert result.message == "주문번호 12345"
+    assert result.raw_result == "주문번호 12345"
+    assert calls == [
+        (
+            "trading-params",
+            "place_order",
+            {
+                "stock_name": "삼성전자",
+                "stock_code": "005930",
+                "side": "BUY",
+                "quantity": 2,
+                "price": 70000,
+                "order_env": "demo",
+            },
+        )
+    ]
+```
+
+Also replace imports:
+
+```python
+from backend.trading_orders import (
+    KST,
+    McpTradingOrderGateway,
+    OrderExecutionResult,
+    PendingOrder,
+    TradeRecorder,
+    _extract_order_message,
+    is_korean_market_open,
+)
+```
+
+- [ ] **Step 2: Run targeted test and verify failure**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py -q
+```
+
+Expected: FAIL because `McpTradingOrderGateway` is not defined.
+
+- [ ] **Step 3: Replace official gateway implementation**
+
+In `backend/trading_orders.py`, remove these official MCP pieces:
+
+- `asyncio`, `httpx`, MCP client imports
+- `McpTransport`
+- `RemoteMcpRunner`
+- `_mcp_first_text_or_error`
+- `_sse_connect_timeout`
+- `call_official_kis_mcp`
+- `_exception_group_contains`
+- `_call_official_kis_mcp_inner`
+- `OfficialKisMcpOrderGateway`
+
+Add:
+
+```python
+McpRunner = Callable[[Any, str, dict[str, Any]], Awaitable[str]]
+
+
+class McpTradingOrderGateway:
+    def __init__(
+        self,
+        *,
+        server_params: Any,
+        mcp_runner: McpRunner,
+        order_env: Literal["real", "demo"],
+        real_order_enabled: bool,
+    ):
+        self.server_params = server_params
+        self.mcp_runner = mcp_runner
+        self.order_env = order_env
+        self.real_order_enabled = real_order_enabled
+
+    async def place_order(self, order: PendingOrder) -> OrderExecutionResult:
+        if self.order_env == "real" and not self.real_order_enabled:
+            raise HTTPException(
+                status_code=403,
+                detail="실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다.",
+            )
+
+        raw_result = await self.mcp_runner(
+            self.server_params,
+            "place_order",
+            {
+                "stock_name": order.stock_name,
+                "stock_code": order.stock_code,
+                "side": order.side,
+                "quantity": order.quantity,
+                "price": order.price,
+                "order_env": self.order_env,
+            },
+        )
+
+        return OrderExecutionResult(
+            stock_code=order.stock_code,
+            stock_name=order.stock_name,
+            side=order.side,
+            quantity=order.quantity,
+            price=order.price,
+            message=_extract_order_message(raw_result),
+            raw_result=raw_result,
+        )
+```
+
+- [ ] **Step 4: Replace Telegram factory**
+
+In `backend/telegram_commands.py`, replace imports from config with:
+
+```python
+from .config import KIS_ORDER_ENV, KIS_REAL_ORDER_ENABLED, TRADING_MCP_PARAMS
+```
+
+Replace trading order import:
+
+```python
+from .trading_orders import (
+    KST,
+    McpTradingOrderGateway,
+    PendingOrder,
+    TradeRecorder,
+    is_korean_market_open,
+)
+```
+
+Replace `_create_order_gateway`:
+
+```python
+def _create_order_gateway() -> McpTradingOrderGateway:
+    return McpTradingOrderGateway(
+        server_params=TRADING_MCP_PARAMS,
+        mcp_runner=run_mcp_tool,
+        order_env=KIS_ORDER_ENV,
+        real_order_enabled=KIS_REAL_ORDER_ENABLED,
+    )
+```
+
+- [ ] **Step 5: Update Telegram factory test**
+
+In `backend/tests/test_telegram_commands.py`, replace the official gateway factory test with:
+
+```python
+def test_create_order_gateway_uses_local_mcp_trading(monkeypatch):
+    captured = {}
+
+    class FakeGateway:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(telegram_commands, "McpTradingOrderGateway", FakeGateway)
+    monkeypatch.setattr(telegram_commands, "KIS_ORDER_ENV", "demo")
+    monkeypatch.setattr(telegram_commands, "KIS_REAL_ORDER_ENABLED", False)
+
+    gateway = telegram_commands._create_order_gateway()
+
+    assert isinstance(gateway, FakeGateway)
+    assert captured == {
+        "server_params": TRADING_MCP_PARAMS,
+        "mcp_runner": telegram_commands.run_mcp_tool,
+        "order_env": "demo",
+        "real_order_enabled": False,
+    }
+```
+
+- [ ] **Step 6: Run focused backend tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_trading_orders.py backend/tests/test_telegram_commands.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/trading_orders.py backend/telegram_commands.py backend/tests/test_trading_orders.py backend/tests/test_telegram_commands.py
+git commit -m "refactor: Telegram 주문 실행을 mcp-trading으로 전환" \
+  -m "- 공식 KIS MCP 주문 어댑터 제거" \
+  -m "- 로컬 mcp-trading place_order 게이트웨이 연결"
+```
+
+---
+
+## Task 4: Config and Docs Replacement
+
+**Files:**
+- Modify: `backend/config.py`
+- Modify: `.env.example`
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-05-20-telegram-manual-trading-design.md`
+- Modify: `docs/superpowers/plans/2026-05-20-telegram-manual-trading.md`
+
+- [ ] **Step 1: Remove official MCP config**
+
+In `backend/config.py`, remove:
+
+```python
+KIS_TRADING_MCP_URL = os.environ.get(
+    "FINUS_KIS_TRADING_MCP_URL",
+    "http://host.docker.internal:3300/sse",
+).strip()
+KIS_TRADING_MCP_TRANSPORT = os.environ.get("FINUS_KIS_TRADING_MCP_TRANSPORT", "sse").strip()
+KIS_TRADING_MCP_TOOL_NAME = os.environ.get("FINUS_KIS_TRADING_TOOL_NAME", "domestic_stock").strip()
+```
+
+Keep:
+
+```python
+KIS_ORDER_ENV = os.environ.get("KIS_ORDER_ENV", "demo").strip().lower()
+KIS_REAL_ORDER_ENABLED = os.environ.get("KIS_REAL_ORDER_ENABLED", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "y",
+}
+```
+
+- [ ] **Step 2: Remove `.env.example` official MCP entries**
+
+Remove:
+
+```dotenv
+FINUS_KIS_TRADING_MCP_URL=http://host.docker.internal:3300/sse
+FINUS_KIS_TRADING_MCP_TRANSPORT=sse
+FINUS_KIS_TRADING_TOOL_NAME=domestic_stock
+```
+
+Ensure the remaining order settings are:
+
+```dotenv
+KIS_ORDER_ENV=demo
+KIS_REAL_ORDER_ENABLED=false
+```
+
+- [ ] **Step 3: Update README manual trading section**
+
+Replace the official MCP paragraph with:
+
+```markdown
+`/buy`와 `/sell`은 60초 동안 유효한 지정가 주문 확인 대기를 만들고, `/confirm`은 로컬 `mcp-trading`의 `place_order` 도구를 통해 한국투자증권 Open API 현금 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령도 같은 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
+```
+
+- [ ] **Step 4: Mark old spec and plan as superseded**
+
+At the top of `docs/superpowers/specs/2026-05-20-telegram-manual-trading-design.md`, add:
+
+```markdown
+> Superseded: 주문 실행 provider는 공식 KIS Trading MCP가 아니라 로컬 `mcp-trading`으로 전환되었습니다. 현재 기준 문서는 `docs/superpowers/specs/2026-05-20-telegram-mcp-trading-order-replacement-design.md`입니다.
+```
+
+At the top of `docs/superpowers/plans/2026-05-20-telegram-manual-trading.md`, add:
+
+```markdown
+> Superseded: 공식 KIS Trading MCP 실행 계획은 로컬 `mcp-trading` 주문 실행 계획으로 대체되었습니다. 현재 기준 문서는 `docs/superpowers/plans/2026-05-20-telegram-mcp-trading-order-replacement.md`입니다.
+```
+
+- [ ] **Step 5: Run config/docs checks**
+
+Run:
+
+```bash
+rg -n "FINUS_KIS_TRADING|KIS_TRADING_MCP|OfficialKisMcp|official KIS Trading MCP|공식 KIS MCP" backend README.md .env.example docs/superpowers
+git diff --check
+```
+
+Expected: matches only in superseded historical paragraphs or no matches in runtime files; `git diff --check` exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/config.py .env.example README.md docs/superpowers/specs/2026-05-20-telegram-manual-trading-design.md docs/superpowers/plans/2026-05-20-telegram-manual-trading.md
+git commit -m "docs: mcp-trading 주문 실행 설정 정리" \
+  -m "- 공식 KIS MCP 환경 변수 제거" \
+  -m "- Telegram 수동 주문 문서 기준 전환"
+```
+
+---
+
+## Task 5: Final Verification
+
+**Files:**
+- Verify only; commit fixes only if a command exposes a real issue.
+
+- [ ] **Step 1: Run Node checks**
+
+Run:
+
+```bash
+npm test --prefix mcp-trading
+node --check mcp-trading/index.js
+node --check mcp-trading/order.js
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Run focused Telegram tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py backend/tests/test_trading_orders.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Run full backend tests**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests -q
+```
+
+Expected: full suite passes with the existing skipped tests unchanged.
+
+- [ ] **Step 4: Run final diff checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git log --oneline -n 8
+```
+
+Expected: no whitespace errors; status is clean after commits; recent log shows atomic replacement commits after the previous official-MCP commits.
+
+- [ ] **Step 5: Prepare PR note**
+
+Use this summary in the PR body or follow-up comment:
+
+```markdown
+## 변경 요약
+
+- 공식 KIS Trading MCP 주문 실행 경로를 로컬 `mcp-trading` `place_order` 도구로 대체
+- Telegram 수동 주문 UX, pending-order TTL, 실계좌 enable guard, 주문 성공 이력 기록 유지
+- 공식 KIS MCP Docker/remote env 설정 제거
+
+## 검증
+
+- `npm test --prefix mcp-trading`
+- `node --check mcp-trading/index.js`
+- `node --check mcp-trading/order.js`
+- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py backend/tests/test_trading_orders.py -q`
+- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests -q`
+- `git diff --check`
+```

--- a/docs/superpowers/specs/2026-05-18-telegram-interactive-commands-design.md
+++ b/docs/superpowers/specs/2026-05-18-telegram-interactive-commands-design.md
@@ -1,0 +1,165 @@
+# Telegram Interactive Commands Design
+
+## Goal
+
+Issue #41 adds an interactive Telegram surface on top of the existing Telegram alert bot.
+
+The first implementation stays inside the current Telegram command boundary:
+
+- Keep `/alerts urgent|all|off|status` behavior unchanged.
+- Add deterministic MCP commands for balance, quote, and investor trend lookup.
+- Add free-form NAT chat fallback for regular Telegram text.
+- Keep Telegram chat separate from scheduler analysis reports and dashboard WebSocket broadcasts.
+
+This work is implemented as one feature branch and one PR, but with atomic commits:
+
+1. MCP command support and help text.
+2. NAT chat fallback with explicit Telegram conversation id.
+
+## Current Context
+
+PR #38 added NAT `conversation-id` support. Backend NAT calls can now pass a `conversation_id` through:
+
+```python
+llm_chat("nat", text, conversation_id="...")
+```
+
+NAT stores short-term transcript state by `conversation-id`. Telegram chat must use this boundary explicitly and must not fall back to the shared `NAT_CONVERSATION_ID` default.
+
+The current Telegram command implementation only supports `/alerts`. The poller already advances `offset` only after `handle_update()` returns successfully, which must be preserved.
+
+## Architecture
+
+`backend/telegram_commands.py` remains the Telegram interaction boundary.
+
+`TelegramCommandPoller` keeps its current responsibility:
+
+- Poll Telegram `getUpdates`.
+- Pass each update to `TelegramCommandHandler`.
+- Advance `offset` only after handler success.
+
+`TelegramCommandHandler.handle_update()` becomes the command router. The routing order is:
+
+1. Ignore messages from any chat other than configured `TELEGRAM_CHAT_ID`.
+2. `/alerts ...` -> existing alert mode handling.
+3. `/help` -> command list.
+4. `/balance` -> MCP balance lookup.
+5. `/quote <stock>` -> MCP quote lookup.
+6. `/trend <stock>` -> MCP investor trend lookup.
+7. Unknown slash command -> help text.
+8. Any other non-empty text -> NAT chat fallback.
+
+The implementation keeps the current flat module style. New behavior is split into private handler helpers such as `_handle_balance`, `_handle_quote`, `_handle_trend`, and `_handle_chat_fallback`.
+
+To keep tests focused, `TelegramCommandHandler` may accept optional injected runners:
+
+- `mcp_runner`, defaulting to `run_mcp_tool`.
+- `llm_runner`, defaulting to `llm_chat`.
+
+No new command abstraction or separate router module is needed for this scope.
+
+## MCP Commands
+
+MCP commands are deterministic lookups and do not use NAT.
+
+Tool mapping:
+
+- `/balance` -> `run_mcp_tool(TRADING_MCP_PARAMS, "get_balance", {})`
+- `/quote <stock>` -> `run_mcp_tool(TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": stock})`
+- `/trend <stock>` -> `run_mcp_tool(TRADING_MCP_PARAMS, "get_investor_trading", {"stock_name": stock})`
+
+The backend sends MCP output to Telegram without additional parsing or summarization because `mcp-trading` already returns user-facing Korean text.
+
+Missing arguments return short usage text:
+
+- `사용법: /quote <종목명>`
+- `사용법: /trend <종목명>`
+
+## NAT Chat Fallback
+
+Regular Telegram text is sent to NAT through the backend LLM boundary:
+
+```python
+llm_chat("nat", text, conversation_id=f"telegram:{chat_id}")
+```
+
+This preserves PR #38 compatibility:
+
+- Telegram chat gets NAT SQLite transcript continuity by chat id.
+- Telegram users do not share the process-wide `NAT_CONVERSATION_ID` default.
+- Telegram chat does not reuse scheduler/API analysis threads such as `api:{stock}:{date}` or `{source}:{stock}:{date}`.
+- Telegram chat does not call `perform_stock_analysis()`.
+- Telegram chat does not create `AgentReport` rows.
+
+NAT chat responses are sent only back to the Telegram chat. They must not trigger scheduler Telegram alert delivery, and they must not broadcast through `/api/v1/ws`.
+
+## Telegram UX
+
+The initial UX stays small:
+
+- Send Telegram `typing` chat action before slow MCP/NAT work.
+- Send the final result with the existing text sending path.
+- Truncate outgoing messages at a Telegram-safe length around 4000 characters and append `...(이하 생략)`.
+
+Issue #41 mentions placeholder messages and `editMessageText`. That is intentionally deferred. The current notifier only exposes text sending, and `typing` plus final response gives a smaller first implementation with fewer Telegram API surfaces.
+
+`/help` lists the supported commands:
+
+- `/alerts urgent|all|off|status`
+- `/balance`
+- `/quote <종목명>`
+- `/trend <종목명>`
+
+Free-form NAT chat can be described briefly in the help response.
+
+## Error Handling
+
+The handler converts expected work failures into short Telegram replies and then returns normally:
+
+- Unknown slash command -> help text.
+- Missing command argument -> command-specific usage text.
+- MCP failure -> `조회 실패: <짧은 사유>`.
+- NAT failure -> `응답 생성 실패: <짧은 사유>`.
+
+When a failure was reported to the user, the update is considered handled and the poller may advance `offset`.
+
+Failures that prevent command handling itself from completing should still propagate to the poller. Examples include `/alerts` Redis state failures or Telegram send failures. In those cases, the poller must not advance `offset`.
+
+## Boundaries
+
+In scope:
+
+- Telegram command routing.
+- MCP deterministic lookup commands.
+- NAT text fallback with explicit `conversation_id`.
+- Focused Telegram command tests.
+- README update for the new Telegram commands if implementation changes user-facing operation.
+
+Out of scope:
+
+- Frontend GUI NAT chat changes.
+- WebSocket chat.
+- Persistent MCP stdio sessions.
+- Multi-user authorization beyond the existing `TELEGRAM_CHAT_ID` gate.
+- Placeholder message editing.
+- Saving Telegram chat results as `AgentReport`.
+
+## Testing
+
+Focused tests should cover:
+
+- Existing `/alerts` behavior.
+- Poller `offset` advance only after handler success.
+- `/help` response.
+- Unknown slash command response.
+- Missing `/quote` and `/trend` arguments.
+- `/balance`, `/quote`, and `/trend` MCP tool names and arguments.
+- Regular text routed to `llm_chat("nat", ..., conversation_id="telegram:{chat_id}")`.
+- NAT chat fallback does not call `perform_stock_analysis()`.
+- MCP and NAT work failures produce short user-facing failure messages.
+
+After Telegram changes, run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q
+```

--- a/docs/superpowers/specs/2026-05-20-telegram-manual-trading-design.md
+++ b/docs/superpowers/specs/2026-05-20-telegram-manual-trading-design.md
@@ -1,0 +1,181 @@
+# Telegram Manual Trading Design
+
+## Context
+
+Issue #43 adds manual stock order commands to the Telegram bot:
+
+- `/buy <종목명> <수량> <지정가>`
+- `/sell <종목명> <수량> <지정가>`
+- `/confirm`
+- `/cancel`
+
+The current Telegram command surface is read-oriented: `/alerts`, `/balance`, `/quote`, `/trend`, `/help`, plus free-form NAT chat fallback. Existing read paths use the local `mcp-trading` stdio MCP. This feature introduces a write-capable trading path, so order execution must have a clearer safety boundary than the existing read commands.
+
+## Decision
+
+Use the official KIS Trading MCP for order execution only. Keep the local `mcp-trading` server for existing read operations in this issue.
+
+This means:
+
+- `/balance`, `/quote`, `/trend`, backend trading routes, and scheduler balance extraction keep using local `mcp-trading`.
+- `/confirm` executes the pending order through an official KIS Trading MCP adapter.
+- Telegram command logic stays provider-agnostic and calls a backend order gateway rather than knowing the MCP transport or KIS parameter schema.
+- A whole-project migration from local `mcp-trading` to official KIS MCP is out of scope for issue #43.
+
+## Safety Boundary
+
+The feature supports both mock and real KIS account environments.
+
+- Mock trading can execute when the official KIS MCP is configured for mock/demo trading.
+- Real-account order execution is blocked unless an explicit opt-in flag is enabled.
+- Use `KIS_REAL_ORDER_ENABLED=true` as the opt-in flag because the boundary is KIS order execution, not Telegram delivery.
+
+If the configured order target is real trading and the flag is absent, `/confirm` must refuse the order, send a clear Telegram message, skip the MCP order call, and skip `TradeHistory` persistence.
+
+## Command Flow
+
+1. `/buy` or `/sell` parses `stock_name`, `quantity`, and `price`.
+2. Invalid format, non-positive quantity, or non-positive price returns a usage message.
+3. Commands outside weekday 09:00-15:30 KST are rejected before a pending order is created.
+4. If the chat already has a pending order, the new order command is rejected.
+5. The handler fetches current quote and balance through existing read tools for the confirmation prompt.
+6. The handler stores one pending order in memory by `chat_id`.
+7. Pending orders expire after 60 seconds.
+8. `/cancel` removes the pending order and confirms cancellation.
+9. `/confirm` validates that a pending order exists and has not expired.
+10. `/confirm` calls the backend order gateway.
+11. On successful order execution, the backend records `TradeHistory`.
+12. On gateway or KIS failure, Telegram receives a short failure message and no trade history is written.
+
+The confirmation prompt should show:
+
+- stock name
+- side
+- quantity
+- limit price
+- estimated order amount
+- current quote when available
+- balance/deposit context when available
+- `/confirm` and `/cancel` instructions
+- 60-second expiration notice
+
+Balance parsing is best-effort. KIS remains the final source of truth for whether an order is accepted.
+
+## Components
+
+### TelegramCommandHandler
+
+Responsibilities:
+
+- route `/buy`, `/sell`, `/confirm`, and `/cancel`
+- parse and validate command arguments
+- check market hours
+- manage in-memory pending orders
+- build confirmation and error messages
+- call read tools for prompt context
+- call the order gateway only on `/confirm`
+- record trade history only after gateway success
+
+The handler should receive injectable dependencies for tests:
+
+- current time provider
+- order gateway
+- trade recorder or session factory
+
+### Pending Order Store
+
+Use an in-memory dictionary keyed by `chat_id`.
+
+Stored fields:
+
+- chat id
+- stock name
+- stock code when available
+- side: `BUY` or `SELL`
+- quantity
+- limit price
+- created timestamp
+
+This matches the issue scope. Redis-backed pending orders can be a later improvement if process restarts become a practical problem.
+
+### Order Gateway
+
+Add a narrow backend adapter for official KIS Trading MCP order execution.
+
+Responsibilities:
+
+- hide official MCP transport and payload shape from Telegram command code
+- select real/demo execution parameters from configuration
+- enforce `KIS_REAL_ORDER_ENABLED` before real-account order calls
+- return normalized success/failure details for Telegram and DB recording
+
+The gateway should be small and order-specific for this issue. It should not become a full trading abstraction for every KIS endpoint yet.
+
+### Trade History
+
+Reuse existing `TradeHistory`.
+
+Save after successful order execution:
+
+- stock code
+- stock name
+- trade type: `BUY` or `SELL`
+- quantity
+- price
+- trade date from the model default
+
+If the official MCP returns an order number or execution id, include it in the Telegram success message. Do not extend the database schema in this issue unless implementation shows the existing model cannot support the acceptance criteria.
+
+## Error Handling
+
+- Invalid `/buy` or `/sell`: return usage text.
+- Market closed: `주문 불가: 현재 장 운영 시간이 아닙니다. (평일 09:00~15:30)`
+- Duplicate pending order: tell the user to `/confirm` or `/cancel` the existing order first.
+- Expired pending order: remove it and ask the user to enter the order again.
+- `/confirm` without pending order: explain that there is no pending order.
+- `/cancel` without pending order: explain that there is no pending order to cancel.
+- Official MCP/KIS rejection: forward a short readable error message.
+- Real account without opt-in: refuse explicitly and do not call the order gateway.
+- Telegram send failure: preserve the existing poller behavior where update offsets advance only after handling succeeds.
+
+## Testing
+
+Focused backend tests should cover:
+
+- `/buy` and `/sell` valid parsing
+- invalid format
+- non-positive quantity and price
+- market-hours rejection
+- pending order creation
+- duplicate pending order rejection
+- `/cancel` success
+- `/confirm` without pending order
+- expiry before confirmation
+- successful gateway call on `/confirm`
+- trade recorder called only after gateway success
+- gateway/KIS failure leaves no trade history
+- real-account guard blocks execution without `KIS_REAL_ORDER_ENABLED`
+- `/help` includes the new commands
+
+Focused command:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q
+```
+
+Also run syntax/static checks that match the final implementation surface, including `node --check` only if JavaScript MCP code changes are made.
+
+## Non-Goals
+
+- No automatic AI trading.
+- No full migration from local `mcp-trading` to official KIS MCP.
+- No Redis pending-order persistence.
+- No new dashboard trading UI.
+- No order correction/cancel endpoint beyond cancelling a pending Telegram confirmation.
+- No holiday calendar management; KIS/API rejection handles holidays beyond the weekday/time gate.
+
+## Open Implementation Notes
+
+- Confirm the exact official KIS Trading MCP `api_type` and required params for domestic cash limit orders during implementation with `find_api_detail`.
+- Keep official MCP-specific field names inside the gateway.
+- Keep Telegram copy concise and Korean-first.

--- a/docs/superpowers/specs/2026-05-20-telegram-manual-trading-design.md
+++ b/docs/superpowers/specs/2026-05-20-telegram-manual-trading-design.md
@@ -1,5 +1,7 @@
 # Telegram Manual Trading Design
 
+> Superseded: 주문 실행 provider는 공식 KIS Trading MCP가 아니라 로컬 `mcp-trading`으로 전환되었습니다. 현재 기준 문서는 `docs/superpowers/specs/2026-05-20-telegram-mcp-trading-order-replacement-design.md`입니다.
+
 ## Context
 
 Issue #43 adds manual stock order commands to the Telegram bot:

--- a/docs/superpowers/specs/2026-05-20-telegram-mcp-trading-order-replacement-design.md
+++ b/docs/superpowers/specs/2026-05-20-telegram-mcp-trading-order-replacement-design.md
@@ -1,0 +1,155 @@
+# Telegram mcp-trading 주문 전환 설계
+
+## 배경
+
+Issue #43의 현재 브랜치는 Telegram `/buy`, `/sell`, `/confirm`, `/cancel` 흐름을 구현하면서 주문 실행을 공식 KIS Trading MCP에 맡기는 방향으로 작성되어 있다. 이 방식은 한국투자증권 공식 MCP 저장소를 별도로 클론하고 Docker 컨테이너를 프로젝트 밖에서 실행해야 하므로, 현재 `fin-us`의 로컬 MCP 구성과 운영 경로가 갈라진다.
+
+기존 `mcp-trading`은 이미 한국투자증권 Open API 인증, 토큰 캐시, 잔고 조회, 현재가 조회, 투자자 매매동향 조회를 담당한다. 따라서 주문 실행도 같은 `mcp-trading` 서버로 흡수하면 Telegram 명령, backend API, scheduler가 모두 동일한 거래 MCP 경계를 사용한다.
+
+## 결정
+
+공식 KIS Trading MCP 주문 어댑터를 새 커밋으로 대체한다. 기존 커밋을 rebase/reset으로 되돌리지 않고, replacement commit으로 다음 변경을 추가한다.
+
+- Telegram 명령 UX와 pending-order 안전장치는 유지한다.
+- 주문 실행 backend provider만 공식 KIS MCP remote adapter에서 로컬 `mcp-trading` stdio tool 호출로 바꾼다.
+- `mcp-trading`에 `place_order` tool을 추가하고, 이 tool이 한국투자증권 Open API `order-cash`를 직접 호출한다.
+- 실계좌 주문은 backend의 `KIS_REAL_ORDER_ENABLED=true` guard를 계속 통과해야 한다.
+
+## 목표
+
+- 프로젝트 외부 공식 KIS MCP Docker 실행 요구 제거
+- `/balance`, `/quote`, `/trend`, `/buy`, `/sell`, `/confirm`이 모두 `TRADING_MCP_PARAMS` 기반 로컬 `mcp-trading` 경로 사용
+- 모의투자와 실계좌 주문을 모두 지원하되, 실계좌 주문은 명시적 enable 없이는 차단
+- 주문 성공 시 기존 `TradeHistory` 기록 유지
+- 주문 실패 또는 상태 확인이 필요한 애매한 실패는 pending order를 제거해 중복 주문 위험을 줄이는 기존 UX 유지
+
+## 비목표
+
+- 증권사에 이미 접수된 주문의 정정/취소 구현
+- 해외주식, 신용주문, 선물옵션 주문 구현
+- 공식 KIS MCP 저장소 클론 또는 Docker 실행 자동화
+- `mcp-trading/data/stocks.json` 전체 종목 마스터 확장
+- 기존 공식 KIS MCP 커밋 히스토리 삭제
+
+## 아키텍처
+
+현재 주문 실행 흐름:
+
+```text
+Telegram /confirm
+  -> TelegramCommandHandler
+  -> OfficialKisMcpOrderGateway
+  -> official KIS Trading MCP over SSE/streamable HTTP
+  -> KIS Open API
+```
+
+대체 후 주문 실행 흐름:
+
+```text
+Telegram /confirm
+  -> TelegramCommandHandler
+  -> McpTradingOrderGateway
+  -> run_mcp_tool(TRADING_MCP_PARAMS, "place_order", args)
+  -> mcp-trading/index.js
+  -> KIS Open API /uapi/domestic-stock/v1/trading/order-cash
+```
+
+조회 흐름은 변경하지 않는다.
+
+```text
+/balance -> run_mcp_tool(TRADING_MCP_PARAMS, "get_balance", {})
+/quote   -> run_mcp_tool(TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": ...})
+/trend   -> run_mcp_tool(TRADING_MCP_PARAMS, "get_investor_trading", {"stock_name": ...})
+```
+
+## 구성 요소
+
+### `mcp-trading`
+
+`mcp-trading`은 `place_order` tool을 추가로 노출한다.
+
+입력:
+
+- `stock_name`: 사용자 입력 종목명 또는 6자리 종목코드
+- `stock_code`: backend가 이미 resolve한 6자리 종목코드
+- `side`: `BUY` 또는 `SELL`
+- `quantity`: 양의 정수
+- `price`: 양의 정수
+- `order_env`: `demo` 또는 `real`
+
+동작:
+
+- `KIS_API_KEY`, `KIS_API_SECRET`, `KIS_ACCOUNT_NO`, `KIS_URL`을 사용한다.
+- `KIS_ACCOUNT_NO`는 앞 8자리를 `CANO`, 뒤 2자리를 `ACNT_PRDT_CD`로 나눈다.
+- 국내주식 현금 주문 endpoint `/uapi/domestic-stock/v1/trading/order-cash`를 POST로 호출한다.
+- 지정가 주문이므로 `ORD_DVSN`은 `"00"`으로 보낸다.
+- 한국투자증권 공식 샘플 기준 TR ID는 다음과 같이 선택한다.
+  - 실전 매수: `TTTC0012U`
+  - 실전 매도: `TTTC0011U`
+  - 모의 매수: `VTTC0012U`
+  - 모의 매도: `VTTC0011U`
+- 거래소 구분은 현재 Telegram 수동 주문 범위에서 `SOR`로 보낸다.
+
+### Backend
+
+`backend/trading_orders.py`에서 공식 MCP transport 관련 코드를 제거하고, `McpTradingOrderGateway`를 둔다.
+
+`McpTradingOrderGateway`는 다음 책임만 가진다.
+
+- `KIS_ORDER_ENV=real`이고 `KIS_REAL_ORDER_ENABLED`가 false면 403으로 차단
+- `run_mcp_tool(TRADING_MCP_PARAMS, "place_order", args)` 호출
+- MCP text 응답을 `OrderExecutionResult`로 변환
+
+`TelegramCommandHandler`의 parsing, market-hours guard, pending-order TTL, `/confirm`, `/cancel`, 실패 시 pending clear 정책은 유지한다.
+
+## 환경 변수
+
+유지:
+
+- `KIS_API_KEY`
+- `KIS_API_SECRET`
+- `KIS_ACCOUNT_NO`
+- `KIS_URL`
+- `KIS_ORDER_ENV=demo|real`
+- `KIS_REAL_ORDER_ENABLED=true|false`
+- `TRADING_MCP_DIR`
+
+제거:
+
+- `FINUS_KIS_TRADING_MCP_URL`
+- `FINUS_KIS_TRADING_MCP_TRANSPORT`
+- `FINUS_KIS_TRADING_TOOL_NAME`
+
+`mcp-trading`은 `order_env`와 `KIS_URL`이 맞지 않으면 실패한다.
+
+- `order_env=demo`는 `KIS_URL`에 `openapivts`가 포함되어야 한다.
+- `order_env=real`은 `KIS_URL`에 `openapivts`가 포함되면 안 된다.
+
+이 검사는 모의투자 명령이 실전 URL로 나가거나 실계좌 명령이 모의 URL로 나가는 설정 사고를 막기 위한 fail-closed 정책이다.
+
+## 오류 처리
+
+- KIS API가 `rt_cd !== "0"`을 반환하면 `mcp-trading`은 `isError: true` MCP 응답을 반환한다.
+- backend `run_mcp_tool`은 MCP `isError`를 HTTPException으로 변환하는 기존 계약을 사용한다.
+- Telegram `/confirm`은 주문 실패 또는 상태 확인 필요 메시지를 보내고 pending order를 제거한다.
+- 실계좌 enable guard 실패는 broker에 주문이 나가지 않은 확정 실패이므로 pending order를 유지해 사용자가 설정 후 다시 `/confirm`할 수 있게 한다.
+
+## 테스트 전략
+
+- Node `node:test`로 `mcp-trading` 주문 helper를 검증한다.
+- backend pytest로 `McpTradingOrderGateway`가 `TRADING_MCP_PARAMS`와 `place_order`를 호출하는지 검증한다.
+- Telegram command tests는 기존 pending-order UX를 유지하면서 gateway factory가 로컬 `mcp-trading` gateway를 만드는지 검증한다.
+- 기존 focused Telegram 테스트와 전체 backend 테스트를 모두 실행한다.
+
+## 구현 순서
+
+1. `mcp-trading` 주문 payload helper와 Node tests 추가
+2. `mcp-trading` `place_order` tool 추가
+3. backend 공식 KIS MCP gateway를 `McpTradingOrderGateway`로 대체
+4. 공식 KIS MCP env/docs 제거 및 README 정리
+5. focused tests, full backend tests, Node checks, `git diff --check` 실행
+
+## 참고
+
+- 한국투자증권 Open API 공식 GitHub 샘플: https://github.com/koreainvestment/open-trading-api/blob/main/examples_llm/domestic_stock/order_cash/order_cash.py
+- 한국투자증권 API 문서의 국내주식 주문/계좌 카테고리: https://apiportal.koreainvestment.com/apiservice-apiservice%3F/uapi/domestic-stock/v1/trading/order-cash

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -1,0 +1,20 @@
+export function buildBalanceParams(accountNo) {
+  return {
+    CANO: accountNo.substring(0, 8),
+    ACNT_PRDT_CD: accountNo.substring(8, 10),
+    AFHR_FLPR_YN: "N",
+    OFL_YN: "",
+    INQR_DVSN: "02",
+    UNPR_DVSN: "01",
+    FUND_STTL_ICLD_YN: "N",
+    FNCG_AMT_AUTO_RDPT_YN: "N",
+    PRCS_DVSN: "00",
+    CTX_AREA_FK100: "",
+    CTX_AREA_NK100: "",
+  };
+}
+
+export function formatPercent(value) {
+  if (value === undefined || value === null || value === "") return "-";
+  return `${value}%`;
+}

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -18,3 +18,54 @@ export function formatPercent(value) {
   if (value === undefined || value === null || value === "") return "-";
   return `${value}%`;
 }
+
+function formatAmount(value) {
+  if (value === undefined || value === null || value === "") return "-";
+  const number = Number(String(value).replaceAll(",", ""));
+  if (!Number.isFinite(number)) {
+    return `${value}원`;
+  }
+  return `${number.toLocaleString("ko-KR")}원`;
+}
+
+function formatQuantity(value) {
+  if (value === undefined || value === null || value === "") return "-";
+  const number = Number(String(value).replaceAll(",", ""));
+  if (!Number.isFinite(number)) {
+    return String(value);
+  }
+  return number.toLocaleString("ko-KR");
+}
+
+export function formatBalanceReport(data) {
+  const summary = data.output2?.[0] || {};
+  const holdings = data.output1 || [];
+
+  const stockList = holdings
+    .map((h) => {
+      const returnRate = h.evlu_pfls_rt || h.evlu_erng_rt;
+      return (
+        `- ${h.prdt_name} (${h.pdno}): ${formatQuantity(h.hldg_qty)}주 ` +
+        `(평가금액: ${formatAmount(h.evlu_amt)}, ` +
+        `평가손익: ${formatAmount(h.evlu_pfls_amt)}, ` +
+        `수익률: ${formatPercent(returnRate)})`
+      );
+    })
+    .join("\n");
+
+  const accountReturnRate = summary.asst_icdc_erng_rt || summary.evlu_pfls_rt;
+
+  return `
+[계좌 잔고 현황]
+- 총 평가금액: ${formatAmount(summary.tot_evlu_amt)}
+- 순자산금액: ${formatAmount(summary.nass_amt || summary.pchs_amt_smtl_amt)}
+- 총 손익: ${formatAmount(summary.evlu_pfls_smtl_amt)} (수익률: ${formatPercent(accountReturnRate)})
+- 예수금총액: ${formatAmount(summary.dnca_tot_amt)}
+- 가수도정산금액: ${formatAmount(summary.prvs_rcdl_excc_amt)}
+- 익일정산금액: ${formatAmount(summary.nxdy_excc_amt)}
+- 금일 매수/매도: ${formatAmount(summary.thdt_buy_amt)} / ${formatAmount(summary.thdt_sll_amt)}
+
+[보유 종목 리스트]
+${stockList || "보유 종목이 없습니다."}
+  `.trim();
+}

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -16,7 +16,18 @@ export function buildBalanceParams(accountNo) {
 
 export function formatPercent(value) {
   if (value === undefined || value === null || value === "") return "-";
-  return `${value}%`;
+  const numeric = Number(String(value).replace("%", ""));
+  if (!Number.isFinite(numeric)) {
+    return `${value}%`;
+  }
+  const formatted = (Math.floor(numeric * 100) / 100).toFixed(2);
+  if (numeric > 0) {
+    return `🔴 ▲ +${formatted}%`;
+  }
+  if (numeric < 0) {
+    return `🔵 ▼ ${formatted}%`;
+  }
+  return `⚪ ${formatted}%`;
 }
 
 function formatAmount(value) {
@@ -37,6 +48,15 @@ function formatQuantity(value) {
   return number.toLocaleString("ko-KR");
 }
 
+function formatSignedAmount(value) {
+  const formatted = formatAmount(value);
+  const number = Number(String(value ?? "").replaceAll(",", ""));
+  if (!Number.isFinite(number) || number <= 0) {
+    return formatted;
+  }
+  return `+${formatted}`;
+}
+
 export function formatBalanceReport(data) {
   const summary = data.output2?.[0] || {};
   const holdings = data.output1 || [];
@@ -45,13 +65,12 @@ export function formatBalanceReport(data) {
     .map((h) => {
       const returnRate = h.evlu_pfls_rt || h.evlu_erng_rt;
       return (
-        `- ${h.prdt_name} (${h.pdno}): ${formatQuantity(h.hldg_qty)}주 ` +
-        `(평가금액: ${formatAmount(h.evlu_amt)}, ` +
-        `평가손익: ${formatAmount(h.evlu_pfls_amt)}, ` +
-        `수익률: ${formatPercent(returnRate)})`
+        `- ${h.prdt_name} (${h.pdno}) · ${formatQuantity(h.hldg_qty)}주\n` +
+        `  평단가 ${formatAmount(h.pchs_avg_pric)} → 평가금액 ${formatAmount(h.evlu_amt)}\n` +
+        `  손익 ${formatSignedAmount(h.evlu_pfls_amt)} · 수익률 ${formatPercent(returnRate)}`
       );
     })
-    .join("\n");
+    .join("\n\n");
 
   const accountReturnRate = summary.asst_icdc_erng_rt || summary.evlu_pfls_rt;
 

--- a/mcp-trading/data/stocks.json
+++ b/mcp-trading/data/stocks.json
@@ -1,26 +1,26154 @@
 [
   {
-    "code": "005930",
-    "name": "삼성전자",
+    "code": "0001A0",
+    "name": "덕양에너젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "000250",
+    "name": "삼천당제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "000440",
+    "name": "중앙에너비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0004V0",
+    "name": "엔비알모션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0004Y0",
+    "name": "디비금융제14호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0007C0",
+    "name": "아크릴",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0007J0",
+    "name": "인벤테라",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0008Z0",
+    "name": "에스엔시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0009K0",
+    "name": "에임드바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "001000",
+    "name": "신라섬유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0010F0",
+    "name": "보원케미칼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0010V0",
+    "name": "제이피아이헬스케어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0011A0",
+    "name": "액스비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0011T0",
+    "name": "채비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0013V0",
+    "name": "삼진식품",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "001540",
+    "name": "안국약품",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0015G0",
+    "name": "그린광학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0015N0",
+    "name": "아로마티카",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0015S0",
+    "name": "페스카로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "001810",
+    "name": "무림SP",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "001840",
+    "name": "이화공영",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "002230",
+    "name": "피에스텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "002290",
+    "name": "삼일기업공사",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "002680",
+    "name": "한탑",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "002800",
+    "name": "신신제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "003100",
+    "name": "선광",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "003310",
+    "name": "대주산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "003380",
+    "name": "하림지주",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0037T0",
+    "name": "KB제32호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "003800",
+    "name": "에이스침대",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0041B0",
+    "name": "교보18호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0041J0",
+    "name": "엘에스스팩1호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0041L0",
+    "name": "하나35호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0044K0",
+    "name": "삼성스팩10호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "004590",
+    "name": "한국가구",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "004650",
+    "name": "창해에탄올",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "004780",
+    "name": "대륙제관",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "005160",
+    "name": "동국산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "005290",
+    "name": "동진쎄미켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0054V0",
+    "name": "엔에이치스팩32호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "005670",
+    "name": "푸드웰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "005710",
+    "name": "대원산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "005860",
+    "name": "한일사료",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "005990",
+    "name": "매일홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "006050",
+    "name": "국영지앤엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "006140",
+    "name": "피제이전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "006620",
+    "name": "동구바이오제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "006730",
+    "name": "서부T&D",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0068Y0",
+    "name": "비엔케이제3호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "006910",
+    "name": "보성파워텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "006920",
+    "name": "모헨즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0071M0",
+    "name": "삼성스팩11호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0072Z0",
+    "name": "KB제33호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "007330",
+    "name": "푸른저축은행",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "007370",
+    "name": "진양제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "007390",
+    "name": "네이처셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "007530",
+    "name": "와이엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "007680",
+    "name": "대원",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "007720",
+    "name": "소노스퀘어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "007770",
+    "name": "한일화학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "007820",
+    "name": "엠엑스로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "008290",
+    "name": "원풍물산",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0082N0",
+    "name": "카나프테라퓨틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "008370",
+    "name": "원풍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "008470",
+    "name": "부스타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "008830",
+    "name": "대동기어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0088D0",
+    "name": "메리츠제1호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0088M0",
+    "name": "메쥬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0091W0",
+    "name": "신영스팩11호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "009300",
+    "name": "삼아제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0093G0",
+    "name": "미래에셋비전스팩8호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "009520",
+    "name": "포스코엠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "009620",
+    "name": "삼보산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0096B0",
+    "name": "삼성스팩12호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0096D0",
+    "name": "미래에셋비전스팩9호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "009730",
+    "name": "이렘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "009780",
+    "name": "엠에스씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0097F0",
+    "name": "미래에셋비전스팩10호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0098T0",
+    "name": "교보19호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0099W0",
+    "name": "미래에셋비전스팩11호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0099X0",
+    "name": "IBKS제25호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "010170",
+    "name": "대한광통신",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0101C0",
+    "name": "하나36호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "010240",
+    "name": "흥국",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "010280",
+    "name": "아이티센엔텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "010470",
+    "name": "오리콤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0105P0",
+    "name": "유진스팩12호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "011040",
+    "name": "경동제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "011080",
+    "name": "형지I&C",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "011320",
+    "name": "유니크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "011370",
+    "name": "서한",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "011560",
+    "name": "세보엠이씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0115H0",
+    "name": "삼성스팩13호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "012210",
+    "name": "삼미금속",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "012340",
+    "name": "뉴인텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "012620",
+    "name": "원일특강",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "012700",
+    "name": "리드코프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "012790",
+    "name": "신일제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "012860",
+    "name": "모베이스전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0129K0",
+    "name": "신한제18호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "013030",
+    "name": "하이록코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0130D0",
+    "name": "신한제17호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0130H0",
+    "name": "엔에이치스팩33호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "013120",
+    "name": "동원개발",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0131D0",
+    "name": "키움히어로제2호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "0132G0",
+    "name": "교보20호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "013310",
+    "name": "아진산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "013720",
+    "name": "THE CUBE&",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "013810",
+    "name": "스페코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "013990",
+    "name": "아가방컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "014100",
+    "name": "메디앙스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "014190",
+    "name": "원익큐브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "014470",
+    "name": "부방",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "014570",
+    "name": "고려제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "014620",
+    "name": "성광벤드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "014940",
+    "name": "오리엔탈정공",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "014950",
+    "name": "삼익제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "014970",
+    "name": "삼륭물산",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "015710",
+    "name": "코콤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "015750",
+    "name": "성우하이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "016100",
+    "name": "리더스코스메틱",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "016250",
+    "name": "SGC E&C",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "016600",
+    "name": "큐캐피탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "016670",
+    "name": "디모아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "016790",
+    "name": "현대사료",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "016920",
+    "name": "카스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "017000",
+    "name": "신원종합개발",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "017250",
+    "name": "인터엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "017480",
+    "name": "삼현철강",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "017510",
+    "name": "세명전기",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "017650",
+    "name": "대림제지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "017890",
+    "name": "한국알콜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "018000",
+    "name": "유니슨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "018120",
+    "name": "진로발효",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "018290",
+    "name": "브이티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "018310",
+    "name": "삼목에스폼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "018620",
+    "name": "우진비앤지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "018680",
+    "name": "서울제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "018700",
+    "name": "졸스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "019010",
+    "name": "베뉴지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "019210",
+    "name": "와이지-원",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "019540",
+    "name": "일지테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "019550",
+    "name": "SBI인베스트먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "019570",
+    "name": "플루토스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "019660",
+    "name": "글로본",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "019770",
+    "name": "서연탑메탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "019990",
+    "name": "에너토크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "020180",
+    "name": "대신정보통신",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "020400",
+    "name": "대동금속",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "020710",
+    "name": "시공테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "021040",
+    "name": "대호특수강",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "021045",
+    "name": "대호특수강우",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "021080",
+    "name": "에이티넘인베스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "021320",
+    "name": "KCC건설",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "021650",
+    "name": "한국큐빅",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "021880",
+    "name": "메이슨캐피탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "022220",
+    "name": "티케이지애강",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023160",
+    "name": "태광",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023410",
+    "name": "유진기업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023440",
+    "name": "제이스코홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023600",
+    "name": "삼보판지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023760",
+    "name": "한국캐피탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023770",
+    "name": "플레이위드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023790",
+    "name": "동일스틸럭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023900",
+    "name": "풍국주정",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "023910",
+    "name": "대한약품",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024060",
+    "name": "흥구석유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024120",
+    "name": "KB오토시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024740",
+    "name": "한일단조",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024800",
+    "name": "유성티엔에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024830",
+    "name": "세원물산",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024840",
+    "name": "KBI메탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024850",
+    "name": "HLB이노베이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024880",
+    "name": "케이피에프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024910",
+    "name": "경창산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024940",
+    "name": "PN풍년",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "024950",
+    "name": "삼천리자전거",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025320",
+    "name": "시노펙스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025440",
+    "name": "DH오토웨어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025550",
+    "name": "한국선재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025770",
+    "name": "한국정보통신",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025870",
+    "name": "신라에스지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025880",
+    "name": "케이씨피드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025900",
+    "name": "동화기업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025950",
+    "name": "동신건설",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "025980",
+    "name": "아난티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "026040",
+    "name": "제이에스티나",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "026150",
+    "name": "특수건설",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "026910",
+    "name": "광진실업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "027040",
+    "name": "서울전자통신",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "027050",
+    "name": "코리아나",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "027360",
+    "name": "아주IB투자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "027580",
+    "name": "상보",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "027710",
+    "name": "팜스토리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "027830",
+    "name": "대성창투",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "028080",
+    "name": "휴맥스홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "028300",
+    "name": "HLB",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "029480",
+    "name": "광무",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "030350",
+    "name": "드래곤플라이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "030520",
+    "name": "한글과컴퓨터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "030530",
+    "name": "원익홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "030960",
+    "name": "양지사",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "031310",
+    "name": "아이즈비전",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "031330",
+    "name": "에스에이엠티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "031510",
+    "name": "오스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "031860",
+    "name": "디에이치엑스컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "031980",
+    "name": "피에스케이홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032080",
+    "name": "아즈텍WB",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032190",
+    "name": "다우데이타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032280",
+    "name": "삼일",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032300",
+    "name": "한국파마",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032500",
+    "name": "케이엠더블유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032540",
+    "name": "TJ미디어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032580",
+    "name": "피델릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032620",
+    "name": "GC메디아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032680",
+    "name": "소프트센",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032685",
+    "name": "소프트센우",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032750",
+    "name": "삼진",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032790",
+    "name": "엠젠솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032800",
+    "name": "판타지오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032820",
+    "name": "우리기술",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032850",
+    "name": "비트컴퓨터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032860",
+    "name": "더라미",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032940",
+    "name": "원익",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032960",
+    "name": "동일기연",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "032980",
+    "name": "바이온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033050",
+    "name": "제이엠아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033100",
+    "name": "제룡전기",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033130",
+    "name": "디지틀조선",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033160",
+    "name": "엠케이전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033170",
+    "name": "시그네틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033200",
+    "name": "모아텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033230",
+    "name": "인성정보",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033290",
+    "name": "로젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033310",
+    "name": "엠투엔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033320",
+    "name": "제이씨현시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033340",
+    "name": "좋은사람들",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033500",
+    "name": "동성화인텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033540",
+    "name": "파라텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033560",
+    "name": "블루콤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033640",
+    "name": "네패스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033790",
+    "name": "피노",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "033830",
+    "name": "티비씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "034810",
+    "name": "해성산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "03481K",
+    "name": "해성산업1우",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "034940",
+    "name": "조아제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "034950",
+    "name": "한국기업평가",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035080",
+    "name": "그래디언트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035200",
+    "name": "프럼파스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035290",
+    "name": "골드앤에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035460",
+    "name": "기산텔레콤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035600",
+    "name": "KG이니시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035610",
+    "name": "솔본",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035620",
+    "name": "바른손이앤에이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035760",
+    "name": "CJ ENM",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035810",
+    "name": "이지홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035890",
+    "name": "서희건설",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "035900",
+    "name": "JYP Ent.",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036000",
+    "name": "예림당",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036010",
+    "name": "아비코전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036030",
+    "name": "케이티알파",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036090",
+    "name": "위지트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036120",
+    "name": "서울평가정보",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036170",
+    "name": "에이치엠넥스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036190",
+    "name": "금화피에스시",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036200",
+    "name": "유니셈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036220",
+    "name": "오상헬스케어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036480",
+    "name": "대성미생물",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036540",
+    "name": "SFA반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036560",
+    "name": "KZ정밀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036620",
+    "name": "감성코퍼레이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036630",
+    "name": "세종텔레콤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036640",
+    "name": "HRS",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036670",
+    "name": "삼양케이씨아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036690",
+    "name": "코맥스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036710",
+    "name": "심텍홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036800",
+    "name": "나이스정보통신",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036810",
+    "name": "에프에스티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036830",
+    "name": "솔브레인홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036890",
+    "name": "진성티이씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "036930",
+    "name": "주성엔지니어링",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037030",
+    "name": "파워넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037070",
+    "name": "파세코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037230",
+    "name": "한국팩키지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037330",
+    "name": "인지디스플레",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037350",
+    "name": "성도이엔지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037370",
+    "name": "EG",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037400",
+    "name": "우리엔터프라이즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037440",
+    "name": "희림",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037460",
+    "name": "삼지전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037760",
+    "name": "쎄니트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "037950",
+    "name": "엘컴텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038010",
+    "name": "제일테크노스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038060",
+    "name": "루멘스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038070",
+    "name": "서린바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038110",
+    "name": "에코플라스틱",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038290",
+    "name": "마크로젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038390",
+    "name": "레드캡투어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038460",
+    "name": "바이오스마트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038500",
+    "name": "삼표시멘트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038530",
+    "name": "케이바이오랩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038540",
+    "name": "상상인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038620",
+    "name": "위즈코프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038680",
+    "name": "에스넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038870",
+    "name": "에코심플렉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038880",
+    "name": "아이에이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "038950",
+    "name": "파인디지털",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039010",
+    "name": "현대에이치티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039020",
+    "name": "이건홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039030",
+    "name": "이오테크닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039200",
+    "name": "오스코텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039240",
+    "name": "경남스틸",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039290",
+    "name": "인포뱅크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039310",
+    "name": "세중",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039340",
+    "name": "한국경제TV",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039420",
+    "name": "케이엘넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039440",
+    "name": "에스티아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039560",
+    "name": "다산네트웍스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039610",
+    "name": "화성밸브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039740",
+    "name": "한국정보공학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039830",
+    "name": "오로라",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039840",
+    "name": "디오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039860",
+    "name": "나노엔텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "039980",
+    "name": "폴라리스AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "040160",
+    "name": "누리플렉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "040300",
+    "name": "YTN",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "040350",
+    "name": "크레오에스지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "040420",
+    "name": "정상제이엘에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "040610",
+    "name": "SG&G",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "040910",
+    "name": "아이씨디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041020",
+    "name": "폴라리스오피스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041190",
+    "name": "우리기술투자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041440",
+    "name": "현대에버다임",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041460",
+    "name": "한국전자인증",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041510",
+    "name": "에스엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041520",
+    "name": "이엘씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041590",
+    "name": "플래스크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041830",
+    "name": "인바디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041910",
+    "name": "폴라리스AI파마",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041920",
+    "name": "메디아나",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041930",
+    "name": "SY동아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "041960",
+    "name": "코미팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042000",
+    "name": "카페24",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042040",
+    "name": "케이피엠테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042110",
+    "name": "에스씨디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042370",
+    "name": "비츠로테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042420",
+    "name": "네오위즈홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042500",
+    "name": "링네트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042510",
+    "name": "라온시큐어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042520",
+    "name": "한스바이오메드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042600",
+    "name": "새로닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "042940",
+    "name": "상지건설",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043090",
+    "name": "더테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043100",
+    "name": "알파AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043150",
+    "name": "바텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043200",
+    "name": "파루",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043220",
+    "name": "티에스넥스젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043260",
+    "name": "성호전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043340",
+    "name": "에쎈테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043360",
+    "name": "디지아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043370",
+    "name": "피에이치에이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043590",
+    "name": "웰킵스하이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043610",
+    "name": "KT지니뮤직",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043650",
+    "name": "국순당",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043710",
+    "name": "코스리거글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "043910",
+    "name": "자연과환경",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "044180",
+    "name": "KD",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "044340",
+    "name": "위닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "044480",
+    "name": "빌리언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "044490",
+    "name": "태웅",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "044780",
+    "name": "에이치케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "044960",
+    "name": "이글벳",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "044990",
+    "name": "에이치엔에스하이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045060",
+    "name": "오공",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045100",
+    "name": "한양이엔지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045300",
+    "name": "성우테크론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045340",
+    "name": "토탈소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045390",
+    "name": "대아티아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045510",
+    "name": "정원엔시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045520",
+    "name": "크린앤사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045660",
+    "name": "에이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "045970",
+    "name": "코아시아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046070",
+    "name": "코다코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046120",
+    "name": "오르비텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046210",
+    "name": "HLB파나진",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046310",
+    "name": "백금T&A",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046390",
+    "name": "삼화네트웍스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046440",
+    "name": "KG파이낸셜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046890",
+    "name": "서울반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046940",
+    "name": "우원개발",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "046970",
+    "name": "우리로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "047080",
+    "name": "한빛소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "047310",
+    "name": "파워로직스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "047560",
+    "name": "이스트소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "047770",
+    "name": "코데즈컴바인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "047820",
+    "name": "초록뱀미디어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "047920",
+    "name": "HLB제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048410",
+    "name": "현대바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048430",
+    "name": "유라테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048470",
+    "name": "대동스틸",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048530",
+    "name": "인트론바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048550",
+    "name": "SM C&C",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048770",
+    "name": "TPC로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048830",
+    "name": "엔피케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048870",
+    "name": "시너지이노베이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "048910",
+    "name": "대원미디어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049070",
+    "name": "인탑스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049080",
+    "name": "기가레인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049120",
+    "name": "파인디앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049180",
+    "name": "셀루메드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049430",
+    "name": "코메론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049470",
+    "name": "비트플래닛",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049480",
+    "name": "오픈베이스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049520",
+    "name": "유아이엘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049550",
+    "name": "잉크테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049630",
+    "name": "재영솔루텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049720",
+    "name": "고려신용정보",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049830",
+    "name": "승일",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049950",
+    "name": "미래컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "049960",
+    "name": "쎌바이오텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "050090",
+    "name": "비케이홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "050110",
+    "name": "캠시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "050120",
+    "name": "ES큐브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "050760",
+    "name": "에스폴리텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "050860",
+    "name": "아세아텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "050890",
+    "name": "쏠리드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "050960",
+    "name": "수산아이앤티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051160",
+    "name": "지어소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051360",
+    "name": "토비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051370",
+    "name": "인터플렉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051380",
+    "name": "피씨디렉트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051390",
+    "name": "YW",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051490",
+    "name": "나라엠앤디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051500",
+    "name": "CJ프레시웨이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051780",
+    "name": "큐로홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "051980",
+    "name": "중앙첨단소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052020",
+    "name": "에스티큐브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052220",
+    "name": "iMBC",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052260",
+    "name": "현대바이오랜드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052300",
+    "name": "오션인더블유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052330",
+    "name": "코텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052400",
+    "name": "코나아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052420",
+    "name": "오성첨단소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052460",
+    "name": "아이크래프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052600",
+    "name": "한네트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052710",
+    "name": "아모텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052770",
+    "name": "아이톡시",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052790",
+    "name": "액토즈소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052860",
+    "name": "아이앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "052900",
+    "name": "KX하이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053030",
+    "name": "바이넥스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053050",
+    "name": "지에스이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053060",
+    "name": "세동",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053080",
+    "name": "케이엔솔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053160",
+    "name": "프리엠스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053260",
+    "name": "금강철강",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053270",
+    "name": "구영테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053280",
+    "name": "예스24",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053290",
+    "name": "NE능률",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053300",
+    "name": "한국정보인증",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053350",
+    "name": "이니텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053450",
+    "name": "세코닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053580",
+    "name": "웹케시",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053610",
+    "name": "프로텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053620",
+    "name": "태양",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053700",
+    "name": "삼보모터스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053800",
+    "name": "안랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053950",
+    "name": "경남제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "053980",
+    "name": "오상자이엘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054040",
+    "name": "한국컴퓨터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054050",
+    "name": "NH농우바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054090",
+    "name": "삼진엘앤디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054180",
+    "name": "메디콕스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054210",
+    "name": "이랜텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054220",
+    "name": "비츠로시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054300",
+    "name": "팬스타엔터프라이즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054410",
+    "name": "케이피티유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054450",
+    "name": "텔레칩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054540",
+    "name": "삼영엠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054620",
+    "name": "APS",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054670",
+    "name": "대한뉴팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054780",
+    "name": "키이스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054800",
+    "name": "아이디스홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054920",
+    "name": "한컴위드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054930",
+    "name": "유신",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054940",
+    "name": "엑사이엔씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "054950",
+    "name": "제이브이엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "056080",
+    "name": "유진로봇",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "056090",
+    "name": "시지메드텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "056190",
+    "name": "에스에프에이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "056360",
+    "name": "코위버",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "056700",
+    "name": "신화인터텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "056730",
+    "name": "CNT85",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "057030",
+    "name": "YBM넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "057540",
+    "name": "옴니시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "057680",
+    "name": "티사이언티픽",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "058110",
+    "name": "멕아이씨에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "058400",
+    "name": "KNN",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "058450",
+    "name": "한주에이알티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "058470",
+    "name": "리노공업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "058610",
+    "name": "에스피지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "058630",
+    "name": "엠게임",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "058820",
+    "name": "CMG제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "058970",
+    "name": "엠로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "059090",
+    "name": "미코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "059100",
+    "name": "아이컴포넌트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "059120",
+    "name": "아진엑스텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "059210",
+    "name": "메타바이오메드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "059270",
+    "name": "해성에어로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060150",
+    "name": "인선이엔티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060230",
+    "name": "제이케이시냅스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060240",
+    "name": "스타코링크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060250",
+    "name": "NHN KCP",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060260",
+    "name": "뉴보텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060280",
+    "name": "큐렉소",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060310",
+    "name": "3S",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060370",
+    "name": "LS마린솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060380",
+    "name": "동양에스텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060480",
+    "name": "국일신동",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060540",
+    "name": "에스에이티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060560",
+    "name": "HC홈센타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060570",
+    "name": "드림어스컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060590",
+    "name": "씨티씨바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060720",
+    "name": "KH바텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060850",
+    "name": "영림원소프트랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "060900",
+    "name": "에이전트AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "061040",
+    "name": "알에프텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "061090",
+    "name": "세나테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "061250",
+    "name": "화일약품",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "061970",
+    "name": "LB세미콘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "062970",
+    "name": "한국첨단소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "063080",
+    "name": "컴투스홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "063170",
+    "name": "서울옥션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "063440",
+    "name": "SM Life Design",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "063570",
+    "name": "NICE인프라",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "063760",
+    "name": "이엘피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064090",
+    "name": "인크레더블버즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064240",
+    "name": "홈캐스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064260",
+    "name": "다날",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064290",
+    "name": "인텍플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064480",
+    "name": "브리지텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064520",
+    "name": "테크엘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064550",
+    "name": "바이오니아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064760",
+    "name": "티씨케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064800",
+    "name": "포니링크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064820",
+    "name": "케이프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "064850",
+    "name": "에프앤가이드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065060",
+    "name": "지엔코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065130",
+    "name": "탑엔지니어링",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065150",
+    "name": "대산F&B",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065170",
+    "name": "비엘팜텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065350",
+    "name": "신성델타테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065370",
+    "name": "위세아이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065420",
+    "name": "에스아이리소스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065440",
+    "name": "이루온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065450",
+    "name": "빅텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065500",
+    "name": "오리엔트정공",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065510",
+    "name": "휴비츠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065530",
+    "name": "와이어블",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065570",
+    "name": "삼영이엔씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065650",
+    "name": "하이퍼코퍼레이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065660",
+    "name": "안트로젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065680",
+    "name": "우주일렉트로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065690",
+    "name": "파커스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065710",
+    "name": "서호전기",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065770",
+    "name": "CS",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "065950",
+    "name": "웰크론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066130",
+    "name": "하츠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066310",
+    "name": "큐에스아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066360",
+    "name": "체리부로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066410",
+    "name": "버킷스튜디오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066430",
+    "name": "아이로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066590",
+    "name": "스모트로닉",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066620",
+    "name": "국보디자인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066670",
+    "name": "디티씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066700",
+    "name": "테라젠이텍스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066790",
+    "name": "씨씨에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066900",
+    "name": "디에이피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066910",
+    "name": "손오공",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "066980",
+    "name": "한성크린텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067000",
+    "name": "조이시티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067010",
+    "name": "이씨에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067080",
+    "name": "대화제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067160",
+    "name": "SOOP",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067170",
+    "name": "오텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067280",
+    "name": "멀티캠퍼스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067290",
+    "name": "JW신약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067310",
+    "name": "하나마이크론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067370",
+    "name": "선바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067390",
+    "name": "아스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067570",
+    "name": "엔브이에이치코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067630",
+    "name": "HLB생명과학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067730",
+    "name": "로지시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067770",
+    "name": "세진티에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067900",
+    "name": "와이엔텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067920",
+    "name": "이글루",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "067990",
+    "name": "도이치모터스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "068050",
+    "name": "팬엔터테인먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "068100",
+    "name": "케이웨더",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "068240",
+    "name": "다원시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "068330",
+    "name": "일신바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "068760",
+    "name": "셀트리온제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "068790",
+    "name": "DMS",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "068930",
+    "name": "디지털대성",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "068940",
+    "name": "셀피글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "069080",
+    "name": "웹젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "069140",
+    "name": "누리플랜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "069330",
+    "name": "유아이디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "069410",
+    "name": "엔텔스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "069510",
+    "name": "에스텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "069540",
+    "name": "빛과전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "069920",
+    "name": "엑시온그룹",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "070300",
+    "name": "엑스큐어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "070590",
+    "name": "인티큐브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "071200",
+    "name": "인피니트헬스케어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "071280",
+    "name": "로체시스템즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "071670",
+    "name": "에이테크솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "071850",
+    "name": "캐스텍코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "072020",
+    "name": "중앙백신",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "072470",
+    "name": "우리산업홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "072770",
+    "name": "멤레이비티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "072870",
+    "name": "메가스터디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "072950",
+    "name": "빛샘전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "072990",
+    "name": "에이치시티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "073010",
+    "name": "케이에스피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "073110",
+    "name": "엘엠에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "073190",
+    "name": "듀오백",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "073490",
+    "name": "LIG아큐버",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "073540",
+    "name": "에프알텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "073560",
+    "name": "우리손에프앤지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "073570",
+    "name": "리튬포어스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "073640",
+    "name": "테라사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "074430",
+    "name": "아미노로직스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "074600",
+    "name": "원익QnC",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "075130",
+    "name": "플랜티넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "075970",
+    "name": "동국알앤에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "076080",
+    "name": "웰크론한텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "076610",
+    "name": "해성옵틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "077360",
+    "name": "덕산하이메탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078020",
+    "name": "LS증권",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078070",
+    "name": "유비쿼스홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078130",
+    "name": "국일제지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078140",
+    "name": "대봉엘에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078150",
+    "name": "HB테크놀러지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078160",
+    "name": "메디포스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078340",
+    "name": "컴투스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078350",
+    "name": "한양디지텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078590",
+    "name": "휴림에이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078600",
+    "name": "대주전자재료",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078860",
+    "name": "아이오케이이엔엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "078890",
+    "name": "가온그룹",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079000",
+    "name": "와토스코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079170",
+    "name": "한창산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079190",
+    "name": "케스피온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079370",
+    "name": "제우스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079650",
+    "name": "서산",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079810",
+    "name": "APS이노베이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079940",
+    "name": "가비아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079950",
+    "name": "인베니아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079960",
+    "name": "동양이엔피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "079970",
+    "name": "투비소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080010",
+    "name": "이상네트웍스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080160",
+    "name": "모두투어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080220",
+    "name": "제주반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080420",
+    "name": "모다이노칩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080470",
+    "name": "성창오토텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080520",
+    "name": "오디텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080530",
+    "name": "코디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080580",
+    "name": "오킨스전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "080720",
+    "name": "한국유니온제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "081150",
+    "name": "티플랙스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "081180",
+    "name": "쎄크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "081580",
+    "name": "성우전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "082210",
+    "name": "옵트론텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "082270",
+    "name": "젬백스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "082660",
+    "name": "코스나인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "082800",
+    "name": "비보존 제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "082850",
+    "name": "우리바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "082920",
+    "name": "비츠로셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083310",
+    "name": "엘오티베큠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083450",
+    "name": "GST",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083470",
+    "name": "이엠앤아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083500",
+    "name": "에프엔에스테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083550",
+    "name": "케이엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083640",
+    "name": "인콘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083650",
+    "name": "비에이치아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083660",
+    "name": "CSA 코스믹",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083790",
+    "name": "CG인바이츠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "083930",
+    "name": "아바코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "084110",
+    "name": "휴온스글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "084180",
+    "name": "수성웹툰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "084370",
+    "name": "유진테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "084440",
+    "name": "유비온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "084650",
+    "name": "랩지노믹스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "084730",
+    "name": "팅크웨어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "084850",
+    "name": "아이티엠반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "084990",
+    "name": "헬릭스미스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "085660",
+    "name": "차바이오텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "085670",
+    "name": "뉴프렉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "085810",
+    "name": "알티캐스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "085910",
+    "name": "네오티스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086040",
+    "name": "바이오톡스텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086060",
+    "name": "진바이오텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086390",
+    "name": "유니테스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086450",
+    "name": "동국제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086520",
+    "name": "에코프로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086670",
+    "name": "비엠티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086710",
+    "name": "선진뷰티사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086820",
+    "name": "바이오솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086890",
+    "name": "이수앱지스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086900",
+    "name": "메디톡스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086960",
+    "name": "MDS테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "086980",
+    "name": "쇼박스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "087010",
+    "name": "펩트론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "087260",
+    "name": "모바일어플라이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "087600",
+    "name": "픽셀플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "088130",
+    "name": "동아엘텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "088280",
+    "name": "쏘닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "088290",
+    "name": "이원컴포텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "088340",
+    "name": "유라클",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "088390",
+    "name": "이녹스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "088800",
+    "name": "에이스테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "088910",
+    "name": "동우팜투테이블",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089010",
+    "name": "켐트로닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089030",
+    "name": "테크윙",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089140",
+    "name": "넥스턴앤롤코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089150",
+    "name": "케이씨티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089230",
+    "name": "THE E&M",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089600",
+    "name": "KT나스미디어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089790",
+    "name": "제이티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089850",
+    "name": "유비벨록스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089890",
+    "name": "코세스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089970",
+    "name": "브이엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "089980",
+    "name": "상아프론테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "090150",
+    "name": "아이윈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "090360",
+    "name": "로보스타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "090410",
+    "name": "덕신이피씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "090470",
+    "name": "제이스로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "090710",
+    "name": "휴림로봇",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "090850",
+    "name": "현대이지웰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "091120",
+    "name": "이엠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "091340",
+    "name": "S&K폴리텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "091440",
+    "name": "한울소재과학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "091580",
+    "name": "상신이디피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "091590",
+    "name": "남화토건",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "091700",
+    "name": "파트론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "091970",
+    "name": "나노캠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092040",
+    "name": "아미코젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092070",
+    "name": "디엔에프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092130",
+    "name": "이크레더블",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092190",
+    "name": "서울바이오시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092300",
+    "name": "현우산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092460",
+    "name": "한라IMS",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092600",
+    "name": "앤씨앤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092730",
+    "name": "네오팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "092870",
+    "name": "엑시콘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "093190",
+    "name": "빅솔론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "093320",
+    "name": "케이아이엔엑스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "093380",
+    "name": "풍강",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "093520",
+    "name": "매커스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "093640",
+    "name": "케이알엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "093920",
+    "name": "서원인텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094170",
+    "name": "동운아나텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094360",
+    "name": "칩스앤미디어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094480",
+    "name": "갤럭시아머니트리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094820",
+    "name": "일진파워",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094840",
+    "name": "슈프리마에이치큐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094850",
+    "name": "참좋은여행",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094860",
+    "name": "네오리진",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094940",
+    "name": "푸른기술",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "094970",
+    "name": "제이엠티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "095190",
+    "name": "신화프리텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "095270",
+    "name": "웨이브일렉트로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "095340",
+    "name": "ISC",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "095500",
+    "name": "미래나노텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "095610",
+    "name": "테스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "095660",
+    "name": "네오위즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "095700",
+    "name": "제넥신",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "095910",
+    "name": "에스에너지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "096240",
+    "name": "크레버스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "096250",
+    "name": "와이즈넛",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "096350",
+    "name": "대창솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "096530",
+    "name": "씨젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "096610",
+    "name": "알에프세미",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "096630",
+    "name": "에스코넥",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "096690",
+    "name": "에이루트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "096870",
+    "name": "엘디티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "097780",
+    "name": "에코볼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "097800",
+    "name": "윈팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "097870",
+    "name": "효성오앤비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "098070",
+    "name": "한텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "098120",
+    "name": "마이크로컨텍솔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "098460",
+    "name": "고영",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "098660",
+    "name": "에스티오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099190",
+    "name": "아이센스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099220",
+    "name": "SDN",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099320",
+    "name": "쎄트렉아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099390",
+    "name": "브레인즈컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099410",
+    "name": "동방선기",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099430",
+    "name": "바이오플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099440",
+    "name": "스맥",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099520",
+    "name": "DGI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "099750",
+    "name": "이지케어텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "100030",
+    "name": "인지소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "100120",
+    "name": "뷰웍스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "100130",
+    "name": "동국S&C",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "100590",
+    "name": "머큐리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "100660",
+    "name": "서암기계공업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "100700",
+    "name": "세운메디칼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "100790",
+    "name": "미래에셋벤처투자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101000",
+    "name": "KS인더스트리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101160",
+    "name": "월덱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101170",
+    "name": "우림피티에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101240",
+    "name": "씨큐브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101330",
+    "name": "모베이스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101360",
+    "name": "에코앤드림",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101390",
+    "name": "아이엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101400",
+    "name": "엔시트론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101490",
+    "name": "에스앤에스텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101670",
+    "name": "하이드로리튬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101680",
+    "name": "한국정밀기계",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101730",
+    "name": "위메이드맥스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101930",
+    "name": "인화정공",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "101970",
+    "name": "우양에이치씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "102120",
+    "name": "어보브반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "102370",
+    "name": "케이옥션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "102710",
+    "name": "이엔에프테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "102940",
+    "name": "코오롱생명과학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "103230",
+    "name": "에스앤더블류",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "103840",
+    "name": "우양",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "104040",
+    "name": "디에스엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "104200",
+    "name": "NHN벅스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "104460",
+    "name": "디와이피엔에프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "104480",
+    "name": "티케이케미칼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "104540",
+    "name": "코렌텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "104620",
+    "name": "노랑풍선",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "104830",
+    "name": "원익머트리얼즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "105330",
+    "name": "케이엔더블유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "105550",
+    "name": "엣지파운드리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "105740",
+    "name": "디케이락",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "105760",
+    "name": "포스뱅크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "106080",
+    "name": "케이이엠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "106190",
+    "name": "하이텍팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "106240",
+    "name": "파인테크닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "106520",
+    "name": "노블엠앤비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "107600",
+    "name": "새빗켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "107640",
+    "name": "한중엔시에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "108230",
+    "name": "톱텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "108380",
+    "name": "대양전기공업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "108490",
+    "name": "로보티즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "108860",
+    "name": "셀바스AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "109080",
+    "name": "옵티시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "109610",
+    "name": "에스와이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "109670",
+    "name": "씨싸이트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "109740",
+    "name": "디에스케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "109820",
+    "name": "진매트릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "109860",
+    "name": "동일금속",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "109960",
+    "name": "앱토크롬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "110020",
+    "name": "전진바이오팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "110790",
+    "name": "크리스에프앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "110990",
+    "name": "디아이티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "111710",
+    "name": "남화산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "112040",
+    "name": "위메이드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "112290",
+    "name": "와이씨켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "113810",
+    "name": "디젠스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "114190",
+    "name": "강원에너지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "114450",
+    "name": "그린생명과학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "114630",
+    "name": "폴라리스우노",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "114810",
+    "name": "한솔아이원스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "114840",
+    "name": "아이패밀리에스씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115160",
+    "name": "휴맥스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115180",
+    "name": "큐리언트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115310",
+    "name": "인포바인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115440",
+    "name": "우리넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115450",
+    "name": "HLB테라퓨틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115480",
+    "name": "씨유메디칼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115500",
+    "name": "케이씨에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115530",
+    "name": "씨엔플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115570",
+    "name": "스타플렉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "115610",
+    "name": "이미지스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "117670",
+    "name": "알파칩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "117730",
+    "name": "티로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "118990",
+    "name": "모트렉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "119500",
+    "name": "포메탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "119610",
+    "name": "인터로조",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "119830",
+    "name": "아이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "119850",
+    "name": "지엔씨에너지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "120240",
+    "name": "대정화금",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "121440",
+    "name": "골프존홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "121600",
+    "name": "나노신소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "121800",
+    "name": "비덴트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "121850",
+    "name": "코이즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "121890",
+    "name": "에스디시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "122310",
+    "name": "제노레이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "122350",
+    "name": "삼기",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "122450",
+    "name": "KX",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "122640",
+    "name": "예스티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "122690",
+    "name": "서진오토모티브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "122870",
+    "name": "와이지엔터테인먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "122990",
+    "name": "와이솔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123010",
+    "name": "알엔티엑스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123040",
+    "name": "엠에스오토텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123330",
+    "name": "제닉",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123410",
+    "name": "코리아에프티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123420",
+    "name": "위메이드플레이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123570",
+    "name": "이엠넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123750",
+    "name": "알톤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123840",
+    "name": "뉴온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "123860",
+    "name": "아나패스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "124500",
+    "name": "아이티센글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "124560",
+    "name": "태웅로직스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "125020",
+    "name": "티씨머티리얼즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "125210",
+    "name": "아모그린텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "125490",
+    "name": "한라캐스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "126340",
+    "name": "비나텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "126600",
+    "name": "BGF에코머티리얼즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "126640",
+    "name": "화신정공",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "126700",
+    "name": "하이비젼시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "126730",
+    "name": "코칩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "126880",
+    "name": "제이엔케이글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "127120",
+    "name": "제이에스링크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "127710",
+    "name": "아시아경제",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "127980",
+    "name": "화인써키트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "128540",
+    "name": "에코캡",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "128660",
+    "name": "피제이메탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "129890",
+    "name": "앱코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "129920",
+    "name": "대성하이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "130500",
+    "name": "GH신소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "130580",
+    "name": "나이스디앤비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "130740",
+    "name": "티피씨글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131030",
+    "name": "옵투스제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131090",
+    "name": "시큐브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131100",
+    "name": "티엔엔터테인먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131180",
+    "name": "딜리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131220",
+    "name": "대한과학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131290",
+    "name": "티에스이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131370",
+    "name": "알서포트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131400",
+    "name": "이브이첨단소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131760",
+    "name": "파인텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "131970",
+    "name": "두산테스나",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "133750",
+    "name": "메가엠디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "134060",
+    "name": "이퓨쳐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "134580",
+    "name": "탑코미디어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "136150",
+    "name": "원일티엔아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "136410",
+    "name": "아셈스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "136480",
+    "name": "하림",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "136540",
+    "name": "윈스테크넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "137080",
+    "name": "나래나노텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "137400",
+    "name": "피엔티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "137940",
+    "name": "넥스트아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "137950",
+    "name": "제이씨케미칼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "138070",
+    "name": "신진에스엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "138080",
+    "name": "오이솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "138360",
+    "name": "앤로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "138610",
+    "name": "나이벡",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "139670",
+    "name": "키네마스터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "140070",
+    "name": "서플러스글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "140410",
+    "name": "메지온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "140430",
+    "name": "카티스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "140520",
+    "name": "대창스틸",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "140670",
+    "name": "알에스오토메이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "140860",
+    "name": "파크시스템스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "141000",
+    "name": "비아트론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "141080",
+    "name": "리가켐바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "142210",
+    "name": "유니트론텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "142280",
+    "name": "녹십자엠에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "142760",
+    "name": "모아라이프플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "143160",
+    "name": "아이디스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "143240",
+    "name": "사람인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "143540",
+    "name": "영우디에스피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "144510",
+    "name": "지씨셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "144960",
+    "name": "뉴파워프라즈마",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "145020",
+    "name": "휴젤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "145170",
+    "name": "노브랜드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "146060",
+    "name": "율촌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "146320",
+    "name": "비씨엔씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "147760",
+    "name": "피엠티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "147830",
+    "name": "제룡산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "148150",
+    "name": "세경하이테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "148250",
+    "name": "알엔투테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "148780",
+    "name": "비큐AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "148930",
+    "name": "에이치와이티씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "149950",
+    "name": "아바텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "149980",
+    "name": "하이로닉",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "150900",
+    "name": "파수AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "151860",
+    "name": "KG에코솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "153460",
+    "name": "네이블",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "153490",
+    "name": "우리이앤엘하루틴",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "153710",
+    "name": "옵티팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "154030",
+    "name": "아시아종묘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "154040",
+    "name": "다산솔루에타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "155650",
+    "name": "와이엠씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "156100",
+    "name": "엘앤케이바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "158430",
+    "name": "아톤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "159010",
+    "name": "아스플로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "159580",
+    "name": "제로투세븐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "159910",
+    "name": "에코글로우",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "160190",
+    "name": "하이젠알앤엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "160550",
+    "name": "NEW",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "160980",
+    "name": "싸이맥스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "161580",
+    "name": "필옵틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "162300",
+    "name": "신스틸",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "163280",
+    "name": "에어레인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "163730",
+    "name": "핑거",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "166090",
+    "name": "하나머티리얼즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "166480",
+    "name": "코아스템켐온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "168330",
+    "name": "내츄럴엔도텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "168360",
+    "name": "펨트론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "169330",
+    "name": "엠브레인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "170030",
+    "name": "현대공업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "170790",
+    "name": "파이오링크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "170920",
+    "name": "엘티씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "171010",
+    "name": "램테크놀러지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "171090",
+    "name": "선익시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "171120",
+    "name": "라이온켐텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "172670",
+    "name": "에이엘티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "173130",
+    "name": "오파스넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "173940",
+    "name": "에프엔씨엔터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "174900",
+    "name": "앱클론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "175140",
+    "name": "휴먼테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "175250",
+    "name": "아이큐어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "176750",
+    "name": "듀켐바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "177350",
+    "name": "베셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "177830",
+    "name": "파버나인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "177900",
+    "name": "쓰리에이로직스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "178320",
+    "name": "서진시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "178780",
+    "name": "일월지엠엘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "179290",
+    "name": "엠아이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "179530",
+    "name": "애드바이오텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "179900",
+    "name": "유티아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "180400",
+    "name": "DXVX",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "182360",
+    "name": "큐브엔터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "182400",
+    "name": "엔케이젠바이오텍코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "183300",
+    "name": "코미코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "183490",
+    "name": "엔지켐생명과학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "184230",
+    "name": "SGA솔루션즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "185490",
+    "name": "아이진",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "186230",
+    "name": "그린플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "187220",
+    "name": "디티앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "187270",
+    "name": "신화콘텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "187420",
+    "name": "HLB제넥스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "187660",
+    "name": "페니트리움바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "187790",
+    "name": "나노",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "187870",
+    "name": "디바이스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "188040",
+    "name": "바이오포트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "188260",
+    "name": "세니젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "189300",
+    "name": "인텔리안테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "189330",
+    "name": "씨이랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "189690",
+    "name": "포시에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "189860",
+    "name": "서전기전",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "189980",
+    "name": "흥국에프엔비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "190510",
+    "name": "나무가",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "190650",
+    "name": "코리아에셋투자증권",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "191410",
+    "name": "육일씨엔에쓰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "191420",
+    "name": "테고사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "192250",
+    "name": "케이사인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "192390",
+    "name": "윈하이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "192410",
+    "name": "오늘이엔엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "192440",
+    "name": "슈피겐코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "193250",
+    "name": "링크드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "194480",
+    "name": "데브시스터즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "194700",
+    "name": "노바렉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "195500",
+    "name": "마니커에프앤지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "195940",
+    "name": "HK이노엔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "195990",
+    "name": "에이비프로바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "196170",
+    "name": "알테오젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "196300",
+    "name": "HLB펩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "196450",
+    "name": "코아시아씨엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "196490",
+    "name": "디에이테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "196700",
+    "name": "웹스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "197140",
+    "name": "디지캡",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "198080",
+    "name": "캐프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "198440",
+    "name": "강동씨앤엘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "198940",
+    "name": "한주라이트메탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "199430",
+    "name": "케이엔알시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "199480",
+    "name": "뱅크웨어글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "199550",
+    "name": "레이저옵텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "199730",
+    "name": "바이오인프라",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "199800",
+    "name": "툴젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "199820",
+    "name": "제일일렉트릭",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "200130",
+    "name": "콜마비앤에이치",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "200230",
+    "name": "텔콘RF제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "200350",
+    "name": "아티스트스튜디오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "200470",
+    "name": "에이팩트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "200670",
+    "name": "휴메딕스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "200710",
+    "name": "에이디테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "200780",
+    "name": "비씨월드제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "201490",
+    "name": "미투온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "203400",
+    "name": "에이비온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "203450",
+    "name": "유니온바이오메트릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "203650",
+    "name": "드림시큐리티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "203690",
+    "name": "아크솔루션스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "204020",
+    "name": "그리티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "204270",
+    "name": "제이앤티씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "204610",
+    "name": "티쓰리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "204620",
+    "name": "글로벌텍스프리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "204840",
+    "name": "지엘팜텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "205100",
+    "name": "엑셈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "205470",
+    "name": "휴마시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "205500",
+    "name": "넥써쓰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "206400",
+    "name": "베노티앤알",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "206560",
+    "name": "덱스터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "206640",
+    "name": "바디텍메드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "206650",
+    "name": "유바이오로직스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "207760",
+    "name": "미스터블루",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "208140",
+    "name": "정다운",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "208350",
+    "name": "지란지교시큐리티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "208370",
+    "name": "셀바스헬스케어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "208640",
+    "name": "썸에이지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "208710",
+    "name": "포톤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "208860",
+    "name": "다산디엠씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "209640",
+    "name": "와이제이링크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "210120",
+    "name": "캔버스엔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "211050",
+    "name": "인카금융서비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "211270",
+    "name": "AP위성",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "212560",
+    "name": "네오오토",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "212710",
+    "name": "아이에스티이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "213420",
+    "name": "덕산네오룩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214150",
+    "name": "클래시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214180",
+    "name": "헥토이노베이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214260",
+    "name": "라파스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214270",
+    "name": "FSN",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214370",
+    "name": "케어젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214430",
+    "name": "아이쓰리시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214450",
+    "name": "파마리서치",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214610",
+    "name": "롤링스톤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "214680",
+    "name": "디알텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215000",
+    "name": "골프존",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215090",
+    "name": "솔디펜스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215100",
+    "name": "로보로보",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215200",
+    "name": "메가스터디교육",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215360",
+    "name": "우리산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215380",
+    "name": "우정바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215480",
+    "name": "토박스코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215600",
+    "name": "신라젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "215790",
+    "name": "이노인스트루먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "216050",
+    "name": "인크로스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "216080",
+    "name": "제테마",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "217190",
+    "name": "제너셈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "217270",
+    "name": "넵튠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "217330",
+    "name": "싸이토젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "217480",
+    "name": "에스디생명공학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "217500",
+    "name": "러셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "217730",
+    "name": "강스템바이오텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "217820",
+    "name": "원익피앤이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "218150",
+    "name": "미래생명자원",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "218410",
+    "name": "RFHIC",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "219130",
+    "name": "타이거일렉",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "219420",
+    "name": "링크제니시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "219550",
+    "name": "디와이디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "219750",
+    "name": "한국비티비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "220100",
+    "name": "퓨쳐켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "220180",
+    "name": "핸디소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "220260",
+    "name": "켐트로스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "221800",
+    "name": "지구홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "221840",
+    "name": "하이즈항공",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "221980",
+    "name": "케이디켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "222040",
+    "name": "코스맥스엔비티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "222080",
+    "name": "씨아이에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "222110",
+    "name": "팬젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "222160",
+    "name": "NPX",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "222420",
+    "name": "쎄노텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "222800",
+    "name": "심텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "222980",
+    "name": "한국맥널티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "223250",
+    "name": "드림씨아이에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "223310",
+    "name": "사토시홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "224060",
+    "name": "더코디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "224110",
+    "name": "에이텍모빌리티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "225190",
+    "name": "LK삼양",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "225220",
+    "name": "제놀루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "225430",
+    "name": "케이엠제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "225530",
+    "name": "HC보광산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "225570",
+    "name": "넥슨게임즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "225590",
+    "name": "패션플랫폼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "226330",
+    "name": "신테카바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "226340",
+    "name": "본느",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "226400",
+    "name": "오스테오닉",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "226590",
+    "name": "엠디바이스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "226950",
+    "name": "올릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "227100",
+    "name": "프로브잇",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "227610",
+    "name": "아우딘퓨쳐스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "227950",
+    "name": "엔투텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "228340",
+    "name": "동양파일",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "228670",
+    "name": "레이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "228760",
+    "name": "지노믹트리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "228850",
+    "name": "레이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "229000",
+    "name": "젠큐릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "230240",
+    "name": "에치에프알",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "230360",
+    "name": "에코마케팅",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "230980",
+    "name": "비유테크놀러지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "232140",
+    "name": "와이씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "232680",
+    "name": "라온로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "232830",
+    "name": "아이티센피엔에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "234030",
+    "name": "싸이닉솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "234100",
+    "name": "폴라리스세원",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "234300",
+    "name": "에스트래픽",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "234340",
+    "name": "헥토파이낸셜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "234690",
+    "name": "녹십자웰빙",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "234920",
+    "name": "자이글",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "235980",
+    "name": "메드팩토",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "236200",
+    "name": "슈프리마",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "236810",
+    "name": "엔비티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "237690",
+    "name": "에스티팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "237750",
+    "name": "피앤씨테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "237820",
+    "name": "플레이디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "237880",
+    "name": "클리오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "238090",
+    "name": "앤디포스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "238120",
+    "name": "얼라인드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "238200",
+    "name": "비피도",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "238490",
+    "name": "힘스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "239340",
+    "name": "이스트에이드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "239610",
+    "name": "에이치엘사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "239890",
+    "name": "피엔에이치테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "240550",
+    "name": "동방메디컬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "240600",
+    "name": "유진테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "240810",
+    "name": "원익IPS",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "241520",
+    "name": "DSC인베스트먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "241690",
+    "name": "유니테크노",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "241710",
+    "name": "코스메카코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "241770",
+    "name": "메카로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "241790",
+    "name": "티이엠씨씨엔에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "241820",
+    "name": "피씨엘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "241840",
+    "name": "에이스토리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "242040",
+    "name": "나무기술",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "243070",
+    "name": "휴온스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "243840",
+    "name": "신흥에스이씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "244460",
+    "name": "올리패스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "245620",
+    "name": "EDGC",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "246250",
+    "name": "에스엘에스바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "246690",
+    "name": "TS인베스트먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "246710",
+    "name": "티앤알바이오팹",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "246720",
+    "name": "아스타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "246960",
+    "name": "SCL사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "247540",
+    "name": "에코프로비엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "247660",
+    "name": "나노씨엠에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "250000",
+    "name": "보라티알",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "250060",
+    "name": "모비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "250930",
+    "name": "예선테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "251120",
+    "name": "바이오에프디엔씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "251370",
+    "name": "와이엠티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "251630",
+    "name": "브이원텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "251970",
+    "name": "펌텍코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "252500",
+    "name": "세화피앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "252990",
+    "name": "샘씨엔에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "253450",
+    "name": "스튜디오드래곤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "253590",
+    "name": "네오셈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "253840",
+    "name": "수젠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "254120",
+    "name": "자비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "254490",
+    "name": "미래반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "255220",
+    "name": "SG",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "255440",
+    "name": "야스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "256150",
+    "name": "한독크린텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "256630",
+    "name": "포인트엔지니어링",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "256840",
+    "name": "한국비엔씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "256940",
+    "name": "킵스파마",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "257370",
+    "name": "피엔티엠에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "257720",
+    "name": "실리콘투",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "258610",
+    "name": "케일럼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "258790",
+    "name": "소프트캠프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "258830",
+    "name": "세종메디칼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "259630",
+    "name": "엠플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "260660",
+    "name": "알리코제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "260930",
+    "name": "씨티케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "260970",
+    "name": "에스앤디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "261200",
+    "name": "덴티스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "261520",
+    "name": "이지스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "261780",
+    "name": "차백신연구소",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "262260",
+    "name": "에이프로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "262840",
+    "name": "아이퀘스트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263020",
+    "name": "디케이앤디",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263050",
+    "name": "유틸렉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263600",
+    "name": "덕우전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263690",
+    "name": "디알젬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263700",
+    "name": "케어랩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263720",
+    "name": "디앤씨미디어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263750",
+    "name": "펄어비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263770",
+    "name": "유에스티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263800",
+    "name": "데이타솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263810",
+    "name": "상신전자",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263860",
+    "name": "지니언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "263920",
+    "name": "휴엠앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "264450",
+    "name": "유비쿼스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "264660",
+    "name": "씨앤지하이테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "264850",
+    "name": "이랜시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "265520",
+    "name": "AP시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "265560",
+    "name": "영화테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "265740",
+    "name": "엔에프씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "267320",
+    "name": "나인테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "267790",
+    "name": "배럴",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "267980",
+    "name": "매일유업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "269620",
+    "name": "시스웍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "270520",
+    "name": "앱튼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "270660",
+    "name": "에브리봇",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "270870",
+    "name": "뉴트리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "271830",
+    "name": "팸텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "272110",
+    "name": "케이엔제이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "272290",
+    "name": "이녹스첨단소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "273060",
+    "name": "와이즈버즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "273640",
+    "name": "와이엠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "274090",
+    "name": "켄코아에어로스페이스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "274400",
+    "name": "이노시뮬레이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "275630",
+    "name": "에스에스알",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "276040",
+    "name": "스코넥",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "276730",
+    "name": "한울앤제주",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "277070",
+    "name": "린드먼아시아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "277410",
+    "name": "인산가",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "277810",
+    "name": "레인보우로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "277880",
+    "name": "티에스아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "278280",
+    "name": "천보",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "278650",
+    "name": "HLB바이오스텝",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "279600",
+    "name": "미디어젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "281740",
+    "name": "레이크머티리얼즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "282720",
+    "name": "금양그린파워",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "282880",
+    "name": "코윈테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "284620",
+    "name": "카이노스메드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "285490",
+    "name": "노바텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "285800",
+    "name": "진영",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "286750",
+    "name": "나노실리칸첨단소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "287840",
+    "name": "인투셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "288180",
+    "name": "케이피항공산업",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "288330",
+    "name": "파라택시스코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "288620",
+    "name": "에스프리즘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "288980",
+    "name": "모아데이타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "289010",
+    "name": "아이스크림에듀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "289080",
+    "name": "SV인베스트먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "289220",
+    "name": "자이언트스텝",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "289930",
+    "name": "웨이비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290090",
+    "name": "트윔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290120",
+    "name": "DH오토리드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290270",
+    "name": "휴네시온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290520",
+    "name": "신도기연",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290550",
+    "name": "디케이티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290560",
+    "name": "파라택시스이더리움",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290650",
+    "name": "엘앤씨바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290660",
+    "name": "다이나믹솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290670",
+    "name": "대보마그네틱",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290690",
+    "name": "소룩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290720",
+    "name": "푸드나무",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "290740",
+    "name": "액트로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "291230",
+    "name": "엔피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "291650",
+    "name": "압타머사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "291810",
+    "name": "핀텔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "293490",
+    "name": "카카오게임즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "293580",
+    "name": "나우IB",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "293780",
+    "name": "압타바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "294090",
+    "name": "이오플로우",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "294140",
+    "name": "레몬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "294570",
+    "name": "쿠콘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "294630",
+    "name": "서남",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "295310",
+    "name": "에이치브이엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "296640",
+    "name": "이노에이엑스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "297090",
+    "name": "씨에스베어링",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "297570",
+    "name": "알로이스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "297890",
+    "name": "HB솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "298060",
+    "name": "풍전약품",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "298380",
+    "name": "에이비엘바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "298540",
+    "name": "더네이쳐홀딩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "298830",
+    "name": "슈어소프트테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "299030",
+    "name": "하나기술",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "299170",
+    "name": "더블유에스아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "299660",
+    "name": "셀리드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "299900",
+    "name": "위지윅스튜디오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "300080",
+    "name": "플리토",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "300120",
+    "name": "라온피플",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "301300",
+    "name": "바이브컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "302430",
+    "name": "이노메트리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "302550",
+    "name": "리메드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "303030",
+    "name": "지니틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "303360",
+    "name": "프로티아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "303530",
+    "name": "이노뎁",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "303810",
+    "name": "동국생명과학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "304100",
+    "name": "솔트룩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "304360",
+    "name": "에스바이오메딕스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "304840",
+    "name": "피플바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "305090",
+    "name": "마이크로디지탈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "306040",
+    "name": "에스제이그룹",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "306620",
+    "name": "지아이에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "307180",
+    "name": "아이엘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "307280",
+    "name": "원바이오젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "307750",
+    "name": "국전",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "307870",
+    "name": "비투엔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "307930",
+    "name": "컴퍼니케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "308080",
+    "name": "바이젠셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "308100",
+    "name": "형지글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "308430",
+    "name": "셀비온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "309710",
+    "name": "아이티켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "309930",
+    "name": "조이웍스앤코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "309960",
+    "name": "LB인베스트먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "310200",
+    "name": "애니플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "310210",
+    "name": "보로노이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "310870",
+    "name": "디와이씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "311320",
+    "name": "지오엘리먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "311390",
+    "name": "네오크레마",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "311690",
+    "name": "CJ 바이오사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "312610",
+    "name": "에이에프더블류",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "313760",
+    "name": "캐리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "314130",
+    "name": "지놈앤컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "314140",
+    "name": "알피바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "314930",
+    "name": "바이오다인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "315640",
+    "name": "딥노이드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317120",
+    "name": "라닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317240",
+    "name": "TS트릴리온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317330",
+    "name": "덕산테코피아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317530",
+    "name": "에피소드컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317690",
+    "name": "퀀타매트릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317770",
+    "name": "엑스페릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317830",
+    "name": "에스피시스템스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317850",
+    "name": "대모",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "317870",
+    "name": "엔바이오니아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "318000",
+    "name": "KBG",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "318010",
+    "name": "팜스빌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "318020",
+    "name": "포인트모바일",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "318060",
+    "name": "그래피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "318160",
+    "name": "셀바이오휴먼텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "318410",
+    "name": "비비씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "319400",
+    "name": "현대무벡스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "319660",
+    "name": "피에스케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "320000",
+    "name": "한울반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "321260",
+    "name": "프로이천",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "321370",
+    "name": "센서뷰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "321550",
+    "name": "티움바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "321820",
+    "name": "아티스트컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "322180",
+    "name": "LS티라유텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "322310",
+    "name": "오로스테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "322510",
+    "name": "제이엘케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "322780",
+    "name": "코퍼스코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "323280",
+    "name": "태성",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "323350",
+    "name": "다원넥스뷰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "323990",
+    "name": "박셀바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "327260",
+    "name": "RF머트리얼즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "328130",
+    "name": "루닛",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "328380",
+    "name": "솔트웨어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "330350",
+    "name": "위더스제약",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "330730",
+    "name": "스톤브릿지벤처스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "330860",
+    "name": "네패스아크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "331380",
+    "name": "포커스에이아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "331520",
+    "name": "밸로프",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "331740",
+    "name": "아우토크립트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "331920",
+    "name": "셀레믹스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "332290",
+    "name": "누보",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "332370",
+    "name": "아이디피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "332570",
+    "name": "PS일렉트로닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "333050",
+    "name": "이노테나",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "333430",
+    "name": "일승",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "333620",
+    "name": "엔시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "334970",
+    "name": "프레스티지바이오로직스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "335810",
+    "name": "프리시젼바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "335870",
+    "name": "윙스풋",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "336060",
+    "name": "웨이버스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "336570",
+    "name": "원텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "336680",
+    "name": "탑런토탈솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "337930",
+    "name": "젝시믹스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "338220",
+    "name": "뷰노",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "338840",
+    "name": "와이바이오로직스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "339950",
+    "name": "아이비김영",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "340360",
+    "name": "다보링크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "340440",
+    "name": "세림B&G",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "340450",
+    "name": "지씨지놈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "340570",
+    "name": "티앤엘",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "340810",
+    "name": "시선AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "340930",
+    "name": "유일에너테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "342870",
+    "name": "오아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "344860",
+    "name": "이노진",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "347000",
+    "name": "센코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "347700",
+    "name": "스피어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "347740",
+    "name": "피엔케이피부임상연구센타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "347770",
+    "name": "핌스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "347850",
+    "name": "디앤디파마텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "347860",
+    "name": "알체라",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "347890",
+    "name": "엠엑스온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "348030",
+    "name": "모비릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "348080",
+    "name": "큐라티스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "348150",
+    "name": "고바이오랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "348210",
+    "name": "넥스틴",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "348340",
+    "name": "뉴로메카",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "348350",
+    "name": "위드텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "348370",
+    "name": "엔켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "351320",
+    "name": "넥사다이내믹스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "351330",
+    "name": "이삭엔지니어링",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "351870",
+    "name": "차이커뮤니케이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "352090",
+    "name": "스톰테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "352480",
+    "name": "씨앤씨인터내셔널",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "352700",
+    "name": "씨앤투스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "352770",
+    "name": "셀레스트라",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "352910",
+    "name": "오비고",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "352940",
+    "name": "인바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "353190",
+    "name": "휴럼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "353590",
+    "name": "오토앤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "353810",
+    "name": "이지바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "354200",
+    "name": "엔젠바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "354320",
+    "name": "알멕",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "355150",
+    "name": "코스텍시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "355390",
+    "name": "크라우드웍스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "355690",
+    "name": "에이텀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "356680",
+    "name": "엑스게이트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "356860",
+    "name": "티엘비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "356890",
+    "name": "싸이버원",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "357230",
+    "name": "에이치피오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "357550",
+    "name": "석경에이티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "357580",
+    "name": "아모센스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "357780",
+    "name": "솔브레인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "357880",
+    "name": "SKAI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "358570",
+    "name": "지아이이노베이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "359090",
+    "name": "씨엔알리서치",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "360070",
+    "name": "탑머티리얼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "360350",
+    "name": "코셈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "361390",
+    "name": "제노코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "361570",
+    "name": "알비더블유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "361670",
+    "name": "삼영에스앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "362320",
+    "name": "청담글로벌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "362990",
+    "name": "드림인사이트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "363250",
+    "name": "진시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "363260",
+    "name": "모비데이즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "364950",
+    "name": "에이아이코리아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "365270",
+    "name": "큐라클",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "365330",
+    "name": "에스와이스틸텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "365340",
+    "name": "성일하이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "365590",
+    "name": "하이딥",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "365900",
+    "name": "브이씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "366030",
+    "name": "공구우먼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "367000",
+    "name": "플래티어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "368600",
+    "name": "아이씨에이치",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "368770",
+    "name": "파이버프로",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "368970",
+    "name": "오에스피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "369370",
+    "name": "블리츠웨이엔터테인먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "370090",
+    "name": "퓨런티어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "371950",
+    "name": "풍원정밀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "372170",
+    "name": "윤성에프앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "372320",
+    "name": "큐로셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "372800",
+    "name": "아이티아이즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "373110",
+    "name": "엑셀세라퓨틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "373160",
+    "name": "데이원컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "373170",
+    "name": "엠아이큐브솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "373200",
+    "name": "엑스플러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "376180",
+    "name": "피코그램",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "376270",
+    "name": "HEM파마",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "376290",
+    "name": "씨유테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "376300",
+    "name": "디어유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "376900",
+    "name": "로킷헬스케어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "376930",
+    "name": "노을",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "376980",
+    "name": "원티드랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "377030",
+    "name": "비트맥스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "377220",
+    "name": "프롬바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "377330",
+    "name": "이지트로닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "377450",
+    "name": "리파인",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "377460",
+    "name": "큐에이드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "377480",
+    "name": "마음AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "378340",
+    "name": "필에너지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "378800",
+    "name": "샤페론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "380540",
+    "name": "옵티코어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "380550",
+    "name": "뉴로핏",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "381620",
+    "name": "제닉스로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "382150",
+    "name": "온코크로스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "382480",
+    "name": "지아이텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "382800",
+    "name": "지앤비에스 에코",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "382840",
+    "name": "원준",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "382900",
+    "name": "범한퓨얼셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "383310",
+    "name": "에코프로에이치엔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "383930",
+    "name": "디티앤씨알오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "384470",
+    "name": "코어라인소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "387570",
+    "name": "파인메딕스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "388050",
+    "name": "지투파워",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "388210",
+    "name": "씨엠티엑스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "388610",
+    "name": "지에프씨생명과학",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "388720",
+    "name": "유일로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "388790",
+    "name": "라이콤",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "388870",
+    "name": "파로스아이바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "389020",
+    "name": "자람테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "389030",
+    "name": "지니너스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "389140",
+    "name": "포바이포",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "389260",
+    "name": "대명에너지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "389470",
+    "name": "인벤티지랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "389500",
+    "name": "에스비비테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "389650",
+    "name": "넥스트바이오메디컬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "389680",
+    "name": "유디엠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "391710",
+    "name": "코닉오토메이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "393210",
+    "name": "토마토시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "393890",
+    "name": "더블유씨피",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "393970",
+    "name": "대진첨단소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "394280",
+    "name": "오픈엣지테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "394420",
+    "name": "리센스메디컬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "394800",
+    "name": "쓰리빌리언",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "396270",
+    "name": "넥스트칩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "396300",
+    "name": "세아메카닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "396470",
+    "name": "워트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "397030",
+    "name": "에이프릴바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "397810",
+    "name": "애드포러스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "398120",
+    "name": "에스지헬스케어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "399720",
+    "name": "가온칩스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "402030",
+    "name": "코난테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "402490",
+    "name": "그린리소스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "403490",
+    "name": "우듬지팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "403850",
+    "name": "더핑크퐁컴퍼니",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "403870",
+    "name": "HPSP",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "405000",
+    "name": "플라즈맵",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "405100",
+    "name": "큐알티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "405920",
+    "name": "나라셀라",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "406820",
+    "name": "뷰티스킨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "407400",
+    "name": "꿈비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "408470",
+    "name": "한패스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "408900",
+    "name": "스튜디오미르",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "408920",
+    "name": "메쎄이상",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "411080",
+    "name": "샌즈랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "412350",
+    "name": "레이저쎌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "412540",
+    "name": "제일엠앤에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "413390",
+    "name": "엠오티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "413630",
+    "name": "씨피시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "413640",
+    "name": "비아이매트릭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "415380",
+    "name": "스튜디오삼익",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "416180",
+    "name": "신성에스티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "417010",
+    "name": "나노팀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "417180",
+    "name": "핑거스토리",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "417200",
+    "name": "LS머트리얼즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "417500",
+    "name": "제이아이테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "417790",
+    "name": "트루엔",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "417840",
+    "name": "저스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "417860",
+    "name": "오브젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "417970",
+    "name": "모델솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "418250",
+    "name": "시큐레터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "418420",
+    "name": "라온텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "418470",
+    "name": "KT밀리의서재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "418550",
+    "name": "제이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "418620",
+    "name": "E8",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "419050",
+    "name": "삼기에너지솔루션즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "419080",
+    "name": "엔젯",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "419120",
+    "name": "산돌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "419530",
+    "name": "SAMG엔터",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "419540",
+    "name": "비스토스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "420570",
+    "name": "제이투케이바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "420770",
+    "name": "기가비스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "424760",
+    "name": "벨로크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "424870",
+    "name": "이뮨온시아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "424960",
+    "name": "스마트레이더시스템",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "424980",
+    "name": "마이크로투나노",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "425040",
+    "name": "티이엠씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "425420",
+    "name": "티에프이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "429270",
+    "name": "시지트로닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "430690",
+    "name": "한싹",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "431190",
+    "name": "케이쓰리아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "432430",
+    "name": "와이랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "432470",
+    "name": "케이엔에스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "432720",
+    "name": "퀄리타스반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "432980",
+    "name": "엠에프씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "434480",
+    "name": "모니터랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "435570",
+    "name": "에르코스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "437730",
+    "name": "삼현",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "438700",
+    "name": "버넥트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "439090",
+    "name": "마녀공장",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "439580",
+    "name": "블루엠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "439960",
+    "name": "코스모로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "440110",
+    "name": "파두",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "440290",
+    "name": "HB인베스트먼트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "440320",
+    "name": "오픈놀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "441270",
+    "name": "파인엠텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "443250",
+    "name": "레뷰코퍼레이션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "443670",
+    "name": "에스피소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "444530",
+    "name": "심플랫폼",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "445090",
+    "name": "에이직랜드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "445180",
+    "name": "퓨릿",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "445680",
+    "name": "큐리옥스바이오시스템즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "446540",
+    "name": "메가터치",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "446840",
+    "name": "지슨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "448280",
+    "name": "에코아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "448710",
+    "name": "코츠테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "448900",
+    "name": "한국피아이엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "450330",
+    "name": "하스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "450520",
+    "name": "인스웨이브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "450950",
+    "name": "아스테라시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "451220",
+    "name": "아이엠티",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "451250",
+    "name": "삐아",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "451700",
+    "name": "엔에이치스팩29호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "451760",
+    "name": "컨텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "452160",
+    "name": "제이엔비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "452190",
+    "name": "한빛레이저",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "452200",
+    "name": "민테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "452280",
+    "name": "한선엔지니어링",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "452300",
+    "name": "캡스톤파트너스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "452400",
+    "name": "이닉스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "452430",
+    "name": "사피엔반도체",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "452450",
+    "name": "피아이이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "453450",
+    "name": "그리드위즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "453860",
+    "name": "에이에스텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "455180",
+    "name": "케이지에이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "455900",
+    "name": "엔젤로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "456010",
+    "name": "아이씨티케이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "456070",
+    "name": "이엔셀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "456160",
+    "name": "지투지바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "457370",
+    "name": "한켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "457550",
+    "name": "우진엔텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "457600",
+    "name": "벡트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "458350",
+    "name": "에스팀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "458650",
+    "name": "성우",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "458870",
+    "name": "씨어스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "459100",
+    "name": "위츠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "459510",
+    "name": "나우로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "459550",
+    "name": "알트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "460470",
+    "name": "아이빔테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "460870",
+    "name": "에스엠씨지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "460930",
+    "name": "현대힘스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "460940",
+    "name": "피앤에스로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "461030",
+    "name": "아이엠비디엑스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "461300",
+    "name": "아이스크림미디어",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "462020",
+    "name": "에이치엠씨제6호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "462310",
+    "name": "뉴키즈온",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "462350",
+    "name": "이노스페이스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "462510",
+    "name": "라메디텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "462860",
+    "name": "더즌",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "462980",
+    "name": "아이지넷",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "463020",
+    "name": "뉴엔AI",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "463480",
+    "name": "모티브링크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "464080",
+    "name": "에스오에스랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "464280",
+    "name": "티디에스팜",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "464440",
+    "name": "한국제13호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "464490",
+    "name": "쿼드메디슨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "464500",
+    "name": "아이언디바이스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "464580",
+    "name": "닷밀",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "464680",
+    "name": "KB제27호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "465320",
+    "name": "교보15호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "465480",
+    "name": "인스피언",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "466100",
+    "name": "클로봇",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "466410",
+    "name": "사이냅소프트",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "466690",
+    "name": "키움히어로제1호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "466910",
+    "name": "엔에이치스팩30호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "467930",
+    "name": "IBKS제23호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "468530",
+    "name": "프로티나",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "468760",
+    "name": "유진스팩10호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "469480",
+    "name": "IBKS제24호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "469610",
+    "name": "이노테크",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "469750",
+    "name": "아이비젼웍스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "469880",
+    "name": "하나30호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "469900",
+    "name": "하나31호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "471050",
+    "name": "대신밸런스제17호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "471820",
+    "name": "셀로맥스사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "472220",
+    "name": "신영스팩10호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "472230",
+    "name": "에스케이증권제11호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "472850",
+    "name": "폰드그룹",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "473000",
+    "name": "에스케이증권제12호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "473050",
+    "name": "유안타제15호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "473950",
+    "name": "에스케이증권제13호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "473980",
+    "name": "노머스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "474170",
+    "name": "루미르",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "474490",
+    "name": "유안타제16호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "474610",
+    "name": "RF시스템즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "474650",
+    "name": "링크솔루션",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "474660",
+    "name": "신한제12호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "474930",
+    "name": "신한제13호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475230",
+    "name": "엔알비",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475240",
+    "name": "하나32호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475250",
+    "name": "하나33호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475400",
+    "name": "씨메스로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475430",
+    "name": "키스트론",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475460",
+    "name": "미트박스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475580",
+    "name": "에이럭스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475660",
+    "name": "에스켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475830",
+    "name": "오름테라퓨틱",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "475960",
+    "name": "토모큐브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "476040",
+    "name": "오가노이드사이언스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "476060",
+    "name": "온코닉테라퓨틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "476080",
+    "name": "M83",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "476830",
+    "name": "알지노믹스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "477340",
+    "name": "에이치엠씨제7호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "477380",
+    "name": "미래에셋비전스팩4호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "477470",
+    "name": "미래에셋비전스팩5호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "477760",
+    "name": "DB금융스팩12호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "477850",
+    "name": "마키나락스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "478110",
+    "name": "이베스트스팩6호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "478340",
+    "name": "나라스페이스테크놀로지",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "478390",
+    "name": "KB제29호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "478440",
+    "name": "미래에셋비전스팩6호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "478560",
+    "name": "블랙야크아이앤씨",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "479880",
+    "name": "한국제15호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "479960",
+    "name": "위너스일렉",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "481070",
+    "name": "에이유브랜즈",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "481890",
+    "name": "엔에이치스팩31호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "482520",
+    "name": "교보16호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "482630",
+    "name": "삼양엔씨켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "482680",
+    "name": "미래에셋비전스팩7호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "482690",
+    "name": "대신밸런스제19호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "484120",
+    "name": "도우인시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "484130",
+    "name": "하나34호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "484590",
+    "name": "삼양컴텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "484810",
+    "name": "티엑스알로보틱스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "486630",
+    "name": "KB제30호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "486990",
+    "name": "노타",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "487360",
+    "name": "신한제14호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "487580",
+    "name": "폴레드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "487720",
+    "name": "키움제10호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "487830",
+    "name": "신한제15호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "488060",
+    "name": "유진스팩11호",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "488280",
+    "name": "에스투더블유",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "488900",
+    "name": "비츠로넥스텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "489210",
+    "name": "교보17호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "489460",
+    "name": "바이오비쥬",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "489480",
+    "name": "키움제11호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "489500",
+    "name": "엘케이켐",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "489730",
+    "name": "디비금융제13호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "490470",
+    "name": "세미파이브",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "491000",
+    "name": "리브스메드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "492220",
+    "name": "KB제31호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "493280",
+    "name": "아이엠바이오로직스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "493330",
+    "name": "지에프아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "493790",
+    "name": "유안타제17호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "494120",
+    "name": "큐리오시스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "496070",
+    "name": "신한제16호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "498390",
+    "name": "한화플러스제5호스팩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900070",
+    "name": "글로벌에스엠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900100",
+    "name": "파이온엑스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900110",
+    "name": "딥커머스",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900120",
+    "name": "씨엑스아이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900250",
+    "name": "크리스탈신소재",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900260",
+    "name": "로스웰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900270",
+    "name": "헝셩그룹",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900290",
+    "name": "GRT",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900300",
+    "name": "오가닉티코스메틱",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900310",
+    "name": "컬러레이",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "900340",
+    "name": "윙입푸드",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "950130",
+    "name": "엑세스바이오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "950140",
+    "name": "잉글우드랩",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "950160",
+    "name": "코오롱티슈진",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "950170",
+    "name": "JTC",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "950190",
+    "name": "고스트스튜디오",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "950200",
+    "name": "소마젠",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "950220",
+    "name": "네오이뮨텍",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "950250",
+    "name": "테라뷰",
+    "market": "KOSDAQ",
+    "aliases": []
+  },
+  {
+    "code": "000020",
+    "name": "동화약품",
     "market": "KOSPI",
-    "aliases": ["Samsung Electronics"]
+    "aliases": []
+  },
+  {
+    "code": "000040",
+    "name": "KR모터스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000050",
+    "name": "경방",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000070",
+    "name": "삼양홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000080",
+    "name": "하이트진로",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000087",
+    "name": "하이트진로2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0000D0",
+    "name": "TIGER 엔비디아미국채커버드콜밸런스(합성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0000H0",
+    "name": "KODEX 인도Nifty미드캡100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0000J0",
+    "name": "PLUS 한화그룹주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0000Y0",
+    "name": "HK 26-12 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0000Z0",
+    "name": "RISE 바이오TOP10액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000100",
+    "name": "유한양행",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000105",
+    "name": "유한양행우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000120",
+    "name": "CJ대한통운",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000140",
+    "name": "하이트진로홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000145",
+    "name": "하이트진로홀딩스우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000150",
+    "name": "두산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000155",
+    "name": "두산우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000157",
+    "name": "두산2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000180",
+    "name": "성창기업지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0001P0",
+    "name": "마이티 바이오시밀러&CDMO액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000210",
+    "name": "DL",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000215",
+    "name": "DL우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000220",
+    "name": "유유제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000225",
+    "name": "유유제약1우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000227",
+    "name": "유유제약2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000230",
+    "name": "일동홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000240",
+    "name": "한국앤컴퍼니",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000270",
+    "name": "기아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0002C0",
+    "name": "에셋플러스 인도일등기업포커스20액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000300",
+    "name": "DH오토넥스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000320",
+    "name": "노루홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000325",
+    "name": "노루홀딩스우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000370",
+    "name": "한화손해보험",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000390",
+    "name": "SP삼화",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000400",
+    "name": "롯데손해보험",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000430",
+    "name": "대원강업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000480",
+    "name": "CR홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000490",
+    "name": "대동",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0004G0",
+    "name": "1Q 미국배당TOP30",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000500",
+    "name": "가온전선",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000520",
+    "name": "삼일제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000540",
+    "name": "흥국화재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000545",
+    "name": "흥국화재우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000590",
+    "name": "CS홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0005A0",
+    "name": "KODEX 미국S&P500데일리커버드콜OTM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0005C0",
+    "name": "RISE 미국S&P500엔화노출(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0005D0",
+    "name": "SOL 전고체배터리&실리콘음극재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0005G0",
+    "name": "IBK K-AI반도체코어테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000640",
+    "name": "동아쏘시오홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000650",
+    "name": "천일고속",
+    "market": "KOSPI",
+    "aliases": []
   },
   {
     "code": "000660",
     "name": "SK하이닉스",
     "market": "KOSPI",
-    "aliases": ["에스케이하이닉스", "SK hynix"]
+    "aliases": [
+      "에스케이하이닉스",
+      "SK hynix"
+    ]
+  },
+  {
+    "code": "000670",
+    "name": "영풍",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000680",
+    "name": "LS네트웍스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000700",
+    "name": "유수홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000720",
+    "name": "현대건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000725",
+    "name": "현대건설우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000760",
+    "name": "이화산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0007F0",
+    "name": "KODEX 27-12 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0007G0",
+    "name": "PLUS 글로벌원자력밸류체인",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0007N0",
+    "name": "아이엠에셋 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000810",
+    "name": "삼성화재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000815",
+    "name": "삼성화재우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000850",
+    "name": "화천기공",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000860",
+    "name": "강남제비스코",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000880",
+    "name": "한화",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "00088K",
+    "name": "한화3우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000890",
+    "name": "보해양조",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0008E0",
+    "name": "ACE 미국중심중소형제조업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0008S0",
+    "name": "TIGER 미국배당다우존스타겟데일리커버드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0008T0",
+    "name": "SOL 화장품TOP3플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000910",
+    "name": "유니온",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000950",
+    "name": "전방",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000970",
+    "name": "한국주철관",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "000990",
+    "name": "DB하이텍",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001020",
+    "name": "페이퍼코리아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001040",
+    "name": "CJ",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001045",
+    "name": "CJ우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "00104K",
+    "name": "CJ4우(전환)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001060",
+    "name": "JW중외제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001065",
+    "name": "JW중외제약우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001067",
+    "name": "JW중외제약2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001070",
+    "name": "대한방직",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001080",
+    "name": "만호제강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001120",
+    "name": "LX인터내셔널",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001130",
+    "name": "대한제분",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001200",
+    "name": "유진투자증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001210",
+    "name": "금호전기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001230",
+    "name": "동국홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001250",
+    "name": "GS글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001260",
+    "name": "남광토건",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001270",
+    "name": "부국증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001275",
+    "name": "부국증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001290",
+    "name": "상상인증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001340",
+    "name": "PKC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001360",
+    "name": "삼성제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001380",
+    "name": "SG글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001390",
+    "name": "KG케미칼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0013P0",
+    "name": "RISE 미국은행TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0013R0",
+    "name": "RISE 테슬라미국채타겟커버드콜혼합(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001420",
+    "name": "태원물산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001430",
+    "name": "세아베스틸지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001440",
+    "name": "대한전선",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001450",
+    "name": "현대해상",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001460",
+    "name": "BYC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001465",
+    "name": "BYC우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001470",
+    "name": "삼부토건",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001500",
+    "name": "현대차증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001510",
+    "name": "SK증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001515",
+    "name": "SK증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001520",
+    "name": "동양",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001525",
+    "name": "동양우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001527",
+    "name": "동양2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001530",
+    "name": "DI동일",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001550",
+    "name": "조비",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001560",
+    "name": "제일연마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001570",
+    "name": "금양",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0015B0",
+    "name": "KoAct 미국나스닥성장기업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0015E0",
+    "name": "KIWOOM 엔비디아미국30년국채혼합액티브(H",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0015F0",
+    "name": "KIWOOM 팔란티어미국30년국채혼합액티브(H",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0015K0",
+    "name": "TIGER 미국소비트렌드액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001620",
+    "name": "케이비아이동국실업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001630",
+    "name": "종근당홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001680",
+    "name": "대상",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001685",
+    "name": "대상우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0016X0",
+    "name": "SOL 중단기회사채(A-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001720",
+    "name": "신영증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001740",
+    "name": "SK네트웍스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001750",
+    "name": "한양증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001755",
+    "name": "한양증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001770",
+    "name": "SHD",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001780",
+    "name": "알루코",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001790",
+    "name": "대한제당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001795",
+    "name": "대한제당우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0017Y0",
+    "name": "1Q 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001800",
+    "name": "오리온홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001820",
+    "name": "삼화콘덴서",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0018C0",
+    "name": "PLUS 고배당주위클리고정커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0018Z0",
+    "name": "RISE 미국양자컴퓨팅",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "001940",
+    "name": "KISCO홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0019K0",
+    "name": "TIME 미국나스닥100채권혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002020",
+    "name": "코오롱",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002025",
+    "name": "코오롱우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002030",
+    "name": "아세아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002070",
+    "name": "비비안",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0020H0",
+    "name": "KoAct 글로벌양자컴퓨팅액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002100",
+    "name": "경농",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002140",
+    "name": "고려산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002150",
+    "name": "도화엔지니어링",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002170",
+    "name": "SYTS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0021C0",
+    "name": "ACE TDF장기자산배분액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0021D0",
+    "name": "ACE TDF2030액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0021E0",
+    "name": "ACE TDF2050액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002200",
+    "name": "한국수출포장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002210",
+    "name": "동성제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002220",
+    "name": "한일철강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002240",
+    "name": "고려제강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0022T0",
+    "name": "SOL 국제금커버드콜액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002310",
+    "name": "아세아제지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002320",
+    "name": "한진",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002350",
+    "name": "넥센타이어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002355",
+    "name": "넥센타이어1우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002360",
+    "name": "SH에너지화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002380",
+    "name": "KCC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002390",
+    "name": "한독",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0023A0",
+    "name": "SOL 미국양자컴퓨팅TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0023B0",
+    "name": "PLUS 미국양자컴퓨팅TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002410",
+    "name": "범양건영",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002420",
+    "name": "세기상사",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002450",
+    "name": "삼익악기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002460",
+    "name": "HS화성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0025N0",
+    "name": "TIGER TDF2045 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002600",
+    "name": "조흥",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002620",
+    "name": "제일파마홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002630",
+    "name": "오리엔트바이오",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002690",
+    "name": "동일제강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0026E0",
+    "name": "KODEX 미국S&P500버퍼3월액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0026S0",
+    "name": "1Q 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002700",
+    "name": "신일전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002710",
+    "name": "TCC스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002720",
+    "name": "국제약품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002760",
+    "name": "보락",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002780",
+    "name": "진흥기업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002785",
+    "name": "진흥기업우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002787",
+    "name": "진흥기업2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002790",
+    "name": "아모레퍼시픽홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002795",
+    "name": "아모레퍼시픽홀딩스우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "00279K",
+    "name": "아모레퍼시픽홀딩스3우C",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002810",
+    "name": "삼영무역",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002820",
+    "name": "SUN&L",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002840",
+    "name": "미원상사",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002870",
+    "name": "신풍",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002880",
+    "name": "디와이에이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0028X0",
+    "name": "KODEX 미국금융테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002900",
+    "name": "TYM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002920",
+    "name": "유성기업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002960",
+    "name": "한국쉘석유",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002990",
+    "name": "금호건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "002995",
+    "name": "금호건설우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003000",
+    "name": "부광약품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003010",
+    "name": "혜인",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003030",
+    "name": "세아제강지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003060",
+    "name": "에이프로젠바이오로직스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003070",
+    "name": "코오롱글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003075",
+    "name": "코오롱글로벌우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003080",
+    "name": "SB성보",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003090",
+    "name": "대웅",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0030R0",
+    "name": "대신밸류리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003120",
+    "name": "일성아이에스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003160",
+    "name": "디아이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003200",
+    "name": "일신방직",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003220",
+    "name": "대원제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003230",
+    "name": "삼양식품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003240",
+    "name": "태광산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003280",
+    "name": "흥아해운",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003300",
+    "name": "한일홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003350",
+    "name": "한국화장품제조",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003460",
+    "name": "유화증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003465",
+    "name": "유화증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003470",
+    "name": "유안타증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003475",
+    "name": "유안타증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003480",
+    "name": "한진중공업홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003490",
+    "name": "대한항공",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003495",
+    "name": "대한항공우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003520",
+    "name": "영진약품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003530",
+    "name": "한화투자증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003535",
+    "name": "한화투자증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003540",
+    "name": "대신증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003545",
+    "name": "대신증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003547",
+    "name": "대신증권2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003550",
+    "name": "LG",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003555",
+    "name": "LG우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003570",
+    "name": "SNT다이내믹스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003580",
+    "name": "HLB글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0035T0",
+    "name": "PLUS 글로벌휴머노이드로봇액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003610",
+    "name": "방림",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003620",
+    "name": "KG모빌리티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003650",
+    "name": "미창석유",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003670",
+    "name": "포스코퓨처엠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003680",
+    "name": "한성기업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003690",
+    "name": "코리안리",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0036D0",
+    "name": "TIME 미국배당다우존스액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0036R0",
+    "name": "RISE 미국휴머노이드로봇",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0036Z0",
+    "name": "RISE 미국천연가스밸류체인",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003720",
+    "name": "삼영",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003780",
+    "name": "진양산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003830",
+    "name": "대한화섬",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003850",
+    "name": "보령",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0038A0",
+    "name": "KODEX 미국휴머노이드로봇",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003920",
+    "name": "남양유업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003925",
+    "name": "남양유업우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "003960",
+    "name": "사조대림",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004000",
+    "name": "롯데정밀화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004020",
+    "name": "현대제철",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004060",
+    "name": "SG세계물산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004080",
+    "name": "신흥",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004090",
+    "name": "한국석유",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0040S0",
+    "name": "HANARO 글로벌피지컬AI액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0040X0",
+    "name": "SOL 팔란티어미국채커버드콜혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0040Y0",
+    "name": "SOL 팔란티어커버드콜OTM채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004100",
+    "name": "태양금속",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004105",
+    "name": "태양금속우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004140",
+    "name": "동방",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004150",
+    "name": "한솔홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004170",
+    "name": "신세계",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0041D0",
+    "name": "KODEX 미국AI소프트웨어TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0041E0",
+    "name": "KODEX 미국S&P500액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004250",
+    "name": "NPC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004255",
+    "name": "NPC우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004270",
+    "name": "남성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004310",
+    "name": "현대약품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004360",
+    "name": "세방",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004365",
+    "name": "세방우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004370",
+    "name": "농심",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004380",
+    "name": "삼익THK",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0043B0",
+    "name": "TIGER 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0043Y0",
+    "name": "TIME 차이나AI테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004410",
+    "name": "서울식품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004415",
+    "name": "서울식품우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004430",
+    "name": "송원산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004440",
+    "name": "삼일씨엔에스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004450",
+    "name": "삼화왕관",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004490",
+    "name": "세방전지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004540",
+    "name": "깨끗한나라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004545",
+    "name": "깨끗한나라우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004560",
+    "name": "현대비앤지스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004690",
+    "name": "삼천리",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0046A0",
+    "name": "TIGER 미국초단기(3개월이하)국채",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0046Y0",
+    "name": "ACE 미국배당퀄리티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004700",
+    "name": "조광피혁",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004710",
+    "name": "한솔테크닉스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004720",
+    "name": "팜젠사이언스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004770",
+    "name": "써니전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0047A0",
+    "name": "TIGER 차이나테크TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0047N0",
+    "name": "PLUS 차이나AI테크TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0047P0",
+    "name": "RISE 테슬라고정테크100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0047R0",
+    "name": "RISE 팔란티어고정테크100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004800",
+    "name": "효성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004830",
+    "name": "덕성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004835",
+    "name": "덕성우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004840",
+    "name": "DRB동일",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004870",
+    "name": "티웨이홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004890",
+    "name": "동일산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0048J0",
+    "name": "KODEX 미국머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0048K0",
+    "name": "KODEX 차이나휴머노이드로봇",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004910",
+    "name": "조광페인트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004920",
+    "name": "씨아이테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004960",
+    "name": "한신공영",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004970",
+    "name": "신라교역",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004980",
+    "name": "성신양회",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004985",
+    "name": "성신양회우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "004990",
+    "name": "롯데지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "00499K",
+    "name": "롯데지주우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0049K0",
+    "name": "ACE 미국배당퀄리티채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0049M0",
+    "name": "ACE 미국배당퀄리티+커버드콜액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005010",
+    "name": "휴스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005030",
+    "name": "부산주공",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005070",
+    "name": "코스모신소재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005090",
+    "name": "SGC에너지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0050E0",
+    "name": "PLUS 미국AI에이전트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005110",
+    "name": "한창",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005180",
+    "name": "빙그레",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0051A0",
+    "name": "KoAct 브로드컴밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0051G0",
+    "name": "SOL 미국원자력SMR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005250",
+    "name": "녹십자홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005257",
+    "name": "녹십자홀딩스2우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0052D0",
+    "name": "TIGER 코리아배당다우존스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0052S0",
+    "name": "1Q 미국S&P500미국채혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0052T0",
+    "name": "1Q 중단기회사채(A-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005300",
+    "name": "롯데칠성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005305",
+    "name": "롯데칠성우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005320",
+    "name": "온타이드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005360",
+    "name": "모나미",
+    "market": "KOSPI",
+    "aliases": []
   },
   {
     "code": "005380",
     "name": "현대차",
     "market": "KOSPI",
-    "aliases": ["현대자동차", "Hyundai Motor"]
+    "aliases": [
+      "현대자동차",
+      "Hyundai Motor"
+    ]
+  },
+  {
+    "code": "005385",
+    "name": "현대차우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005387",
+    "name": "현대차2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005389",
+    "name": "현대차3우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0053L0",
+    "name": "TIGER 차이나휴머노이드로봇",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0053M0",
+    "name": "더제이 중소형포커스액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005420",
+    "name": "코스모화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005430",
+    "name": "한국공항",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005440",
+    "name": "현대지에프홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005490",
+    "name": "POSCO홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005500",
+    "name": "삼진제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005610",
+    "name": "삼립",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005680",
+    "name": "삼영전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005690",
+    "name": "파미셀",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005720",
+    "name": "넥센",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005725",
+    "name": "넥센우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005740",
+    "name": "크라운해태홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005745",
+    "name": "크라운해태홀딩스우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005750",
+    "name": "대림바스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0057H0",
+    "name": "PLUS 미국S&P500미국채혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005800",
+    "name": "신영와코루",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005810",
+    "name": "풍산홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005820",
+    "name": "원림",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005830",
+    "name": "DB손해보험",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005850",
+    "name": "에스엘",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005870",
+    "name": "휴니드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005880",
+    "name": "대한해운",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005930",
+    "name": "삼성전자",
+    "market": "KOSPI",
+    "aliases": [
+      "Samsung Electronics"
+    ]
+  },
+  {
+    "code": "005935",
+    "name": "삼성전자우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005940",
+    "name": "NH투자증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005945",
+    "name": "NH투자증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005950",
+    "name": "이수화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005960",
+    "name": "동부건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "005965",
+    "name": "동부건설우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006040",
+    "name": "동원산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006060",
+    "name": "화승인더",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006090",
+    "name": "사조오양",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0060H0",
+    "name": "TIGER 토탈월드스탁액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006110",
+    "name": "삼아알미늄",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006120",
+    "name": "SK디스커버리",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006125",
+    "name": "SK디스커버리우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0061Z0",
+    "name": "RISE 단기특수은행채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006200",
+    "name": "한국전자홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006220",
+    "name": "제주은행",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006260",
+    "name": "LS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006280",
+    "name": "녹십자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006340",
+    "name": "대원전선",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006345",
+    "name": "대원전선우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006360",
+    "name": "GS건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006370",
+    "name": "대구백화점",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006380",
+    "name": "카프로",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006400",
+    "name": "삼성SDI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006405",
+    "name": "삼성SDI우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006490",
+    "name": "인스코비",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0064K0",
+    "name": "KODEX 금액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006570",
+    "name": "대림통상",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0065G0",
+    "name": "KODEX 차이나테크TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006650",
+    "name": "대한유화",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006660",
+    "name": "삼성공조",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0066W0",
+    "name": "SOL 국제금",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006740",
+    "name": "블루산업개발",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0067V0",
+    "name": "TIGER 차이나글로벌리더스TOP3+",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0067Y0",
+    "name": "TIGER 차이나AI소프트웨어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006800",
+    "name": "미래에셋증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006805",
+    "name": "미래에셋증권우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "00680K",
+    "name": "미래에셋증권2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006840",
+    "name": "AK홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006880",
+    "name": "신송홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006890",
+    "name": "태경케미컬",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0068M0",
+    "name": "KODEX 미국S&P500버퍼6월액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "006980",
+    "name": "우성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0069M0",
+    "name": "1Q 미국나스닥100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007070",
+    "name": "GS리테일",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007110",
+    "name": "일신석재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007120",
+    "name": "미래아이앤지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007160",
+    "name": "사조산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007210",
+    "name": "벽산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007280",
+    "name": "한국특강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0072R0",
+    "name": "TIGER KRX금현물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007310",
+    "name": "오뚜기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007340",
+    "name": "DN오토모티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0073X0",
+    "name": "FOCUS 알리바바미국채커버드콜혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007460",
+    "name": "에이프로젠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0074K0",
+    "name": "KoAct K수출핵심기업TOP30액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007540",
+    "name": "샘표",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007570",
+    "name": "일양약품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007575",
+    "name": "일양약품우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007590",
+    "name": "동방아그로",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007610",
+    "name": "선도전기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007660",
+    "name": "이수페타시스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007690",
+    "name": "국도화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007700",
+    "name": "F&F홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007810",
+    "name": "코리아써키트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007815",
+    "name": "코리아써우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "00781K",
+    "name": "코리아써키트2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007860",
+    "name": "서연",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0078V0",
+    "name": "PLUS 미국로보택시",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "007980",
+    "name": "TP",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0079X0",
+    "name": "ACE BYD밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008040",
+    "name": "사조동아원",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008060",
+    "name": "대덕",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "00806K",
+    "name": "대덕1우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0080G0",
+    "name": "KODEX 방산TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0080X0",
+    "name": "SOL 미국S&P500미국채혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0080Y0",
+    "name": "SOL 조선TOP3플러스레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008250",
+    "name": "이건산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008260",
+    "name": "NI스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0082F0",
+    "name": "HANARO 유럽방산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0082V0",
+    "name": "KODEX TDF2060액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008350",
+    "name": "남선알미늄",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008355",
+    "name": "남선알미우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0083S0",
+    "name": "1Q 미국메디컬AI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008420",
+    "name": "문배철강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008490",
+    "name": "서흥",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0084D0",
+    "name": "KIWOOM 미국테크100월간목표헤지액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0084E0",
+    "name": "KIWOOM 미국대형주500월간목표헤지액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008500",
+    "name": "일정실업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0085N0",
+    "name": "ACE 미국10년국채액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0085P0",
+    "name": "ACE 미국10년국채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008600",
+    "name": "윌비스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0086B0",
+    "name": "TIGER 리츠부동산인프라TOP10액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0086C0",
+    "name": "TIGER 리츠부동산인프라10채권혼합액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008700",
+    "name": "아남전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008730",
+    "name": "율촌화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008770",
+    "name": "호텔신라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008775",
+    "name": "호텔신라우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0087F0",
+    "name": "ACE 차이나AI빅테크TOP2+액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008870",
+    "name": "금비",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0088N0",
+    "name": "WON K-글로벌수급상위",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008930",
+    "name": "한미사이언스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "008970",
+    "name": "KBI동양철관",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0089B0",
+    "name": "PLUS 미국나스닥100미국채혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0089C0",
+    "name": "KODEX 미국S&P500변동성확대시커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0089D0",
+    "name": "KODEX 금융고배당TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009070",
+    "name": "KCTC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0090B0",
+    "name": "PLUS K방산소부장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009140",
+    "name": "경인전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009150",
+    "name": "삼성전기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009155",
+    "name": "삼성전기우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009160",
+    "name": "SIMPAC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009180",
+    "name": "한솔로지스틱스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009190",
+    "name": "대양금속",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0091C0",
+    "name": "KODEX 미국10년국채액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0091M0",
+    "name": "HANARO 27-06 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0091P0",
+    "name": "TIGER 코리아원자력",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009200",
+    "name": "무림페이퍼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009240",
+    "name": "한샘",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009270",
+    "name": "신원",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009290",
+    "name": "광동제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0092B0",
+    "name": "SOL 한국원자력SMR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0092C0",
+    "name": "SOL 27-12 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009310",
+    "name": "참엔지니어링",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009320",
+    "name": "아진전자부품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0093A0",
+    "name": "RISE AI반도체TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0093B0",
+    "name": "RISE 엔비디아고정테크100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0093D0",
+    "name": "KoAct 팔란티어밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009410",
+    "name": "태영건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009415",
+    "name": "태영건설우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009420",
+    "name": "한올바이오파마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009440",
+    "name": "KC그린홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009450",
+    "name": "경동나비엔",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009460",
+    "name": "한창제지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009470",
+    "name": "삼화전기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0094K0",
+    "name": "TIGER 28-04 회사채(A+이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0094L0",
+    "name": "RISE 차이나테크TOP10위클리타겟커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0094M0",
+    "name": "RISE 코리아밸류업위클리고정커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0094X0",
+    "name": "1Q 샤오미밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009540",
+    "name": "HD한국조선해양",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009580",
+    "name": "무림P&P",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009680",
+    "name": "모토닉",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009770",
+    "name": "삼정펄프",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0097L0",
+    "name": "KIWOOM 한국고배당&미국AI테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009810",
+    "name": "플레이그램",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009830",
+    "name": "한화솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009835",
+    "name": "한화솔루션우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0098F0",
+    "name": "KODEX 원자력SMR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0098N0",
+    "name": "PLUS 자사주매입고배당주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0098Z0",
+    "name": "FOCUS 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009900",
+    "name": "명신산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "009970",
+    "name": "영원무역홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0099L0",
+    "name": "ACE 우량회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010040",
+    "name": "한국내화",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010060",
+    "name": "OCI홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0100K0",
+    "name": "KODEX 방산TOP10레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010100",
+    "name": "한국무브넥스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010120",
+    "name": "LS ELECTRIC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010130",
+    "name": "고려아연",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010140",
+    "name": "삼성중공업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0101N0",
+    "name": "RISE AI전력인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0102A0",
+    "name": "TIGER 미국AI소프트웨어TOP4Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0102X0",
+    "name": "ACE 유럽방산TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0103T0",
+    "name": "1Q K소버린AI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010400",
+    "name": "우진아이엔에스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0104G0",
+    "name": "PLUS K방산레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0104H0",
+    "name": "KoAct 미국나스닥채권혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0104N0",
+    "name": "TIGER 200타겟위클리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0104P0",
+    "name": "TIGER 코리아배당다우존스위클리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010580",
+    "name": "에스엠벡셀",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0105D0",
+    "name": "SOL 한국AI소프트웨어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0105E0",
+    "name": "SOL 코리아고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010640",
+    "name": "진양폴리",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010660",
+    "name": "화천기계",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010690",
+    "name": "화신",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0106J0",
+    "name": "대신 KOSPI200인덱스 X클래스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010770",
+    "name": "평화홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010780",
+    "name": "아이에스동서",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0107F0",
+    "name": "KIWOOM 미국고배당&AI테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010820",
+    "name": "퍼스텍",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010950",
+    "name": "S-Oil",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010955",
+    "name": "S-Oil우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "010960",
+    "name": "삼호개발",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011000",
+    "name": "진원생명과학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011070",
+    "name": "LG이노텍",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011090",
+    "name": "에넥스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011150",
+    "name": "CJ씨푸드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011155",
+    "name": "CJ씨푸드1우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011170",
+    "name": "롯데케미칼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0111J0",
+    "name": "HANARO 증권고배당TOP3플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0111P0",
+    "name": "1Q 미국나스닥100미국채혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011200",
+    "name": "HMM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011210",
+    "name": "현대위아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011230",
+    "name": "삼화전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011280",
+    "name": "태림포장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0112X0",
+    "name": "마이티 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011300",
+    "name": "우성머티리얼스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011330",
+    "name": "유니켐",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011390",
+    "name": "부산산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0113D0",
+    "name": "TIME 글로벌탑픽액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0113G0",
+    "name": "KoAct 미국바이오헬스케어액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0113P0",
+    "name": "HK 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011420",
+    "name": "갤럭시아에스엠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0114X0",
+    "name": "RISE 글로벌게임테크TOP3Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011500",
+    "name": "한농화성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0115C0",
+    "name": "RISE 미국고배당다우존스TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0115D0",
+    "name": "KODEX 조선TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0115E0",
+    "name": "KODEX 코리아소버린AI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011690",
+    "name": "와이투솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011700",
+    "name": "한신기계",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011760",
+    "name": "현대코퍼레이션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011780",
+    "name": "금호석유화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011785",
+    "name": "금호석유화학우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011790",
+    "name": "SKC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0117L0",
+    "name": "KODEX 26-12 금융채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0117V0",
+    "name": "TIGER 코리아AI전력기기TOP3플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011810",
+    "name": "STX",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0118S0",
+    "name": "SOL 미국넥스트테크TOP10액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0118Z0",
+    "name": "ACE 미국AI테크핵심산업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "011930",
+    "name": "신성이엔지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0119H0",
+    "name": "KODEX 28-12 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012030",
+    "name": "DB",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0120G0",
+    "name": "삼양바이오팜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0120J0",
+    "name": "BNK 카카오그룹포커스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0120X0",
+    "name": "유진 챔피언중단기크레딧 X클래스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012160",
+    "name": "영흥",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012170",
+    "name": "아센디오",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012200",
+    "name": "계양전기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012205",
+    "name": "계양전기우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012280",
+    "name": "영화금속",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0122W0",
+    "name": "RISE 26-11 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012320",
+    "name": "경동인베스트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012330",
+    "name": "현대모비스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0123G0",
+    "name": "TIGER 미국AI전력SMR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0123S0",
+    "name": "HANARO 26-12 은행채(AA+이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012450",
+    "name": "한화에어로스페이스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012510",
+    "name": "더존비즈온",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012610",
+    "name": "경인양행",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012630",
+    "name": "HDC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012690",
+    "name": "모나리자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0126Z0",
+    "name": "삼성에피스홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012750",
+    "name": "에스원",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0127M0",
+    "name": "ACE 미국대형가치주액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0127P0",
+    "name": "ACE 미국대형성장주액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0127R0",
+    "name": "RISE 미국AI클라우드인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0127T0",
+    "name": "KIWOOM 미국S&P500&배당다우존스비중전환",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0127V0",
+    "name": "KIWOOM 미국S&P500 TOP10&배당다우비중전",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "012800",
+    "name": "대창",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0128D0",
+    "name": "PLUS 차이나항셍테크위클리타겟커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "013000",
+    "name": "세우글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0131A0",
+    "name": "SOL 차이나소비트렌드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0131V0",
+    "name": "1Q 미국우주항공테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0131W0",
+    "name": "1Q 단기특수은행채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0132D0",
+    "name": "KoAct 글로벌K컬처밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0132H0",
+    "name": "KODEX 미국원자력SMR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0132K0",
+    "name": "PLUS 테슬라위클리커버드콜채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "013360",
+    "name": "일성건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0133E0",
+    "name": "TIGER 차이나증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "013520",
+    "name": "화승코퍼레이션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "013570",
+    "name": "디와이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "013580",
+    "name": "계룡건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0135Y0",
+    "name": "IBK 중기종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "013700",
+    "name": "까뮤이앤씨",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0137V0",
+    "name": "KIWOOM 미국S&P500모멘텀",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0137W0",
+    "name": "KIWOOM 미국S&P500&GOLD",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "013870",
+    "name": "지엠비코리아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "013890",
+    "name": "지누스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0138D0",
+    "name": "RISE 동학개미",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0138T0",
+    "name": "RISE 미국S&P500데일리고정커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0138Y0",
+    "name": "PLUS 금채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0139F0",
+    "name": "TIGER 12월자동연장금융채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0139P0",
+    "name": "ACE 고배당주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014130",
+    "name": "한익스프레스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014160",
+    "name": "대영포장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0141S0",
+    "name": "SOL 조선기자재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0141T0",
+    "name": "SOL 중기종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014280",
+    "name": "금강공업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014285",
+    "name": "금강공업우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0142D0",
+    "name": "TIGER 미국AI데이터센터TOP4Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014440",
+    "name": "영보화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0144L0",
+    "name": "KODEX 미국성장커버드콜액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0144M0",
+    "name": "KODEX 미국드론UAM TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014530",
+    "name": "극동유화",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014580",
+    "name": "태경비케이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014680",
+    "name": "한솔케미칼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014710",
+    "name": "사조씨푸드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014790",
+    "name": "HL D&I",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014820",
+    "name": "동원시스템즈",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014825",
+    "name": "동원시스템즈우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014830",
+    "name": "유니드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0148J0",
+    "name": "TIGER 코리아휴머노이드로봇산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014910",
+    "name": "성문전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014915",
+    "name": "성문전자우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "014990",
+    "name": "인디에프",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "015020",
+    "name": "이스타코",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0150K0",
+    "name": "KoAct 수소전력ESS인프라액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0151P0",
+    "name": "RISE 코리아전략산업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0151S0",
+    "name": "KODEX 미국AI반도체TOP3플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "015230",
+    "name": "대창단조",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "015260",
+    "name": "에이엔피",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0152E0",
+    "name": "SOL 배당성향탑픽액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "015360",
+    "name": "INVENI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0153K0",
+    "name": "KODEX 주주환원고배당주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0153P0",
+    "name": "ACE 리츠부동산인프라액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0153X0",
+    "name": "PLUS 미국고배당주액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0154F0",
+    "name": "WON 초대형IB&금융지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0154H0",
+    "name": "KoAct 차이나바이오헬스케어액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "015590",
+    "name": "DKME",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0155M0",
+    "name": "ACE 미국SMR원자력TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0155N0",
+    "name": "HANARO K휴머노이드테마TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "015760",
+    "name": "한국전력",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "015860",
+    "name": "일진홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "015890",
+    "name": "태경산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016090",
+    "name": "대현",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0162L0",
+    "name": "KODEX 차이나AI반도체TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0162M0",
+    "name": "KODEX 금융채1~2년(AA-이상)PLUS액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0162Y0",
+    "name": "TIME 코스닥액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0162Z0",
+    "name": "RISE 삼성전자SK하이닉스채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016360",
+    "name": "삼성증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016380",
+    "name": "KG스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0163Y0",
+    "name": "KoAct 코스닥액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016450",
+    "name": "한세예스24홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0164G0",
+    "name": "RISE 차이나AI반도체TOP4Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016580",
+    "name": "환인제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016590",
+    "name": "신대양제지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016610",
+    "name": "DB증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0166N0",
+    "name": "PLUS 코스닥150액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0166S0",
+    "name": "PLUS K제조업핵심기업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0166T0",
+    "name": "PLUS 글로벌저작권핵심기업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016710",
+    "name": "대성홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016740",
+    "name": "두올",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0167A0",
+    "name": "SOL AI반도체TOP2플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0167B0",
+    "name": "SOL 200타겟위클리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0167Z0",
+    "name": "KODEX 미국우주항공",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016800",
+    "name": "퍼시스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "016880",
+    "name": "웅진",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0168K0",
+    "name": "TIGER 기술이전바이오액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017040",
+    "name": "광명전기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017180",
+    "name": "명문제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0172V0",
+    "name": "1Q 은액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0172Y0",
+    "name": "ACE K수출핵심TOP10산업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017370",
+    "name": "우신시스템",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017390",
+    "name": "서울가스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0173Y0",
+    "name": "KODEX 미국AI광통신네트워크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0174B0",
+    "name": "KoAct 글로벌AI메모리반도체액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0174J0",
+    "name": "DAISHIN343 오피스리츠플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0174R0",
+    "name": "KIWOOM 미국성장다우존스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017550",
+    "name": "수산세보틱스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017670",
+    "name": "SK텔레콤",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0176E0",
+    "name": "RISE 미국AI전력인프라액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0176P0",
+    "name": "FOCUS AI반도체위클리고정커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0177A0",
+    "name": "WON 두산그룹포커스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0177N0",
+    "name": "KODEX 삼성전자SK하이닉스채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0177R0",
+    "name": "TIGER 반도체TOP10커버드콜액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0177X0",
+    "name": "ACE K휴머노이드로봇산업TOP2+",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017800",
+    "name": "현대엘리베이터",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017810",
+    "name": "풀무원",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017860",
+    "name": "DS단석",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0178H0",
+    "name": "IBK 미국AI TOP10국채혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017900",
+    "name": "광전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017940",
+    "name": "E1",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "017960",
+    "name": "한국카본",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0180V0",
+    "name": "ACE 미국우주테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0181B0",
+    "name": "HANARO 미국AI메모리반도체TOP4+",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0181L0",
+    "name": "SOL 미국우주항공TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "018250",
+    "name": "애경산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "018260",
+    "name": "삼성에스디에스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0182R0",
+    "name": "1Q K반도체TOP2+",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0182S0",
+    "name": "1Q K반도체TOP2채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0183J0",
+    "name": "TIGER 미국우주테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0183V0",
+    "name": "KIWOOM 삼성전자&SK하이닉스채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "018470",
+    "name": "조일알미늄",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0184E0",
+    "name": "1Q 200채권혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0184L0",
+    "name": "PLUS 중기종합채권(A-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0184N0",
+    "name": "PLUS 은채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0184V0",
+    "name": "UNICORN 코스닥바이오액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "018500",
+    "name": "동원금속",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0185L0",
+    "name": "TIME 글로벌휴머노이드로봇산업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "018670",
+    "name": "SK가스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0186L0",
+    "name": "KoAct 미국로봇피지컬AI액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0186S0",
+    "name": "1Q 코스닥150채권혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "018880",
+    "name": "한온시스템",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0189B0",
+    "name": "TIGER 은액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0190C0",
+    "name": "RISE 현대차고정피지컬AI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0190G0",
+    "name": "KODEX 반도체타겟위클리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0190M0",
+    "name": "KIWOOM 미국AI테크하이베타",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0190Y0",
+    "name": "TIGER 구글밸류체인",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "019170",
+    "name": "신풍제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "019175",
+    "name": "신풍제약우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "019180",
+    "name": "티에이치엔",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0191B0",
+    "name": "MIDAS 코스닥액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0191S0",
+    "name": "IBK 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0191W0",
+    "name": "HANARO 중기종합채권(A-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0192S0",
+    "name": "SOL 코스피200채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0192T0",
+    "name": "SOL 코스닥TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0192Z0",
+    "name": "TIGER 중기종합채권(A-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "0193G0",
+    "name": "KoAct 코스피액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "019490",
+    "name": "엑시큐어하이트론",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "019680",
+    "name": "대교",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "019685",
+    "name": "대교우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "020000",
+    "name": "한섬",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "020120",
+    "name": "키다리스튜디오",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "020150",
+    "name": "롯데에너지머티리얼즈",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "020560",
+    "name": "아시아나항공",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "020760",
+    "name": "일진디스플",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "021050",
+    "name": "서원",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "021240",
+    "name": "코웨이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "021820",
+    "name": "세원정공",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "022100",
+    "name": "포스코DX",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023000",
+    "name": "삼원강재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023150",
+    "name": "MH에탄올",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023350",
+    "name": "한국종합기술",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023450",
+    "name": "동남합성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023530",
+    "name": "롯데쇼핑",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023590",
+    "name": "다우기술",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023800",
+    "name": "인지컨트롤스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023810",
+    "name": "인팩",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "023960",
+    "name": "에쓰씨엔지니어링",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "024070",
+    "name": "WISCOM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "024090",
+    "name": "디씨엠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "024110",
+    "name": "기업은행",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "024720",
+    "name": "콜마홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "024890",
+    "name": "대원화성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "024900",
+    "name": "디와이덕양",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025000",
+    "name": "KPX케미칼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025530",
+    "name": "SJM홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025540",
+    "name": "한국단자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025560",
+    "name": "미래산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025620",
+    "name": "차AI헬스케어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025750",
+    "name": "한솔홈데코",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025820",
+    "name": "이구산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025860",
+    "name": "남해화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "025890",
+    "name": "한국주강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "026890",
+    "name": "스틱인베스트먼트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "026940",
+    "name": "부국철강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "026960",
+    "name": "동서",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "027410",
+    "name": "BGF",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "027740",
+    "name": "마니커",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "027970",
+    "name": "한국제지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "028050",
+    "name": "삼성E&A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "028100",
+    "name": "동아지질",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "028260",
+    "name": "삼성물산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "02826K",
+    "name": "삼성물산우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "028670",
+    "name": "팬오션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "029460",
+    "name": "케이씨",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "029530",
+    "name": "신도리코",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "029780",
+    "name": "삼성카드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "030000",
+    "name": "제일기획",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "030190",
+    "name": "NICE평가정보",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "030200",
+    "name": "KT",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "030210",
+    "name": "다올투자증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "030610",
+    "name": "교보증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "030720",
+    "name": "동원수산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "031210",
+    "name": "서울보증보험",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "031430",
+    "name": "신세계인터내셔날",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "031440",
+    "name": "신세계푸드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "031820",
+    "name": "아이티센씨티에스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "032350",
+    "name": "롯데관광개발",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "032560",
+    "name": "황금에스티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "032640",
+    "name": "LG유플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "032830",
+    "name": "삼성생명",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "033240",
+    "name": "자화전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "033250",
+    "name": "체시스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "033270",
+    "name": "유나이티드제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "033530",
+    "name": "SJG세종",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "033780",
+    "name": "KT&G",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "033920",
+    "name": "무학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "034020",
+    "name": "두산에너빌리티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "034120",
+    "name": "SBS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "034220",
+    "name": "LG디스플레이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "034230",
+    "name": "파라다이스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "034310",
+    "name": "NICE",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "034590",
+    "name": "인천도시가스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "034730",
+    "name": "SK",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "03473K",
+    "name": "SK우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "034830",
+    "name": "한국토지신탁",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "035000",
+    "name": "HS애드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "035150",
+    "name": "백산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "035250",
+    "name": "강원랜드",
+    "market": "KOSPI",
+    "aliases": []
   },
   {
     "code": "035420",
     "name": "NAVER",
     "market": "KOSPI",
-    "aliases": ["네이버"]
+    "aliases": [
+      "네이버"
+    ]
+  },
+  {
+    "code": "035510",
+    "name": "신세계 I&C",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "035720",
+    "name": "카카오",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "036420",
+    "name": "콘텐트리중앙",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "036460",
+    "name": "한국가스공사",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "036530",
+    "name": "SNT홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "036570",
+    "name": "NC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "036580",
+    "name": "팜스코",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "037270",
+    "name": "YG PLUS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "037560",
+    "name": "LG헬로비전",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "037710",
+    "name": "광주신세계",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "039130",
+    "name": "하나투어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "039490",
+    "name": "키움증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "039570",
+    "name": "HDC랩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "041650",
+    "name": "상신브레이크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "042660",
+    "name": "한화오션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "042700",
+    "name": "한미반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "044380",
+    "name": "주연테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "044450",
+    "name": "KSS해운",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "044820",
+    "name": "코스맥스비티아이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "047040",
+    "name": "대우건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "047050",
+    "name": "포스코인터내셔널",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "047400",
+    "name": "유니온머티리얼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "047810",
+    "name": "한국항공우주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "049800",
+    "name": "우진플라임",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "051600",
+    "name": "한전KPS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "051630",
+    "name": "진양화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "051900",
+    "name": "LG생활건강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "051905",
+    "name": "LG생활건강우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "051910",
+    "name": "LG화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "051915",
+    "name": "LG화학우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "052690",
+    "name": "한전기술",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "053210",
+    "name": "스카이라이프",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "053690",
+    "name": "한미글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "055490",
+    "name": "테이팩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "055550",
+    "name": "신한지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "057050",
+    "name": "현대홈쇼핑",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "058430",
+    "name": "포스코스틸리온",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "058650",
+    "name": "세아홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "058730",
+    "name": "다스코",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "058850",
+    "name": "KTcs",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "058860",
+    "name": "KTis",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "060980",
+    "name": "HL홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "062040",
+    "name": "산일전기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "063160",
+    "name": "종근당바이오",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "064350",
+    "name": "현대로템",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "064400",
+    "name": "LG씨엔에스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "064960",
+    "name": "SNT모티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "066570",
+    "name": "LG전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "066575",
+    "name": "LG전자우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "066970",
+    "name": "엘앤에프",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "067830",
+    "name": "세이브존I&C",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "068270",
+    "name": "셀트리온",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "068290",
+    "name": "삼성출판사",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "069260",
+    "name": "TKG휴켐스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "069460",
+    "name": "대호에이엘",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "069500",
+    "name": "KODEX 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "069620",
+    "name": "대웅제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "069640",
+    "name": "한세엠케이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "069660",
+    "name": "KIWOOM 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "069730",
+    "name": "DSR제강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "069960",
+    "name": "현대백화점",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "070960",
+    "name": "모나용평",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "071050",
+    "name": "한국금융지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "071055",
+    "name": "한국금융지주우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "071090",
+    "name": "하이스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "071320",
+    "name": "지역난방공사",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "071840",
+    "name": "롯데하이마트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "071950",
+    "name": "코아스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "071970",
+    "name": "HD현대마린엔진",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "072130",
+    "name": "유엔젤",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "072710",
+    "name": "농심홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "073240",
+    "name": "금호타이어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "074610",
+    "name": "이엔플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "075180",
+    "name": "새론오토모티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "075580",
+    "name": "세진중공업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "077500",
+    "name": "유니퀘스트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "077970",
+    "name": "STX엔진",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "078000",
+    "name": "텔코웨어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "078520",
+    "name": "에이블씨엔씨",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "078930",
+    "name": "GS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "078935",
+    "name": "GS우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "079160",
+    "name": "CJ CGV",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "079430",
+    "name": "현대리바트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "079550",
+    "name": "LIG디펜스앤에어로스페이스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "079900",
+    "name": "전진건설로봇",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "079980",
+    "name": "휴비스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "081000",
+    "name": "일진다이아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "081660",
+    "name": "미스토홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "082640",
+    "name": "동양생명",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "082740",
+    "name": "한화엔진",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "083420",
+    "name": "그린케미칼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "084010",
+    "name": "대한제강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "084670",
+    "name": "동양고속",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "084680",
+    "name": "이월드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "084690",
+    "name": "대상홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "084695",
+    "name": "대상홀딩스우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "084870",
+    "name": "TBH글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "085310",
+    "name": "엔케이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "085620",
+    "name": "미래에셋생명",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "086280",
+    "name": "현대글로비스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "086790",
+    "name": "하나금융지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "088260",
+    "name": "이리츠코크렙",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "088350",
+    "name": "한화생명",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "088790",
+    "name": "진도",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "088980",
+    "name": "맥쿼리인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "089470",
+    "name": "HDC현대EP",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "089590",
+    "name": "제주항공",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "089860",
+    "name": "롯데렌탈",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "090080",
+    "name": "평화산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "090350",
+    "name": "노루페인트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "090355",
+    "name": "노루페인트우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "090370",
+    "name": "메타랩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "090430",
+    "name": "아모레퍼시픽",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "090435",
+    "name": "아모레퍼시픽우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "090460",
+    "name": "비에이치",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "091160",
+    "name": "KODEX 반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "091170",
+    "name": "KODEX 은행",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "091180",
+    "name": "KODEX 자동차",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "091220",
+    "name": "TIGER 은행",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "091230",
+    "name": "TIGER 반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "091810",
+    "name": "트리니티항공",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "092200",
+    "name": "디아이씨",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "092220",
+    "name": "KEC",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "092230",
+    "name": "KPX홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "092440",
+    "name": "기신정기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "092780",
+    "name": "DYP",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "092790",
+    "name": "넥스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "093050",
+    "name": "LF",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "093240",
+    "name": "형지엘리트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "093370",
+    "name": "후성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "094280",
+    "name": "효성ITX",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "094800",
+    "name": "맵스리얼티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "095570",
+    "name": "AJ네트웍스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "095720",
+    "name": "웅진씽크빅",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "096760",
+    "name": "JW홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "096770",
+    "name": "SK이노베이션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "096775",
+    "name": "SK이노베이션우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "097230",
+    "name": "HJ중공업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "097520",
+    "name": "엠씨넥스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "097950",
+    "name": "CJ제일제당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "097955",
+    "name": "CJ제일제당 우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "099140",
+    "name": "KODEX 차이나H",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "100090",
+    "name": "SK오션플랜트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "100220",
+    "name": "비상교육",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "100250",
+    "name": "진양홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "100840",
+    "name": "SNT에너지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "100910",
+    "name": "KIWOOM KRX100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "101140",
+    "name": "인바이오젠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "101280",
+    "name": "KODEX 일본TOPIX100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "101530",
+    "name": "해태제과식품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "102110",
+    "name": "TIGER 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "102260",
+    "name": "동성케미컬",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "102460",
+    "name": "이연제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "102780",
+    "name": "KODEX 삼성그룹",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "102960",
+    "name": "KODEX 기계장비",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "102970",
+    "name": "KODEX 증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "103140",
+    "name": "풍산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "103590",
+    "name": "일진전기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "104520",
+    "name": "KIWOOM 블루칩",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "104530",
+    "name": "KIWOOM 코리아고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "104700",
+    "name": "한국철강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "105010",
+    "name": "TIGER 라틴35",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "105190",
+    "name": "ACE 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "105560",
+    "name": "KB금융",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "105630",
+    "name": "한세실업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "105780",
+    "name": "RISE 5대그룹주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "105840",
+    "name": "우진",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "107590",
+    "name": "미원홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "108320",
+    "name": "LX세미콘",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "108450",
+    "name": "ACE 삼성그룹섹터가중",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "108590",
+    "name": "TREX 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "108670",
+    "name": "LX하우시스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "108675",
+    "name": "LX하우시스우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "109070",
+    "name": "주성코퍼레이션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "111110",
+    "name": "호전실업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "111380",
+    "name": "동인기연",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "111770",
+    "name": "영원무역",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "112610",
+    "name": "씨에스윈드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "114090",
+    "name": "GKL",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "114100",
+    "name": "RISE 국고채3년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "114260",
+    "name": "KODEX 국고채3년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "114460",
+    "name": "ACE 국고채3년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "114470",
+    "name": "KIWOOM 국고채3년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "114800",
+    "name": "KODEX 인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "114820",
+    "name": "TIGER 국채3년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "117460",
+    "name": "KODEX 에너지화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "117580",
+    "name": "대성에너지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "117680",
+    "name": "KODEX 철강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "117690",
+    "name": "TIGER 차이나항셍30",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "117700",
+    "name": "KODEX 건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "118000",
+    "name": "메타케어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "119650",
+    "name": "KC코트렐",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "120030",
+    "name": "조선선재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "120110",
+    "name": "코오롱인더",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "120115",
+    "name": "코오롱인더우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "122090",
+    "name": "PLUS 코스피50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "122260",
+    "name": "KIWOOM 통안채1년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "122630",
+    "name": "KODEX 레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "122900",
+    "name": "아이마켓코리아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "123310",
+    "name": "TIGER 인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "123320",
+    "name": "TIGER 레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "123690",
+    "name": "한국화장품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "123700",
+    "name": "SJM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "123890",
+    "name": "한국자산신탁",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "126560",
+    "name": "현대퓨처넷",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "126720",
+    "name": "수산인더스트리",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "128820",
+    "name": "대성산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "128940",
+    "name": "한미약품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "129260",
+    "name": "인터지스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "130660",
+    "name": "한전산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "130680",
+    "name": "TIGER 원유선물Enhanced(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "130730",
+    "name": "KIWOOM 단기자금",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "131890",
+    "name": "ACE 삼성그룹동일가중",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "132030",
+    "name": "KODEX 골드선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "133690",
+    "name": "TIGER 미국나스닥100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "133820",
+    "name": "화인베스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "134380",
+    "name": "미원화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "134790",
+    "name": "시디즈",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "136340",
+    "name": "RISE 중기우량회사채",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "136490",
+    "name": "선진",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "137310",
+    "name": "에스디바이오센서",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "137610",
+    "name": "TIGER 농산물선물Enhanced(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "138040",
+    "name": "메리츠금융지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "138230",
+    "name": "KIWOOM 미국달러선물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "138520",
+    "name": "TIGER 삼성그룹",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "138530",
+    "name": "TIGER LG그룹플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "138540",
+    "name": "TIGER 현대차그룹플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "138910",
+    "name": "KODEX 구리선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "138920",
+    "name": "KODEX 콩선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "138930",
+    "name": "BNK금융지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139130",
+    "name": "iM금융지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139220",
+    "name": "TIGER 200 건설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139230",
+    "name": "TIGER 200 중공업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139240",
+    "name": "TIGER 200 철강소재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139250",
+    "name": "TIGER 200 에너지화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139260",
+    "name": "TIGER 200 IT",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139270",
+    "name": "TIGER 200 금융",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139280",
+    "name": "TIGER 경기방어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139290",
+    "name": "TIGER 200 경기소비재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139320",
+    "name": "TIGER 금은선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139480",
+    "name": "이마트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139660",
+    "name": "KIWOOM 미국달러선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "139990",
+    "name": "아주스틸",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "140570",
+    "name": "RISE 수출주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "140580",
+    "name": "RISE 우량업종대표주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "140700",
+    "name": "KODEX 보험",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "140710",
+    "name": "KODEX 운송",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "140910",
+    "name": "에이리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "140950",
+    "name": "파워 코스피100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "143210",
+    "name": "핸즈코퍼레이션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "143850",
+    "name": "TIGER 미국S&P500선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "143860",
+    "name": "TIGER 헬스케어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "144600",
+    "name": "KODEX 은선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "145210",
+    "name": "다이나믹디자인",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "145270",
+    "name": "케이탑리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "145670",
+    "name": "ACE 인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "145720",
+    "name": "덴티움",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "145850",
+    "name": "TREX 펀더멘탈 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "145990",
+    "name": "삼양사",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "145995",
+    "name": "삼양사우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "147970",
+    "name": "TIGER 모멘텀",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "148020",
+    "name": "RISE 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "148070",
+    "name": "KIWOOM 국고채10년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "150460",
+    "name": "TIGER 중국소비테마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "152100",
+    "name": "PLUS 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "152380",
+    "name": "KODEX 국채선물10년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "152500",
+    "name": "ACE 레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "152870",
+    "name": "파워 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "153130",
+    "name": "KODEX 단기채권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "153270",
+    "name": "KIWOOM 코스피100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "155660",
+    "name": "DSR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "156080",
+    "name": "KODEX MSCI Korea",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "157450",
+    "name": "TIGER 단기통안채",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "157490",
+    "name": "TIGER 소프트웨어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "157500",
+    "name": "TIGER 증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "159800",
+    "name": "마이티 코스피100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "160580",
+    "name": "TIGER 구리실물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "161000",
+    "name": "애경케미칼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "161390",
+    "name": "한국타이어앤테크놀로지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "161510",
+    "name": "PLUS 고배당주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "161890",
+    "name": "한국콜마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "163560",
+    "name": "동일고무벨트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "166400",
+    "name": "TIGER 200커버드콜OTM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "167860",
+    "name": "KIWOOM 국고채10년레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "168580",
+    "name": "ACE 중국본토CSI300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "169950",
+    "name": "KODEX 차이나A50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "170900",
+    "name": "동아에스티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "174350",
+    "name": "TIGER 로우볼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "174360",
+    "name": "RISE 중국본토대형주CSI100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "175330",
+    "name": "JB금융지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "176950",
+    "name": "KODEX 국채선물10년인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "178920",
+    "name": "PI첨단소재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "180640",
+    "name": "한진칼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "18064K",
+    "name": "한진칼우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "181480",
+    "name": "ACE 미국부동산리츠(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "181710",
+    "name": "NHN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "182480",
+    "name": "TIGER 미국MSCI리츠(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "182490",
+    "name": "TIGER 단기선진하이일드(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "183190",
+    "name": "아세아시멘트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "183700",
+    "name": "RISE 200채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "183710",
+    "name": "RISE 주식혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "185680",
+    "name": "KODEX 미국S&P바이오(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "185750",
+    "name": "종근당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "189400",
+    "name": "PLUS 글로벌MSCI(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "190620",
+    "name": "ACE 단기통안채",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "192080",
+    "name": "더블유게임즈",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "192090",
+    "name": "TIGER 차이나CSI300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "192400",
+    "name": "쿠쿠홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "192650",
+    "name": "드림텍",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "192720",
+    "name": "파워 고배당저변동성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "192820",
+    "name": "코스맥스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "194370",
+    "name": "제이에스코퍼레이션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "195870",
+    "name": "해성디에스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "195920",
+    "name": "TIGER 일본TOPIX(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "195930",
+    "name": "TIGER 유로스탁스50(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "195970",
+    "name": "PLUS 선진국MSCI(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "195980",
+    "name": "PLUS 신흥국MSCI(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "196030",
+    "name": "ACE 일본TOPIX레버리지(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "196230",
+    "name": "RISE 단기통안채",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "200030",
+    "name": "KODEX 미국S&P500산업재(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "200250",
+    "name": "KIWOOM 인도Nifty50(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "200880",
+    "name": "서연이화",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "203780",
+    "name": "TIGER 미국나스닥바이오",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "204210",
+    "name": "JK리버스톤리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "204320",
+    "name": "HL만도",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "204450",
+    "name": "KODEX 차이나H레버리지(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "204480",
+    "name": "TIGER 차이나CSI300레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "205720",
+    "name": "ACE 일본TOPIX인버스(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "207940",
+    "name": "삼성바이오로직스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "210540",
+    "name": "디와이파워",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "210780",
+    "name": "TIGER 코스피고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "210980",
+    "name": "SK디앤디",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "211560",
+    "name": "TIGER 배당성장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "211900",
+    "name": "KODEX 코리아배당성장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "213500",
+    "name": "한솔제지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "213610",
+    "name": "KODEX 삼성그룹밸류",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "213630",
+    "name": "PLUS 미국다우존스고배당주(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "214320",
+    "name": "이노션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "214330",
+    "name": "금호에이치티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "214390",
+    "name": "경보제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "214420",
+    "name": "토니모리",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "214980",
+    "name": "KODEX 단기채권PLUS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "215620",
+    "name": "HK S&P코리아로우볼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "217590",
+    "name": "티엠씨",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "217770",
+    "name": "TIGER 원유선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "217780",
+    "name": "TIGER 차이나CSI300인버스(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "218420",
+    "name": "KODEX 미국S&P500에너지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "219390",
+    "name": "RISE 미국S&P원유생산기업(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "219480",
+    "name": "KODEX 미국S&P500선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "219900",
+    "name": "ACE 중국본토CSI300레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "220130",
+    "name": "SOL 차이나강소기업CSI500(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "223190",
+    "name": "KODEX 200가치저변동",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "225030",
+    "name": "TIGER 미국S&P500선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "225040",
+    "name": "TIGER 미국S&P500레버리지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "225050",
+    "name": "TIGER 유로스탁스레버리지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "225060",
+    "name": "TIGER 이머징마켓MSCI레버리지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "225130",
+    "name": "ACE 골드선물 레버리지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "225800",
+    "name": "KIWOOM 미국달러선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "226320",
+    "name": "잇츠한불",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "226380",
+    "name": "ACE Fn성장소비주도주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "226490",
+    "name": "KODEX 코스피",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "226980",
+    "name": "KODEX 200 중소형",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "227540",
+    "name": "TIGER 200 헬스케어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "227550",
+    "name": "TIGER 200 산업재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "227560",
+    "name": "TIGER 200 생활소비재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "227570",
+    "name": "TIGER 우량가치",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "227830",
+    "name": "PLUS 코스피",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "227840",
+    "name": "현대코퍼레이션홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "228790",
+    "name": "TIGER 화장품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "228800",
+    "name": "TIGER 여행레저",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "228810",
+    "name": "TIGER 미디어컨텐츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "228820",
+    "name": "TIGER KTOP30",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "229200",
+    "name": "KODEX 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "229640",
+    "name": "LS에코에너지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "229720",
+    "name": "KODEX KTOP30",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "230480",
+    "name": "KIWOOM 미국달러선물인버스2X",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "232080",
+    "name": "TIGER 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "233160",
+    "name": "TIGER 코스닥150 레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "233740",
+    "name": "KODEX 코스닥150레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "234080",
+    "name": "JW생명과학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "234310",
+    "name": "RISE V&S셀렉트밸류",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "236350",
+    "name": "TIGER 인도니프티50레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "237350",
+    "name": "KODEX 코스피100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "237370",
+    "name": "KODEX 코리아배당성장채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "237440",
+    "name": "TIGER 경기방어채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "238670",
+    "name": "PLUS 스마트베타Quality채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "238720",
+    "name": "ACE 일본Nikkei225(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "239660",
+    "name": "PLUS 우량회사채50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "241180",
+    "name": "TIGER 일본니케이225",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "241390",
+    "name": "RISE V&S셀렉트밸류채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "241560",
+    "name": "두산밥캣",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "241590",
+    "name": "화승엔터프라이즈",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "243880",
+    "name": "TIGER 200IT레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "243890",
+    "name": "TIGER 200에너지화학레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "244580",
+    "name": "KODEX 바이오",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "244620",
+    "name": "KODEX 모멘텀Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "244660",
+    "name": "KODEX 퀄리티Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "244670",
+    "name": "KODEX 밸류Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "244920",
+    "name": "에이플러스에셋",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "245340",
+    "name": "TIGER 미국다우존스30",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "245350",
+    "name": "TIGER 유로스탁스배당30",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "245360",
+    "name": "TIGER 차이나HSCEI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "245710",
+    "name": "ACE 베트남VN30(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "248070",
+    "name": "솔루엠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "248170",
+    "name": "샘표식품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "248270",
+    "name": "TIGER S&P글로벌헬스케어(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "249420",
+    "name": "일동제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "250730",
+    "name": "RISE 차이나HSCEI(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "250780",
+    "name": "TIGER 코스닥150선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "251270",
+    "name": "넷마블",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "251340",
+    "name": "KODEX 코스닥150선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "251350",
+    "name": "KODEX MSCI선진국",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "251590",
+    "name": "PLUS 고배당저변동50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "251600",
+    "name": "PLUS 고배당주채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "252000",
+    "name": "TIGER 200동일가중",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "252400",
+    "name": "RISE 200선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "252410",
+    "name": "RISE 200선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "252420",
+    "name": "RISE 200선물인버스2X",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "252650",
+    "name": "KODEX 200동일가중",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "252670",
+    "name": "KODEX 200선물인버스2X",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "252710",
+    "name": "TIGER 200선물인버스2X",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "253150",
+    "name": "PLUS 200선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "253160",
+    "name": "PLUS 200선물인버스2X",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "253230",
+    "name": "KIWOOM 200선물인버스2X",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "253240",
+    "name": "KIWOOM 200선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "253250",
+    "name": "KIWOOM 200선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "253280",
+    "name": "RISE 헬스케어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "253290",
+    "name": "RISE 헬스케어채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "256440",
+    "name": "ACE MSCI인도네시아(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "256450",
+    "name": "PLUS 심천차이넥스트(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "256750",
+    "name": "KODEX 차이나심천ChiNext(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "259960",
+    "name": "크래프톤",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261060",
+    "name": "TIGER 코스닥150IT",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261070",
+    "name": "TIGER 코스닥150바이오테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261110",
+    "name": "TIGER 미국달러선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261120",
+    "name": "TIGER 미국달러선물인버스2X",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261140",
+    "name": "TIGER 우선주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261220",
+    "name": "KODEX WTI원유선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261240",
+    "name": "KODEX 미국달러선물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261250",
+    "name": "KODEX 미국달러선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261260",
+    "name": "KODEX 미국달러선물인버스2X",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261270",
+    "name": "KODEX 미국달러선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "261920",
+    "name": "ACE MSCI필리핀(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "264900",
+    "name": "크라운제과",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "26490K",
+    "name": "크라운제과우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "265690",
+    "name": "ACE 러시아MSCI(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "266160",
+    "name": "RISE 고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "266360",
+    "name": "KODEX K콘텐츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "266370",
+    "name": "KODEX IT",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "266390",
+    "name": "KODEX 경기소비재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "266410",
+    "name": "KODEX 필수소비재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "266420",
+    "name": "KODEX 헬스케어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "266550",
+    "name": "PLUS 중형주저변동50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267250",
+    "name": "HD현대",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267260",
+    "name": "HD현대일렉트릭",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267270",
+    "name": "HD건설기계",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267290",
+    "name": "경동도시가스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267440",
+    "name": "RISE 미국장기국채선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267450",
+    "name": "RISE 미국장기국채선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267490",
+    "name": "RISE 미국장기국채선물레버리지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267770",
+    "name": "TIGER 200선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "267850",
+    "name": "아시아나IDT",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "268280",
+    "name": "미원에스씨",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "269370",
+    "name": "TIGER S&P글로벌인프라(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "269420",
+    "name": "KODEX S&P글로벌인프라(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "269530",
+    "name": "PLUS S&P글로벌인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "269540",
+    "name": "PLUS 미국S&P500(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "270800",
+    "name": "RISE KQ고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "270810",
+    "name": "RISE 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "271050",
+    "name": "KODEX WTI원유선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "271060",
+    "name": "KODEX 3대농산물선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "271560",
+    "name": "오리온",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "271940",
+    "name": "일진하이솔루스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "271980",
+    "name": "제일약품",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "272210",
+    "name": "한화시스템",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "272450",
+    "name": "진에어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "272550",
+    "name": "삼양패키징",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "272560",
+    "name": "RISE 단기국공채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "272570",
+    "name": "RISE 중장기국공채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "272580",
+    "name": "TIGER 단기채권액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "272910",
+    "name": "ACE 중장기국공채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "273130",
+    "name": "KODEX 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "273140",
+    "name": "KODEX 단기변동금리부채권액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "275280",
+    "name": "KODEX 모멘텀주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "275290",
+    "name": "KODEX 가치주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "275300",
+    "name": "KODEX 우량주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "275750",
+    "name": "RISE 코스닥150선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "275980",
+    "name": "TIGER 글로벌4차산업혁신기술(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "276000",
+    "name": "TIGER 글로벌자원생산기업(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "276650",
+    "name": "RISE 글로벌테크놀로지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "276970",
+    "name": "KODEX 미국S&P500배당귀족커버드콜(합성 H",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "276990",
+    "name": "KODEX 글로벌로봇(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "277540",
+    "name": "ACE 아시아TOP50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "277630",
+    "name": "TIGER 코스피",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "277640",
+    "name": "TIGER 코스피대형주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "277650",
+    "name": "TIGER 코스피중형주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "278240",
+    "name": "RISE 코스닥150선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "278470",
+    "name": "에이피알",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "278530",
+    "name": "KODEX 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "278540",
+    "name": "KODEX MSCI Korea TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "278620",
+    "name": "PLUS 단기채권액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "279530",
+    "name": "KODEX 고배당주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "279540",
+    "name": "KODEX 최소변동성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "279570",
+    "name": "케이뱅크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "280320",
+    "name": "ACE 미국IT인터넷(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "280360",
+    "name": "롯데웰푸드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "280920",
+    "name": "PLUS 주도업종",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "280930",
+    "name": "KODEX 미국러셀2000(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "280940",
+    "name": "KODEX 골드선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "281820",
+    "name": "케이씨텍",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "281990",
+    "name": "RISE 중소형고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "282000",
+    "name": "RISE 국고채3년선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "282330",
+    "name": "BGF리테일",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "283580",
+    "name": "KODEX 차이나CSI300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "284430",
+    "name": "KODEX 200미국채혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "284740",
+    "name": "쿠쿠홈시스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "284980",
+    "name": "RISE 200금융",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "285130",
+    "name": "SK케미칼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "28513K",
+    "name": "SK케미칼우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "285690",
+    "name": "FOCUS ESG리더스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "286940",
+    "name": "롯데이노베이트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "287180",
+    "name": "PLUS 미국나스닥테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "289040",
+    "name": "KODEX MSCI KOREA ESG유니버설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "289250",
+    "name": "TIGER MSCI KOREA ESG유니버설",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "289260",
+    "name": "TIGER MSCI KOREA ESG리더스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "289480",
+    "name": "TIGER 200커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "289670",
+    "name": "PLUS 국채선물10년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "290080",
+    "name": "RISE 200고배당커버드콜ATM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "290130",
+    "name": "RISE ESG사회책임투자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "291130",
+    "name": "ACE MSCI멕시코(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "291620",
+    "name": "KIWOOM 코스닥150선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "291630",
+    "name": "KIWOOM 코스닥150선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "291680",
+    "name": "RISE 차이나H선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "291890",
+    "name": "KODEX MSCI EM선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "292050",
+    "name": "RISE KRX300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "292150",
+    "name": "TIGER 코리아TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "292160",
+    "name": "TIGER KRX300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "292190",
+    "name": "KODEX KRX300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "292500",
+    "name": "SOL KRX300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "292560",
+    "name": "TIGER 일본엔선물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "292770",
+    "name": "KODEX 국채선물3년인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "293180",
+    "name": "HANARO 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "293480",
+    "name": "하나제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "293940",
+    "name": "신한알파리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "294400",
+    "name": "KIWOOM 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "294870",
+    "name": "IPARK현대산업개발",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "295000",
+    "name": "RISE 국채선물10년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "295020",
+    "name": "RISE 국채선물10년인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "295040",
+    "name": "SOL 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "298000",
+    "name": "효성화학",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "298020",
+    "name": "효성티앤씨",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "298040",
+    "name": "효성중공업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "298050",
+    "name": "HS효성첨단소재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "298340",
+    "name": "PLUS 국채선물3년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "298690",
+    "name": "에어부산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "298770",
+    "name": "KODEX 한국대만IT프리미어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "300610",
+    "name": "TIGER K게임",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "300640",
+    "name": "RISE 게임테마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "300720",
+    "name": "한일시멘트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "300950",
+    "name": "KODEX 게임산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "301400",
+    "name": "PLUS 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "301410",
+    "name": "PLUS 코스닥150선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "302190",
+    "name": "TIGER 중장기국채",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "302440",
+    "name": "SK바이오사이언스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "302450",
+    "name": "RISE 코스피",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "304660",
+    "name": "KODEX 미국30년국채울트라선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "304670",
+    "name": "KODEX 미국30년국채울트라선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "304760",
+    "name": "HANARO KRX300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "304770",
+    "name": "HANARO 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "304780",
+    "name": "HANARO 200선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "304940",
+    "name": "KODEX 미국나스닥100선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "305050",
+    "name": "ACE 코스피",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "305080",
+    "name": "TIGER 미국채10년선물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "305540",
+    "name": "TIGER 2차전지테마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "305720",
+    "name": "KODEX 2차전지산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "306200",
+    "name": "세아제강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "306520",
+    "name": "HANARO 200선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "306530",
+    "name": "HANARO 코스닥150선물레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "306950",
+    "name": "KODEX KRX300레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "307510",
+    "name": "TIGER 의료기기",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "307520",
+    "name": "TIGER 지주회사",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "307950",
+    "name": "현대오토에버",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "308170",
+    "name": "씨티알모빌리티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "308620",
+    "name": "KODEX 미국10년국채선물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "309230",
+    "name": "ACE 미국WideMoat동일가중",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "310080",
+    "name": "RISE 중국MSCI China(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "310960",
+    "name": "TIGER 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "310970",
+    "name": "TIGER MSCI Korea TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "314250",
+    "name": "KODEX 미국빅테크10(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "314700",
+    "name": "HANARO 농업융복합산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "315270",
+    "name": "TIGER 200커뮤니케이션서비스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "315930",
+    "name": "KODEX Top5PlusTR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "315960",
+    "name": "RISE 대형고배당10TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "316140",
+    "name": "우리금융지주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "316300",
+    "name": "ACE 싱가포르리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "316670",
+    "name": "KIWOOM 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "317400",
+    "name": "자이에스앤디",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "317450",
+    "name": "명인제약",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "319640",
+    "name": "TIGER 골드선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "321410",
+    "name": "KODEX 멀티에셋하이인컴(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "322000",
+    "name": "HD현대에너지솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "322400",
+    "name": "HANARO e커머스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "322410",
+    "name": "HANARO K고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "323410",
+    "name": "카카오뱅크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "325010",
+    "name": "KODEX 성장주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "325020",
+    "name": "KODEX 배당가치",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "326030",
+    "name": "SK바이오팜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "326230",
+    "name": "RISE 내수주플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "326240",
+    "name": "RISE IT플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "328370",
+    "name": "PLUS 코스피TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "329180",
+    "name": "HD현대중공업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "329200",
+    "name": "TIGER 리츠부동산인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "329650",
+    "name": "KODEX TRF3070",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "329660",
+    "name": "KODEX TRF5050",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "329670",
+    "name": "KODEX TRF7030",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "329750",
+    "name": "TIGER 미국달러단기채권액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "330590",
+    "name": "롯데리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "332500",
+    "name": "ACE 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "332610",
+    "name": "PLUS 미국단기회사채(AAA~A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "332620",
+    "name": "PLUS 미국장기우량회사채",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "332930",
+    "name": "HANARO 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "332940",
+    "name": "HANARO MSCI Korea TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "334690",
+    "name": "RISE 팔라듐선물(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "334700",
+    "name": "RISE 팔라듐선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "334890",
+    "name": "이지스밸류플러스리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "336160",
+    "name": "RISE 금융채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "336260",
+    "name": "두산퓨얼셀",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "33626K",
+    "name": "두산퓨얼셀1우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "33626L",
+    "name": "두산퓨얼셀2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "336370",
+    "name": "솔루스첨단소재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "33637K",
+    "name": "솔루스첨단소재1우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "33637L",
+    "name": "솔루스첨단소재2우B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "337120",
+    "name": "KODEX 멀티팩터",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "337140",
+    "name": "KODEX 코스피대형주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "337150",
+    "name": "KODEX 200exTOP",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "337160",
+    "name": "KODEX 200ESG",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "338100",
+    "name": "NH프라임리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "339770",
+    "name": "교촌에프앤비",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "341850",
+    "name": "TIGER 리츠부동산인프라채권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "344820",
+    "name": "KCC글라스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "348950",
+    "name": "제이알글로벌리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "350520",
+    "name": "이지스레지던스리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "352540",
+    "name": "KODEX 일본부동산리츠(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "352560",
+    "name": "KODEX 미국부동산리츠(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "352820",
+    "name": "하이브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "353200",
+    "name": "대덕전자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "35320K",
+    "name": "대덕전자1우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "354240",
+    "name": "RISE 미국고정배당우선증권",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "354350",
+    "name": "HANARO 글로벌럭셔리S&P(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "354500",
+    "name": "ACE 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "356540",
+    "name": "ACE 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "357120",
+    "name": "코람코라이프인프라리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "357250",
+    "name": "미래에셋맵스리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "357430",
+    "name": "마스턴프리미어리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "357870",
+    "name": "TIGER CD금리투자KIS(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "359210",
+    "name": "KODEX 코스피TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "360140",
+    "name": "KODEX 200롱코스닥150숏선물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "360150",
+    "name": "KODEX 코스닥150롱코스피200숏선물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "360200",
+    "name": "ACE 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "360750",
+    "name": "TIGER 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "361580",
+    "name": "RISE 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "361610",
+    "name": "SK아이이테크놀로지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "363280",
+    "name": "티와이홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "36328K",
+    "name": "티와이홀딩스우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "363510",
+    "name": "SOL KIS단기통안채",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "363570",
+    "name": "KODEX 장기종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "363580",
+    "name": "KODEX 200IT TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "364690",
+    "name": "KODEX 혁신기술테마액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "364960",
+    "name": "TIGER BBIG",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "364970",
+    "name": "TIGER 바이오TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "364980",
+    "name": "TIGER 2차전지TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "364990",
+    "name": "TIGER 게임TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "365000",
+    "name": "TIGER 인터넷TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "365040",
+    "name": "TIGER AI코리아그로스액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "365550",
+    "name": "ESR켄달스퀘어리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "365780",
+    "name": "ACE 국고채10년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "367380",
+    "name": "ACE 미국나스닥100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "367740",
+    "name": "HANARO Fn5G산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "367760",
+    "name": "RISE 네트워크인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "367770",
+    "name": "RISE 수소경제테마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "368190",
+    "name": "HANARO Fn K-뉴딜디지털플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "368590",
+    "name": "RISE 미국나스닥100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "368680",
+    "name": "KODEX K-뉴딜디지털플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "371150",
+    "name": "RISE 차이나항셍테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "371160",
+    "name": "TIGER 차이나항셍테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "371450",
+    "name": "TIGER 글로벌클라우드컴퓨팅INDXX",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "371460",
+    "name": "TIGER 차이나전기차SOLACTIVE",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "371470",
+    "name": "TIGER 차이나바이오테크SOLACTIVE",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "371870",
+    "name": "ACE 차이나항셍테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "372330",
+    "name": "KODEX 차이나항셍테크",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "372910",
+    "name": "한컴라이프케어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "373220",
+    "name": "LG에너지솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "373490",
+    "name": "KODEX 코리아혁신성장액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "373790",
+    "name": "KIWOOM 미국방어배당성장나스닥",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "375270",
+    "name": "RISE 글로벌데이터센터리츠(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "375500",
+    "name": "DL이앤씨",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "37550K",
+    "name": "DL이앤씨우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "37550L",
+    "name": "DL이앤씨2우(전환)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "375760",
+    "name": "HANARO 탄소효율그린뉴딜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "375770",
+    "name": "KODEX 탄소효율그린뉴딜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "376410",
+    "name": "TIGER 탄소효율그린뉴딜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "377190",
+    "name": "디앤디플랫폼리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "377300",
+    "name": "카카오페이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "377740",
+    "name": "바이오노트",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "377990",
+    "name": "TIGER Fn신재생에너지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "378850",
+    "name": "화승알앤에이",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "379780",
+    "name": "RISE 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "379790",
+    "name": "RISE 유로스탁스50(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "379800",
+    "name": "KODEX 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "379810",
+    "name": "KODEX 미국나스닥100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "380340",
+    "name": "ACE 코리아AI테크핵심산업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "381170",
+    "name": "TIGER 미국테크TOP10 INDXX",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "381180",
+    "name": "TIGER 미국필라델피아반도체나스닥",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "381560",
+    "name": "HANARO Fn전기&수소차",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "381570",
+    "name": "HANARO Fn친환경에너지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "381970",
+    "name": "케이카",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "383220",
+    "name": "F&F",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "383800",
+    "name": "LX홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "38380K",
+    "name": "LX홀딩스1우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385510",
+    "name": "KODEX 신재생에너지액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385520",
+    "name": "KODEX 자율주행액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385540",
+    "name": "RISE 종합채권(A-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385550",
+    "name": "RISE 단기채권알파액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385560",
+    "name": "RISE KIS국고채30년Enhanced",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385590",
+    "name": "ACE ESG액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385600",
+    "name": "ACE 2차전지&친환경차액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385710",
+    "name": "TIME K이노베이션액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "385720",
+    "name": "TIME 코스피액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "387270",
+    "name": "TIGER 글로벌이노베이션액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "387280",
+    "name": "TIGER 퓨처모빌리티액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "388280",
+    "name": "RISE K엔터&여행레저",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "388420",
+    "name": "RISE 비메모리반도체액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "390390",
+    "name": "KODEX 미국반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "390400",
+    "name": "KODEX 미국스마트모빌리티S&P",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "391600",
+    "name": "ACE 미국친환경그린테마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "391670",
+    "name": "HK 베스트일레븐액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "394660",
+    "name": "TIGER 글로벌자율주행&전기차SOLACTIVE",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "394670",
+    "name": "TIGER 글로벌리튬&2차전지SOLACTIVE(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395150",
+    "name": "KODEX 웹툰&드라마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395160",
+    "name": "KODEX AI반도체TOP2플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395170",
+    "name": "KODEX Top10동일가중",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395270",
+    "name": "HANARO Fn K-반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395280",
+    "name": "HANARO Fn K-게임",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395290",
+    "name": "HANARO Fn K-POP&미디어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395400",
+    "name": "SK리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395750",
+    "name": "PLUS ESG가치주액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "395760",
+    "name": "PLUS ESG성장주액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "396500",
+    "name": "TIGER 반도체TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "396510",
+    "name": "TIGER 차이나클린에너지SOLACTIVE",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "396520",
+    "name": "TIGER 차이나반도체FACTSET",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "396690",
+    "name": "미래에셋글로벌리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "397420",
+    "name": "RISE 국채선물5년추종",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "399110",
+    "name": "SOL 미국S&P500ESG",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "399580",
+    "name": "RISE 글로벌클린에너지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "400570",
+    "name": "KODEX 유럽탄소배출권선물ICE(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "400580",
+    "name": "SOL 유럽탄소배출권선물S&P(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "400590",
+    "name": "SOL 글로벌탄소배출권선물ICE(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "400760",
+    "name": "NH올원리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "400970",
+    "name": "TIGER Fn메타버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "401170",
+    "name": "RISE 메타버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "401470",
+    "name": "KODEX 메타버스액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "401590",
+    "name": "HANARO 글로벌탄소배출권선물ICE(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "402340",
+    "name": "SK스퀘어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "402460",
+    "name": "HANARO Fn K-메타버스MZ",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "402970",
+    "name": "ACE 미국배당다우존스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "403550",
+    "name": "쏘카",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "403790",
+    "name": "MIDAS 코스피액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "404120",
+    "name": "TIME K신재생에너지액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "404260",
+    "name": "KODEX 기후변화솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "404540",
+    "name": "TIGER KRX기후변화솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "404650",
+    "name": "SOL KRX기후변화솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "404990",
+    "name": "신한서부티엔디리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "407300",
+    "name": "HANARO Fn골프테마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "407310",
+    "name": "HANARO 200 TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "407820",
+    "name": "에셋플러스 코리아플랫폼액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "407830",
+    "name": "에셋플러스 글로벌플랫폼액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "409810",
+    "name": "KODEX 미국나스닥100선물인버스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "409820",
+    "name": "KODEX 미국나스닥100레버리지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "410870",
+    "name": "TIME K컬처액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "411060",
+    "name": "ACE KRX금현물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "411420",
+    "name": "KODEX 미국나스닥AI테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "411540",
+    "name": "SOL 200 Top10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "411860",
+    "name": "KIWOOM 독일DAX",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "412560",
+    "name": "TIGER BBIG레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "412570",
+    "name": "TIGER 2차전지TOP10레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "412770",
+    "name": "TIGER 글로벌AI플랫폼액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "413220",
+    "name": "SOL 차이나태양광CSI(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "413930",
+    "name": "WON AI ESG액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "414270",
+    "name": "ACE 글로벌자율주행액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "414780",
+    "name": "TIGER 차이나과창판STAR50(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "415340",
+    "name": "KODEX 차이나과창판STAR50(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "415640",
+    "name": "KB발해인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "415760",
+    "name": "SOL 차이나육성산업액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "415920",
+    "name": "PLUS 글로벌희토류&전략자원생산기업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "416090",
+    "name": "ACE 중국과창판STAR50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "417310",
+    "name": "코람코더원리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "417450",
+    "name": "RISE 글로벌수소경제",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "417630",
+    "name": "TIGER KEDI혁신기업ESG30",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "418660",
+    "name": "TIGER 미국나스닥100레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "418670",
+    "name": "TIGER 글로벌AI사이버보안",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "419420",
+    "name": "KODEX 미국클린에너지나스닥",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "419430",
+    "name": "KODEX 차이나2차전지MSCI(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "419650",
+    "name": "PLUS 글로벌수소&차세대연료전지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "419890",
+    "name": "KIWOOM 단기채권ESG액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "421320",
+    "name": "PLUS 우주항공&UAM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "422260",
+    "name": "VITA MZ소비액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "422420",
+    "name": "RISE 2차전지액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "423160",
+    "name": "KODEX KOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "423170",
+    "name": "SOL 글로벌AI반도체탑픽액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "423920",
+    "name": "TIGER 미국필라델피아반도체레버리지(합성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "424460",
+    "name": "HANARO 글로벌워터MSCI(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "426020",
+    "name": "TIME 미국S&P500액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "426030",
+    "name": "TIME 미국나스닥100액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "426150",
+    "name": "WON 대한민국국고채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "427120",
+    "name": "RISE AI플랫폼",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "428510",
+    "name": "KODEX 차이나AI테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "428560",
+    "name": "KODEX 미국ETF산업Top10 Indxx",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "429000",
+    "name": "TIGER 미국S&P500배당귀족",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "429010",
+    "name": "TIGER 미국나스닥넥스트100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "429740",
+    "name": "PLUS K리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "429760",
+    "name": "PLUS 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "429980",
+    "name": "SOL 한국형글로벌전기차&2차전지액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "430500",
+    "name": "KIWOOM 물가채KIS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "432320",
+    "name": "KB스타리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "432600",
+    "name": "RISE 국채선물3년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "432840",
+    "name": "HANARO 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "433220",
+    "name": "에셋플러스 글로벌대장장이액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "433250",
+    "name": "UNICORN R&D 액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "433330",
+    "name": "SOL 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "433500",
+    "name": "ACE 원자력TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "433880",
+    "name": "PLUS TDF2060액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "433970",
+    "name": "KODEX TDF2030액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "433980",
+    "name": "KODEX TDF2040액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "434060",
+    "name": "KODEX TDF2050액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "434730",
+    "name": "HANARO 원자력iSelect",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "434960",
+    "name": "DAISHIN343 K200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "435040",
+    "name": "ACE 글로벌브랜드TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "435420",
+    "name": "TIGER 미국나스닥100채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "435530",
+    "name": "KIWOOM TDF2030액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "435540",
+    "name": "KIWOOM TDF2040액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "435550",
+    "name": "KIWOOM TDF2050액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "436140",
+    "name": "SOL 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "437070",
+    "name": "KODEX 아시아달러채권ESG플러스액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "437080",
+    "name": "KODEX 미국종합채권ESG액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "437350",
+    "name": "RISE 미국단기투자등급회사채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "437370",
+    "name": "RISE 글로벌농업경제",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "438080",
+    "name": "ACE 미국S&P500미국채혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "438100",
+    "name": "ACE 미국나스닥100미국채혼합50액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "438320",
+    "name": "TIGER 차이나항셍테크레버리지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "438330",
+    "name": "TIGER 우량회사채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "438560",
+    "name": "SOL 국고채3년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "438570",
+    "name": "SOL 국고채10년",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "438740",
+    "name": "MIDAS 중소형액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "438900",
+    "name": "HANARO Fn K-푸드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "439260",
+    "name": "대한조선",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "439860",
+    "name": "KODEX ESG종합채권(A-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "439870",
+    "name": "KODEX 국고채30년액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "440340",
+    "name": "TIGER 글로벌멀티에셋TIF액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "440640",
+    "name": "ACE 단기채권알파액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "440650",
+    "name": "ACE 미국달러단기채권액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "440910",
+    "name": "WON 미국우주항공방산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "441540",
+    "name": "HANARO Fn조선해운",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "441640",
+    "name": "KODEX 미국배당커버드콜액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "441680",
+    "name": "TIGER 미국나스닥100커버드콜(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "441800",
+    "name": "TIME Korea플러스배당액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "442090",
+    "name": "에셋플러스 코리아대장장이액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "442260",
+    "name": "마이티 다이나믹퀀트액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "442320",
+    "name": "RISE 글로벌원자력",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "442550",
+    "name": "RISE TDF2030액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "442560",
+    "name": "RISE TDF2040액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "442570",
+    "name": "RISE TDF2050액티브 적격",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "442580",
+    "name": "PLUS 글로벌HBM반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "443060",
+    "name": "HD현대마린솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "444200",
+    "name": "SOL 코리아메가테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "444490",
+    "name": "WON 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "445150",
+    "name": "KODEX 친환경조선해운액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "445290",
+    "name": "KODEX 로봇액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "445690",
+    "name": "BNK 주주가치액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "445910",
+    "name": "TIGER MKF배당귀족",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "446070",
+    "name": "유니드비티플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "446690",
+    "name": "KODEX 아시아AI반도체exChina액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "446700",
+    "name": "RISE 배터리 리사이클링",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "446720",
+    "name": "SOL 미국배당다우존스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "446770",
+    "name": "ACE 글로벌반도체TOP4 Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "447430",
+    "name": "ACE 주주환원가치주액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "447620",
+    "name": "SOL 미국TOP5채권혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "447660",
+    "name": "PLUS 애플채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "447770",
+    "name": "TIGER 테슬라채권혼합Fn",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448100",
+    "name": "WON 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448290",
+    "name": "TIGER 미국S&P500(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448300",
+    "name": "TIGER 미국나스닥100(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448330",
+    "name": "KODEX 삼성전자채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448490",
+    "name": "HANARO 32-10 국고채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448540",
+    "name": "ACE 엔비디아채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448570",
+    "name": "FOCUS AI코리아액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448630",
+    "name": "RISE 삼성그룹Top3채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "448730",
+    "name": "삼성FN리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449170",
+    "name": "TIGER KOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449180",
+    "name": "KODEX 미국S&P500(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449190",
+    "name": "KODEX 미국나스닥100(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449450",
+    "name": "PLUS K방산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449580",
+    "name": "RISE 테슬라애플아마존채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449680",
+    "name": "TIGER 한중전기차(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449690",
+    "name": "TIGER 한중반도체(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449770",
+    "name": "KIWOOM 미국S&P500",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "449780",
+    "name": "KIWOOM 미국S&P500(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "450080",
+    "name": "에코프로머티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "450180",
+    "name": "KODEX 한중전기차(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "450190",
+    "name": "KODEX 한중반도체(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "450910",
+    "name": "SOL 코스닥150",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "451000",
+    "name": "PLUS 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "451060",
+    "name": "1Q 200액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "451150",
+    "name": "에셋플러스 글로벌영에이지액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "451530",
+    "name": "TIGER 국고채30년스트립액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "451540",
+    "name": "TIGER 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "451600",
+    "name": "PLUS 국고채30년액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "451670",
+    "name": "RISE 국채30년레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "451800",
+    "name": "한화리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "452250",
+    "name": "ACE 미국30년국채선물레버리지(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "452260",
+    "name": "한화갤러리아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "45226K",
+    "name": "한화갤러리아우",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "452360",
+    "name": "SOL 미국배당다우존스(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "452440",
+    "name": "VITA 밸류알파액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453010",
+    "name": "PLUS KOFR금리",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453060",
+    "name": "HANARO KOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453080",
+    "name": "KIWOOM 미국나스닥100(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453330",
+    "name": "RISE 미국S&P500(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453340",
+    "name": "현대그린푸드",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453630",
+    "name": "KODEX 미국S&P500필수소비재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453640",
+    "name": "KODEX 미국S&P500헬스케어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453650",
+    "name": "KODEX 미국S&P500금융",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453660",
+    "name": "KODEX 미국S&P500경기소비재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453810",
+    "name": "KODEX 인도Nifty50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453820",
+    "name": "KODEX 인도Nifty50레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453850",
+    "name": "ACE 미국30년국채액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453870",
+    "name": "TIGER 인도니프티50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "453950",
+    "name": "TIGER TSMC파운드리밸류체인",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "454180",
+    "name": "KIWOOM 차이나내수소비TOP CSI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "454320",
+    "name": "HANARO CAPEX설비투자iSelect",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "454780",
+    "name": "KIWOOM 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "454910",
+    "name": "두산로보틱스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "455030",
+    "name": "KODEX 미국달러SOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "455660",
+    "name": "ACE 미국하이일드액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "455850",
+    "name": "SOL AI반도체소부장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "455860",
+    "name": "SOL 2차전지소부장Fn",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "455890",
+    "name": "RISE 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "455960",
+    "name": "RISE 미국달러SOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "456040",
+    "name": "OCI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "456200",
+    "name": "PLUS 미국달러SOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "456250",
+    "name": "KODEX 유럽명품TOP10 STOXX",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "456600",
+    "name": "TIME 글로벌AI인공지능액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "456610",
+    "name": "TIGER 미국달러SOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "456680",
+    "name": "TIGER 차이나전기차레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "456880",
+    "name": "ACE 미국달러SOFR금리(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "457190",
+    "name": "이수스페셜티케미컬",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "457480",
+    "name": "ACE 테슬라밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "457690",
+    "name": "KODEX 33-06 국고채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "457700",
+    "name": "KODEX 53-09 국고채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "457930",
+    "name": "BNK 미래전략기술액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "457990",
+    "name": "PLUS 태양광&ESS",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "458030",
+    "name": "WON 국공채머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "458210",
+    "name": "KIWOOM CD금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "458250",
+    "name": "TIGER 미국30년국채스트립액티브(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "458260",
+    "name": "TIGER 미국투자등급회사채액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "458730",
+    "name": "TIGER 미국배당다우존스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "458750",
+    "name": "TIGER 미국배당다우존스타겟커버드콜1호",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "458760",
+    "name": "TIGER 미국배당다우존스타겟커버드콜2호",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "459560",
+    "name": "KODEX 테슬라밸류체인FactSet",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "459580",
+    "name": "KODEX CD금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "459750",
+    "name": "RISE 글로벌주식분산액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "459790",
+    "name": "KIWOOM 미국성장기업30액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "460270",
+    "name": "KIWOOM 미국달러SOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "460660",
+    "name": "RISE 미국S&P배당킹",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "460850",
+    "name": "동국씨엠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "460860",
+    "name": "동국제강",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "460960",
+    "name": "ACE 글로벌인컴TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461270",
+    "name": "ACE 26-06 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461340",
+    "name": "HANARO 글로벌생성형AI액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461450",
+    "name": "KODEX 코스닥글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461460",
+    "name": "PLUS 국고채10년액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461490",
+    "name": "RISE 글로벌자산배분액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461500",
+    "name": "HANARO 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461580",
+    "name": "TIGER 코스닥글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461600",
+    "name": "SOL 미국30년국채액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461900",
+    "name": "PLUS 미국테크TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461910",
+    "name": "PLUS 미국테크TOP10레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "461950",
+    "name": "KODEX 2차전지핵심소재10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "462010",
+    "name": "TIGER 2차전지소재Fn",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "462330",
+    "name": "KODEX 2차전지산업레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "462340",
+    "name": "에셋플러스 글로벌다이나믹시니어액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "462520",
+    "name": "조선내화",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "462870",
+    "name": "시프트업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "462900",
+    "name": "KoAct 바이오헬스케어액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "463050",
+    "name": "TIME K바이오액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "463250",
+    "name": "TIGER K방산&우주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "463290",
+    "name": "1Q 단기금융채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "463300",
+    "name": "RISE 중국본토CSI300",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "463640",
+    "name": "KODEX 미국S&P500유틸리티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "463680",
+    "name": "KODEX 미국S&P500테크놀로지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "463690",
+    "name": "KODEX 미국S&P500커뮤니케이션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "464240",
+    "name": "KIWOOM 26-09회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "464310",
+    "name": "TIGER 글로벌AI&로보틱스 INDXX",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "464470",
+    "name": "PLUS 미국채30년액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "464600",
+    "name": "SOL 자동차소부장Fn",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "464610",
+    "name": "SOL 의료기기소부장Fn",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "464920",
+    "name": "PLUS 일본반도체소부장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "464930",
+    "name": "TIGER 글로벌혁신블루칩TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465330",
+    "name": "RISE 2차전지TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465350",
+    "name": "RISE 2차전지TOP10인버스(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465580",
+    "name": "ACE 미국빅테크TOP7 Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465610",
+    "name": "ACE 미국빅테크TOP7 Plus레버리지(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465620",
+    "name": "ACE 미국빅테크TOP7 Plus인버스(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465660",
+    "name": "TIGER 일본반도체FACTSET",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465670",
+    "name": "TIGER 미국캐시카우100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465770",
+    "name": "STX그린로지스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "465780",
+    "name": "마이티 26-09 특수채(AAA)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "466810",
+    "name": "BNK 2차전지양극재",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "466920",
+    "name": "SOL 조선TOP3플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "466930",
+    "name": "SOL 자동차TOP3플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "466940",
+    "name": "TIGER 은행고배당플러스TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "466950",
+    "name": "TIGER 글로벌AI액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "468370",
+    "name": "KODEX iShares미국인플레이션국채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "468380",
+    "name": "KODEX iShares미국하이일드액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "468630",
+    "name": "KODEX iShares미국투자등급회사채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469050",
+    "name": "RISE 미국반도체NYSE(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469060",
+    "name": "RISE 미국반도체NYSE",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469070",
+    "name": "RISE AI&로봇",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469150",
+    "name": "ACE AI반도체TOP3+",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469160",
+    "name": "ACE 일본반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469170",
+    "name": "ACE 포스코그룹포커스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469530",
+    "name": "RISE 미국달러선물인버스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469790",
+    "name": "KIWOOM 코리아테크TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "469830",
+    "name": "SOL 초단기채권액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "470310",
+    "name": "UNICORN 생성형AI강소기업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "471040",
+    "name": "KoAct 글로벌AI&로봇액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "471230",
+    "name": "KODEX 국고채10년액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "471460",
+    "name": "KIWOOM 국고채30년액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "471760",
+    "name": "TIGER AI반도체핵심공정",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "471780",
+    "name": "TIGER 코리아테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "471990",
+    "name": "KODEX AI반도체핵심장비",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "472150",
+    "name": "TIGER 배당커버드콜액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "472160",
+    "name": "TIGER 미국테크TOP10 INDXX(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "472170",
+    "name": "TIGER 미국테크TOP10채권혼합",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "472720",
+    "name": "TRUSTON 주주가치액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "472830",
+    "name": "RISE 미국30년국채커버드콜(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "472840",
+    "name": "IBK 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "472870",
+    "name": "RISE 미국30년국채엔화노출(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "472920",
+    "name": "HK 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "473290",
+    "name": "KODEX 26-12 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "473330",
+    "name": "SOL 미국30년국채커버드콜(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "473440",
+    "name": "ACE 11월만기자동연장회사채AA-이상액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "473460",
+    "name": "KODEX 미국서학개미",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "473490",
+    "name": "KIWOOM 글로벌AI반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "473590",
+    "name": "ACE 미국주식베스트셀러",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "473640",
+    "name": "HANARO 글로벌금채굴기업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "474220",
+    "name": "TIGER 미국테크TOP10타겟커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "474390",
+    "name": "SOL 국고채30년액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "474590",
+    "name": "WON 반도체밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "474800",
+    "name": "KIWOOM 미국원유에너지기업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "474920",
+    "name": "에셋플러스 차이나일등기업포커스10액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475050",
+    "name": "ACE KPOP포커스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475070",
+    "name": "KoAct 글로벌친환경전력인프라액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475080",
+    "name": "KODEX 테슬라커버드콜채권혼합액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475150",
+    "name": "SK이터닉스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475260",
+    "name": "ACE 2월만기자동연장회사채AA-이상액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475270",
+    "name": "ACE 5월만기자동연장회사채AA-이상액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475280",
+    "name": "ACE 8월만기자동연장회사채AA-이상액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475300",
+    "name": "SOL 반도체전공정",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475310",
+    "name": "SOL 반도체후공정",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475350",
+    "name": "RISE 버크셔포트폴리오TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475380",
+    "name": "RISE 글로벌리얼티인컴",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475560",
+    "name": "더본코리아",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475630",
+    "name": "TIGER CD1년금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "475720",
+    "name": "RISE 200위클리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476000",
+    "name": "UNICORN 포스트IPO액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476030",
+    "name": "SOL 미국나스닥100",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476070",
+    "name": "KODEX 글로벌비만치료제TOP2 Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476260",
+    "name": "HANARO 반도체핵심공정주도주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476310",
+    "name": "RISE 글로벌비만산업TOP2+",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476450",
+    "name": "KIWOOM 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476550",
+    "name": "TIGER 미국30년국채커버드콜액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476690",
+    "name": "TIGER 글로벌비만치료제TOP2Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476750",
+    "name": "ACE 미국30년국채엔화노출액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476760",
+    "name": "ACE 미국30년국채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476800",
+    "name": "KODEX 한국부동산리츠인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "476850",
+    "name": "KoAct 배당성장액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "477050",
+    "name": "PLUS 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "477080",
+    "name": "RISE CD금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "477490",
+    "name": "에셋플러스 글로벌일등기업포커스10액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "477730",
+    "name": "KODEX 인도타타그룹",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "478150",
+    "name": "TIME 글로벌우주테크&방산액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "479080",
+    "name": "1Q 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "479520",
+    "name": "RISE KOFR금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "479620",
+    "name": "SOL 미국AI반도체칩메이커",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "479730",
+    "name": "TIGER 인도빌리언컨슈머",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "479850",
+    "name": "HANARO K-뷰티",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "480020",
+    "name": "ACE 미국빅테크7+데일리타겟커버드콜(합성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "480030",
+    "name": "ACE 미국500데일리타겟커버드콜(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "480040",
+    "name": "ACE 미국반도체데일리타겟커버드콜(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "480260",
+    "name": "TIGER 27-04회사채(A+이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "480310",
+    "name": "TIGER 글로벌온디바이스AI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "480370",
+    "name": "씨케이솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "480460",
+    "name": "WON 한국부동산TOP3플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "481050",
+    "name": "KODEX CD1년금리플러스액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "481060",
+    "name": "KODEX 미국30년국채타겟커버드콜(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "481180",
+    "name": "SOL 미국AI소프트웨어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "481190",
+    "name": "SOL 미국테크TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "481340",
+    "name": "RISE 미국30년국채액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "481430",
+    "name": "RISE 국고채10년액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "481850",
+    "name": "신한글로벌액티브리츠",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "482030",
+    "name": "KoAct 반도체&2차전지핵심소재액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "482730",
+    "name": "TIGER 미국S&P500타겟데일리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483020",
+    "name": "KIWOOM 의료AI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483030",
+    "name": "KIWOOM 미국블록버스터바이오테크의약품+",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483240",
+    "name": "TIGER 미국나스닥100ETF선물",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483280",
+    "name": "KODEX 미국AI테크TOP10타겟커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483290",
+    "name": "KODEX 미국배당다우존스타겟커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483320",
+    "name": "ACE 엔비디아밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483330",
+    "name": "ACE 마이크로소프트밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483340",
+    "name": "ACE 구글밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483420",
+    "name": "ACE 애플밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483570",
+    "name": "KCGI 미국S&P500 TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "483650",
+    "name": "달바글로벌",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "484790",
+    "name": "KODEX 미국30년국채액티브(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "484870",
+    "name": "엠앤씨솔루션",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "484880",
+    "name": "SOL 금융지주플러스고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "484890",
+    "name": "SOL 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "485540",
+    "name": "KODEX 미국AI테크TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "485690",
+    "name": "RISE 미국AI밸류체인TOP3Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "485810",
+    "name": "TIME 글로벌바이오액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "486240",
+    "name": "DAISHIN343 AI반도체&인프라액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "486290",
+    "name": "TIGER 미국나스닥100타겟데일리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "486450",
+    "name": "SOL 미국AI전력인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "486830",
+    "name": "HANARO 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487130",
+    "name": "KoAct AI인프라액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487230",
+    "name": "KODEX 미국AI전력핵심인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487240",
+    "name": "KODEX AI전력핵심설비",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487340",
+    "name": "ACE 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487570",
+    "name": "HS효성",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487750",
+    "name": "BNK 온디바이스AI",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487910",
+    "name": "ACE 인도컨슈머파워액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487920",
+    "name": "ACE 인도시장대표BIG5그룹액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "487950",
+    "name": "KODEX 대만테크고배당다우존스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488080",
+    "name": "TIGER 반도체TOP10레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488200",
+    "name": "KIWOOM K-2차전지북미공급망",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488210",
+    "name": "KIWOOM K-반도체북미공급망",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488290",
+    "name": "MIDAS 일본테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488480",
+    "name": "RISE 일본섹터TOP4Plus",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488500",
+    "name": "TIGER 미국S&P500동일가중",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488720",
+    "name": "WON 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488770",
+    "name": "KODEX 머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "488980",
+    "name": "SOL 26-12 회사채(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "489000",
+    "name": "PLUS 일본엔화초단기국채(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "489010",
+    "name": "PLUS 글로벌AI인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "489030",
+    "name": "PLUS 고배당주위클리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "489250",
+    "name": "KODEX 미국배당다우존스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "489290",
+    "name": "WON 미국빌리어네어",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "489790",
+    "name": "한화비전",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "489860",
+    "name": "KIWOOM 글로벌전력GRID인프라",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "490090",
+    "name": "TIGER 미국AI빅테크10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "490330",
+    "name": "KoAct 미국치매&뇌질환치료제액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "490480",
+    "name": "SOL K방산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "490490",
+    "name": "SOL 미국배당미국채혼합50",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "490590",
+    "name": "RISE 미국AI밸류체인데일리고정커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "490600",
+    "name": "RISE 미국배당100데일리고정커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491010",
+    "name": "TIGER 글로벌AI전력인프라액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491090",
+    "name": "KODEX 미국테크TOP3플러스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491220",
+    "name": "PLUS 200TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491230",
+    "name": "PLUS 국공채머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491510",
+    "name": "파워 K-주주가치액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491610",
+    "name": "1Q CD금리액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491620",
+    "name": "RISE 미국테크100데일리고정커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491630",
+    "name": "RISE 미국반도체인버스(합성 H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491700",
+    "name": "HK 200",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491820",
+    "name": "HANARO 전력설비투자",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "491830",
+    "name": "TIGER 미국AI반도체팹리스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "492500",
+    "name": "1Q 현대차그룹채권(A+이상)&국고통안",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "493420",
+    "name": "SOL 미국배당다우존스2호",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "493810",
+    "name": "TIGER 미국AI빅테크10타겟데일리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494180",
+    "name": "TIME 글로벌소비트렌드액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494210",
+    "name": "SOL 미국500타겟데일리커버드콜액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494220",
+    "name": "UNICORN SK하이닉스밸류체인액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494300",
+    "name": "KODEX 미국나스닥100데일리커버드콜OTM",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494310",
+    "name": "KODEX 반도체레버리지",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494330",
+    "name": "ACE 라이프자산주주가치액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494340",
+    "name": "ACE 글로벌AI맞춤형반도체",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494410",
+    "name": "PLUS 미국S&P500성장주",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494420",
+    "name": "PLUS 미국배당증가성장주데일리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494670",
+    "name": "TIGER 조선TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494840",
+    "name": "TIGER 미국방산TOP10",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "494890",
+    "name": "KODEX 200액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495040",
+    "name": "PLUS 코리아밸류업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495050",
+    "name": "RISE 코리아밸류업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495060",
+    "name": "TIME 코리아밸류업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495230",
+    "name": "KoAct 코리아밸류업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495330",
+    "name": "1Q 코리아밸류업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495550",
+    "name": "SOL 코리아밸류업TR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495710",
+    "name": "BNK 26-06 특수채(AAA이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495750",
+    "name": "HANARO 코리아밸류업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495850",
+    "name": "KODEX 코리아밸류업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "495940",
+    "name": "RISE 미국AI테크액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "496020",
+    "name": "WON 전단채플러스액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "496080",
+    "name": "TIGER 코리아밸류업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "496090",
+    "name": "KIWOOM 코리아밸류업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "496120",
+    "name": "ACE 코리아밸류업",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "496130",
+    "name": "TRUSTON 코리아밸류업액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "496770",
+    "name": "PLUS 글로벌방산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "497510",
+    "name": "ACE 글로벌빅파마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "497520",
+    "name": "ACE 일라이릴리밸류체인",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "497570",
+    "name": "TIGER 미국필라델피아AI반도체나스닥",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "497780",
+    "name": "KoAct 미국천연가스인프라액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "497880",
+    "name": "SOL CD금리&머니마켓액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "498050",
+    "name": "HANARO 바이오코리아액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "498180",
+    "name": "파워 종합채권(AA-이상)액티브",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "498270",
+    "name": "KIWOOM 미국양자컴퓨팅",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "498400",
+    "name": "KODEX 200타겟위클리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "498410",
+    "name": "KODEX 금융고배당TOP10타겟위클리커버드콜",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "498610",
+    "name": "RISE 인도디지털성장",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "498860",
+    "name": "RISE 코리아금융고배당",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "499150",
+    "name": "SOL 미국S&P500엔화노출(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "499660",
+    "name": "TIGER CD금리플러스액티브(합성)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "499790",
+    "name": "GS피앤엘",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "900140",
+    "name": "엘브이엠씨홀딩스",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "950210",
+    "name": "프레스티지바이오파마",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100026",
+    "name": "한투글로벌넥스트웨이브1(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100027",
+    "name": "한투글로벌넥스트웨이브1(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100028",
+    "name": "한투글로벌넥스트웨이브2(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100029",
+    "name": "한투글로벌넥스트웨이브2(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100030",
+    "name": "한투한미핵심성장포커스1(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100031",
+    "name": "한투한미핵심성장포커스1(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100032",
+    "name": "한투한미핵심성장포커스2(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100033",
+    "name": "한투한미핵심성장포커스2(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100034",
+    "name": "한투한미넥스트혁신성장1(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100035",
+    "name": "한투한미넥스트혁신성장1(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100036",
+    "name": "한투한미넥스트혁신성장2(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100037",
+    "name": "한투한미넥스트혁신성장2(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100038",
+    "name": "한투AI혁신산업1(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100039",
+    "name": "한투AI혁신산업2(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100040",
+    "name": "한투AI혁신산업2(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70100041",
+    "name": "한투AI혁신산업1(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70101B95",
+    "name": "밀라노부동산",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70101B96",
+    "name": "벨기에코어오피스2호",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70101B9A",
+    "name": "한국투자뉴욕오피스1호",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70102B96",
+    "name": "룩셈부르크코어오피스(파생형)(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70103B96",
+    "name": "룩셈부르크코어오피스(파생형)(C-I)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70900001",
+    "name": "대신하이일드공모주알파증권2호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F70900002",
+    "name": "대신하이일드공모주알파증권2호 A-e",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F71201B98",
+    "name": "키움히어로즈유럽오피스부동산1호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F71202B98",
+    "name": "키움히어로즈유럽오피스부동산1호 C-I",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F71203B98",
+    "name": "키움히어로즈유럽오피스부동산2호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F71204B98",
+    "name": "키움히어로즈유럽오피스부동산2호 C-I",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F71205B98",
+    "name": "키움히어로즈유럽오피스부동산3호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F71206B98",
+    "name": "키움히어로즈유럽오피스부동산3호 C-I",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F71207B98",
+    "name": "키움히어로즈유럽오피스부동산4호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F71208B98",
+    "name": "키움히어로즈유럽오피스부동산4호 C-I",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F73400008",
+    "name": "코레이트하이일드공모주만기형3호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F73400009",
+    "name": "코레이트하이일드공모주만기형3호 A2",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F73400010",
+    "name": "코레이트하이일드공모주만기형3호 Ae",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F73400011",
+    "name": "코레이트하이일드공모주만기형4호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F73400012",
+    "name": "코레이트하이일드공모주만기형4호 Ae",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74201773",
+    "name": "하나대체나사부동산1호",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74201BAA",
+    "name": "하나대체미국부동산1호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74202BAA",
+    "name": "하나대체미국부동산1호 C-I",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74401777",
+    "name": "맵스미국11호",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74401BAA",
+    "name": "맵스미국16호 종류A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74601669",
+    "name": "KCGI베트남증권투자신탁",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74701776",
+    "name": "이지스코어부동산126호 A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74701B97",
+    "name": "이지스글로벌281호 Class A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74701B9A",
+    "name": "이지스299호A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F74702776",
+    "name": "이지스코어부동산126호 C-i",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F75601BA2",
+    "name": "유경공모부동산3호ClassA",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F75602BA2",
+    "name": "유경공모부동산3호ClassC-I",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F75701BA7",
+    "name": "현대유퍼스트부동산30호[파생형] A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F75702BA7",
+    "name": "현대유퍼스트부동산30호[파생형] C-i",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F76201BC5",
+    "name": "이탈리아물류1호 종류A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200017",
+    "name": "한국밸류라이프V파워1(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200018",
+    "name": "한국밸류라이프V파워1(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200019",
+    "name": "한국밸류라이프V파워1(C-F)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200020",
+    "name": "한국밸류라이프V파워2(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200021",
+    "name": "한국밸류라이프V파워2(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200022",
+    "name": "한국밸류라이프V파워2(C-F)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200023",
+    "name": "한국밸류코리아기업가치포커스1호A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200024",
+    "name": "한국밸류코리아기업가치포커스1호C-F",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200025",
+    "name": "한국밸류코리아기업가치포커스2호A",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200026",
+    "name": "한국밸류코리아기업가치포커스1호A-e",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200027",
+    "name": "한국밸류코리아기업가치포커스2호C-F",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200028",
+    "name": "한국밸류코리아기업가치포커스2호A-e",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200029",
+    "name": "한국밸류 K-파워2 1호(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200030",
+    "name": "한국밸류 K-파워2 1호(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200031",
+    "name": "한국밸류 K-파워2 2호(C-F)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200032",
+    "name": "한국밸류 K-파워2 2호(A-e)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200033",
+    "name": "한국밸류 K-파워2 2호(A)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "F77200034",
+    "name": "한국밸류 K-파워2 1호(C-F)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "J0036221D",
+    "name": "KG모빌리티 122WR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "J0113321F",
+    "name": "유니켐 41WR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "J0669721F",
+    "name": "엘앤에프 7WR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "J0671721G",
+    "name": "오텍 13WR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "J1099621D",
+    "name": "앱토크롬 6WR",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "J4623501G",
+    "name": "이노스페이스 40R",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500020",
+    "name": "신한 레버리지 다우존스지수 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500023",
+    "name": "신한 콩 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500024",
+    "name": "신한 인버스 콩 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500028",
+    "name": "신한 인버스 2X 다우존스지수 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500029",
+    "name": "신한 레버리지 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500030",
+    "name": "신한 인버스 2X 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500035",
+    "name": "신한 레버리지 미국달러 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500036",
+    "name": "신한 인버스 2X 미국달러 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500037",
+    "name": "신한 레버리지 금 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500038",
+    "name": "신한 인버스 2X 금 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500040",
+    "name": "신한 레버리지 구리 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500041",
+    "name": "신한 인버스 2X 구리 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500050",
+    "name": "신한 레버리지 S&P500 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500051",
+    "name": "신한 인버스 2X S&P500 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500061",
+    "name": "신한 인버스 코스피 200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500063",
+    "name": "신한 인버스 코스닥 150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500067",
+    "name": "신한 레버리지 10년 국채선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500068",
+    "name": "신한 인버스 2X 10년 국채선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500069",
+    "name": "신한 레버리지 코스피 200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500071",
+    "name": "신한 레버리지 코스닥 150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500072",
+    "name": "신한 인버스 2X 코스닥 150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500078",
+    "name": "신한 S&P 유로 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500079",
+    "name": "신한 S&P 인버스 유로 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500080",
+    "name": "신한 S&P 레버리지 유로 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500081",
+    "name": "신한 S&P 인버스 2X 유로 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500082",
+    "name": "신한 블룸버그 2X 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500085",
+    "name": "신한 코스피 200 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500086",
+    "name": "신한 코스닥 150 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500091",
+    "name": "신한 33-12 국고채 플러스 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500093",
+    "name": "신한 블룸버그 레버리지 WTI원유선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500094",
+    "name": "신한 블룸버그 인버스2X WTI원유선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500095",
+    "name": "신한 S&P500 VIX S/T 선물 ETN E",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500096",
+    "name": "신한 인버스2X 천연가스 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500097",
+    "name": "신한 레버리지 Russell 2000 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500098",
+    "name": "신한 인버스 2X Russell 2000 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500099",
+    "name": "신한 WTI원유 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500100",
+    "name": "신한 금 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500101",
+    "name": "신한 블룸버그 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q500102",
+    "name": "신한 블룸버그 2X 천연가스 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q510016",
+    "name": "대신 천연가스 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q510027",
+    "name": "대신 인버스 2X 코스닥 150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q510043",
+    "name": "대신 인버스 천연가스 선물 ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q510044",
+    "name": "대신 레버리지 미국달러 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q510045",
+    "name": "대신 인버스 2X 미국달러 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520037",
+    "name": "미래에셋 코스피200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520038",
+    "name": "미래에셋 인버스 코스피200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520039",
+    "name": "미래에셋 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520040",
+    "name": "미래에셋 인버스 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520046",
+    "name": "미래에셋 레버리지 옥수수 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520047",
+    "name": "미래에셋 인버스 2X 옥수수 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520054",
+    "name": "미래에셋 레버리지 코스피200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520056",
+    "name": "미래에셋 레버리지 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520057",
+    "name": "미래에셋 인버스 2X 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520064",
+    "name": "미래에셋 2X 미국채울트라30년 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520065",
+    "name": "미래에셋 -2X 미국채울트라30년 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520066",
+    "name": "미래에셋 KRX금현물 Auto-KO-C 2810-01 ET",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520068",
+    "name": "미래에셋 2X 홍콩H 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520069",
+    "name": "미래에셋 -2X 홍콩H 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520072",
+    "name": "미래에셋 미국 AI TOP3 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520073",
+    "name": "미래에셋 레버리지 미국 AI TOP3 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520074",
+    "name": "미래에셋 미국 방위산업 TOP3 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520075",
+    "name": "미래에셋 레버리지 미국 방위산업 TOP3 ET",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520076",
+    "name": "미래에셋 1.5X 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520077",
+    "name": "미래에셋 -1.5X 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520078",
+    "name": "미래에셋 미국 제약 TOP3 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520079",
+    "name": "미래에셋 레버리지 미국 제약 TOP3 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520080",
+    "name": "미래에셋 미국 테크&반도체 TOP3 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520081",
+    "name": "미래에셋 2X 미국 테크&반도체 TOP3 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520082",
+    "name": "미래에셋 미국 자율주행대표기업 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520083",
+    "name": "미래에셋 2X 미국 자율주행대표기업 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520084",
+    "name": "미래에셋 -2X 미국 자율주행대표기업 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520085",
+    "name": "미래에셋 -2X 미국 AI TOP3 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520086",
+    "name": "미래에셋-0.5X S&P500 VIX S/T선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520087",
+    "name": "미래에셋 레버리지 KRX 금현물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520088",
+    "name": "미래에셋 S&P500 VIX S/T 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520089",
+    "name": "미래에셋 CAPE 실러 US Core Sector ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520090",
+    "name": "미래에셋 천연가스 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520091",
+    "name": "미래에셋 인버스 천연가스 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520092",
+    "name": "미래에셋 레버리지 은 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520093",
+    "name": "미래에셋 인버스 2X 은 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520094",
+    "name": "미래에셋 CD금리 플러스 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520097",
+    "name": "미래에셋 1.5X S&P500 VIX S/T선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520098",
+    "name": "미래에셋 레버리지 반도체 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q520099",
+    "name": "미래에셋 인버스 2X 반도체 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530031",
+    "name": "삼성 레버리지 WTI원유 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530036",
+    "name": "삼성 인버스 2X WTI원유 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530055",
+    "name": "삼성 레버리지 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530056",
+    "name": "삼성 인버스 2X 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530060",
+    "name": "삼성 코스피 양매도 5% OTM ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530061",
+    "name": "삼성 레버리지 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530062",
+    "name": "삼성 인버스 2X 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530063",
+    "name": "삼성 레버리지 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530064",
+    "name": "삼성 인버스 2X 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530067",
+    "name": "삼성 KRX 금현물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530083",
+    "name": "삼성 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530084",
+    "name": "삼성 인버스 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530089",
+    "name": "삼성 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530090",
+    "name": "삼성 인버스 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530092",
+    "name": "삼성 인버스 코스피 200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530094",
+    "name": "삼성 인버스 코스닥 150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530095",
+    "name": "삼성 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530096",
+    "name": "삼성 인버스 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530104",
+    "name": "삼성 레버리지 코스피200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530106",
+    "name": "삼성 레버리지 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530107",
+    "name": "삼성 인버스 2X 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530112",
+    "name": "삼성 S&P500 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530113",
+    "name": "삼성 레버리지 S&P500 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530114",
+    "name": "삼성 인버스 2X S&P500 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530115",
+    "name": "삼성 레버리지 나스닥 100 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530116",
+    "name": "삼성 인버스 2X 나스닥 100 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530117",
+    "name": "삼성 코스피 200 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530118",
+    "name": "삼성 코스닥 150 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530119",
+    "name": "삼성 레버리지 항셍테크 TR ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530120",
+    "name": "삼성 나스닥 100 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530121",
+    "name": "삼성 항셍테크 TR ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530122",
+    "name": "삼성 인버스 2X 항셍테크 TR ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530123",
+    "name": "삼성 일본니케이225선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530124",
+    "name": "삼성 레버리지 일본니케이225선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530125",
+    "name": "삼성 인버스 2X 일본니케이225선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530126",
+    "name": "삼성 코리아 밸류업 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530127",
+    "name": "삼성 미국다우존스 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530128",
+    "name": "삼성 레버리지 미국다우존스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530129",
+    "name": "삼성 인버스 2X 미국다우존스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530130",
+    "name": "삼성 S&P500 VIX S/T 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530131",
+    "name": "삼성 인버스0.5X S&P500 VIX S/T선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530132",
+    "name": "삼성 블룸버그 WTI원유 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530133",
+    "name": "삼성 블룸버그 레버리지 WTI원유선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530134",
+    "name": "삼성 블룸버그 인버스2X WTI원유선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530135",
+    "name": "삼성 인버스 China A50 선물 ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530136",
+    "name": "삼성 인버스 2X 천연가스 선물 ETN D",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530137",
+    "name": "삼성 KRX 2차전지 TOP10 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530138",
+    "name": "삼성 KRX 레버리지 2차전지 TOP10 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530139",
+    "name": "삼성 iSelect 조선 TOP10 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530140",
+    "name": "삼성 iSelect 레버리지 조선 TOP10 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530141",
+    "name": "삼성 중국 자동차 TOP5 TR ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530142",
+    "name": "삼성 중국 AI 테크 TOP5 TR ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530143",
+    "name": "삼성 인버스 2X 은 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q530145",
+    "name": "삼성 레버리지 천연가스 선물 ETN D",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550041",
+    "name": "N2 미국 IT TOP5 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550043",
+    "name": "N2 인버스 레버리지 WTI원유 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550062",
+    "name": "N2 레버리지 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550063",
+    "name": "N2 인버스 레버리지 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550064",
+    "name": "N2 레버리지 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550069",
+    "name": "N2 레버리지 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550070",
+    "name": "N2 인버스 레버리지 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550082",
+    "name": "N2 KIS CD금리투자 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550084",
+    "name": "N2 코스피 200 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550085",
+    "name": "N2 코스닥 150 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550087",
+    "name": "N2 선진국 1등주 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550088",
+    "name": "N2 월간 레버리지 선진국 1등주 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550089",
+    "name": "N2 월간 레버리지 코스피 200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550091",
+    "name": "N2 방위산업 Top5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550092",
+    "name": "N2 월간 레버리지 방위산업 Top5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550093",
+    "name": "N2 전력인프라 Top5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550095",
+    "name": "N2 레버리지 국채10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550096",
+    "name": "N2 레버리지 국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550097",
+    "name": "N2 레버리지 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550098",
+    "name": "N2 인버스 2X 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550099",
+    "name": "N2 레버리지 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q550100",
+    "name": "N2 인버스 2X 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570019",
+    "name": "한투 코스피양매도5%OTM ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570022",
+    "name": "한투 레버리지S&P500선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570023",
+    "name": "한투 인버스2XS&P500선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570029",
+    "name": "한투 코스피양매도3%OTM ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570047",
+    "name": "한투 FTSE100 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570050",
+    "name": "한투 S&P500선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570051",
+    "name": "한투 나스닥100 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570055",
+    "name": "한투 금선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570056",
+    "name": "한투 인버스금선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570057",
+    "name": "한투 은선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570058",
+    "name": "한투 인버스은선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570059",
+    "name": "한투 레버리지금선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570060",
+    "name": "한투 인버스2X금선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570061",
+    "name": "한투 레버리지은선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570063",
+    "name": "한투 베트남VN30선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570064",
+    "name": "한투 인버스베트남VN30선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570065",
+    "name": "한투 레버리지베트남VN30선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570066",
+    "name": "한투 인버스2X베트남VN30 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570069",
+    "name": "한투 레버리지플래티넘선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570070",
+    "name": "한투 인버스2X플래티넘선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570071",
+    "name": "한투 구리선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570072",
+    "name": "한투 레버리지구리선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570073",
+    "name": "한투 인버스2X구리선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570074",
+    "name": "한투 유럽탄소배출권선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570081",
+    "name": "한투 레버리지코스닥150선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570082",
+    "name": "한투 인버스2X코스닥150선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570085",
+    "name": "한투 인도네시아대표원자재 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570090",
+    "name": "한투 KIS CD금리투자 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570091",
+    "name": "한투 인버스유로스탁스50 ETN(H) C",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570092",
+    "name": "한투 인버스2X유로스탁스50 ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570093",
+    "name": "한투 레버리지천연가스선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570094",
+    "name": "한투 일본엔선물 ETN C",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570095",
+    "name": "한투 레버리지일본엔선물 ETN C",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570096",
+    "name": "한투 인버스2X일본엔선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570097",
+    "name": "한투 엔달러선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570098",
+    "name": "한투 레버리지엔달러선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570099",
+    "name": "한투 인버스2X엔달러 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570100",
+    "name": "한투 일본종합상사TOP5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570101",
+    "name": "한투 인버스나스닥100 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570102",
+    "name": "한투 레버리지나스닥100 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570103",
+    "name": "한투 인버스2X나스닥100 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570104",
+    "name": "한투 일본니케이225선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570105",
+    "name": "한투 인버스일본니케이225선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570106",
+    "name": "한투 레버리지일본니케이225선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570107",
+    "name": "한투 인버스2X일본니케이225선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570108",
+    "name": "한투 레버리지국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570109",
+    "name": "한투 레버리지미국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570110",
+    "name": "한투 3X레버리지국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570111",
+    "name": "한투 3X레버리지미국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570114",
+    "name": "한투 S&P500 VIX S/T선물 ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570115",
+    "name": "한투 인버스0.5X S&P500 VIX S/T선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570116",
+    "name": "한투 레버리지WTI원유선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570117",
+    "name": "한투 인버스2XWTI원유선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570118",
+    "name": "한투 인버스2X천연가스선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570119",
+    "name": "한투 인버스2X은선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570120",
+    "name": "한투 레버리지천연가스선물 ETN C",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570121",
+    "name": "한투 금선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570122",
+    "name": "한투 인버스금선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570123",
+    "name": "한투 은선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q570124",
+    "name": "한투 인버스은선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580010",
+    "name": "KB Wise 분할매매 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580019",
+    "name": "KB 인버스 2X 항셍테크 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580020",
+    "name": "KB 천연가스 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580021",
+    "name": "KB 인버스 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580022",
+    "name": "KB 레버리지 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580023",
+    "name": "KB 인버스 2X 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580026",
+    "name": "KB S&P 레버리지 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580032",
+    "name": "KB 레버리지 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580033",
+    "name": "KB 인버스 2X 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580034",
+    "name": "KB 레버리지 FANG 플러스 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580035",
+    "name": "KB S&P 유럽탄소배출권 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580039",
+    "name": "KB 레버리지 KOSPI 200 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580043",
+    "name": "KB 레버리지 KOSDAQ 150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580044",
+    "name": "KB 인버스 2X KOSDAQ 150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580047",
+    "name": "KB 레버리지 항셍테크 선물 ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580048",
+    "name": "KB 차이나 대형주 CSI 300 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580049",
+    "name": "KB 차이나 중형주 CSI 500 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580050",
+    "name": "KB 차이나 과창판 STAR 50 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580051",
+    "name": "KB 레버리지 밀 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580052",
+    "name": "KB 인버스 2X 밀 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580053",
+    "name": "KB 레버리지 콩 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580054",
+    "name": "KB 인버스 2X 콩 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580055",
+    "name": "KB 블룸버그 레버리지 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580056",
+    "name": "KB 일본 로보틱스 TOP 10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580057",
+    "name": "KB 일본 컨슈머 TOP 10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580058",
+    "name": "KB KIS CD금리투자 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580059",
+    "name": "KB 미국채 10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580060",
+    "name": "KB 레버리지 미국채 10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580061",
+    "name": "KB 미국채 30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580062",
+    "name": "KB 레버리지 미국채 30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580063",
+    "name": "KB 레버리지 미국채 10년 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580064",
+    "name": "KB 인버스 2X 미국채 10년 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580065",
+    "name": "KB 코스닥 150 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580066",
+    "name": "KB 인도 대형 성장주 Select 5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580067",
+    "name": "KB 인도 디지털 Select 5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580068",
+    "name": "KB S&P 레버리지 WTI원유 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580069",
+    "name": "KB S&P 인버스 2X WTI원유 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580070",
+    "name": "KB 레버리지 2차전지 TOP 10 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580071",
+    "name": "KB 인버스 2X 천연가스 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580072",
+    "name": "KB 화웨이 밸류체인 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580073",
+    "name": "KB 레버리지 화웨이 밸류체인 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580074",
+    "name": "KB BYD 밸류체인 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580075",
+    "name": "KB 레버리지 BYD 밸류체인 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580076",
+    "name": "KB 레버리지 미국 나스닥 100 TR ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580077",
+    "name": "KB 인버스 2X 미국 나스닥 100 TR ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580078",
+    "name": "KB 은 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580079",
+    "name": "KB 레버리지 은 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580080",
+    "name": "KB 인버스 은 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580081",
+    "name": "KB 인버스 2X 은 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580082",
+    "name": "KB 레버리지 반도체 TOP10 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580083",
+    "name": "KB 레버리지 미국 S&P500 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580084",
+    "name": "KB 인버스 2X 미국 S&P500 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580085",
+    "name": "KB 솔랙티브 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580086",
+    "name": "KB 솔랙티브 레버리지 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q580087",
+    "name": "KB 솔랙티브 인버스 천연가스 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610001",
+    "name": "메리츠 인플레이션 국채 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610003",
+    "name": "메리츠 미국 인플레이션 국채 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610007",
+    "name": "메리츠 국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610008",
+    "name": "메리츠 레버리지 국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610009",
+    "name": "메리츠 인버스 국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610012",
+    "name": "메리츠 레버리지 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610013",
+    "name": "메리츠 인버스 2X 금 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610018",
+    "name": "메리츠 국채10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610020",
+    "name": "메리츠 인버스 국채10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610022",
+    "name": "메리츠 미국채10년 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610023",
+    "name": "메리츠 레버리지 미국채10년 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610024",
+    "name": "메리츠 인버스 미국채10년 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610025",
+    "name": "메리츠 인버스 2X 미국채10년 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610028",
+    "name": "메리츠 레버리지 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610029",
+    "name": "메리츠 인버스 2X 구리 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610030",
+    "name": "메리츠 S&P 유럽탄소배출권 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610034",
+    "name": "메리츠 대표 농산물 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610035",
+    "name": "메리츠 레버리지 대표 농산물 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610036",
+    "name": "메리츠 인버스 2X 대표 농산물 선물 ETN(H",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610037",
+    "name": "메리츠 미국채30년 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610038",
+    "name": "메리츠 레버리지 미국채30년 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610039",
+    "name": "메리츠 인버스 미국채30년 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610040",
+    "name": "메리츠 인버스 2X 미국채30년 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610045",
+    "name": "메리츠 국채3년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610047",
+    "name": "메리츠 인버스 국채3년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610049",
+    "name": "메리츠 국채5년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610051",
+    "name": "메리츠 인버스 국채5년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610055",
+    "name": "메리츠 3X 레버리지 국채3년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610056",
+    "name": "메리츠 인버스 3X 국채3년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610057",
+    "name": "메리츠 3X 레버리지 국채5년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610058",
+    "name": "메리츠 인버스 3X 국채5년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610059",
+    "name": "메리츠 3X 레버리지 국채10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610060",
+    "name": "메리츠 인버스 3X 국채10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610061",
+    "name": "메리츠 3X 레버리지 국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610062",
+    "name": "메리츠 인버스 3X 국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610063",
+    "name": "메리츠 KIS CD금리투자 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610064",
+    "name": "메리츠 KAP 통안채 6개월 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610066",
+    "name": "메리츠 KAP 통안채 3개월 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610067",
+    "name": "메리츠 블룸버그 2X 천연가스선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610068",
+    "name": "메리츠 KAP 일본 엔화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610069",
+    "name": "메리츠 KAP 레버리지 일본 엔화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610070",
+    "name": "메리츠 KAP 인버스 2X 일본 엔화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610071",
+    "name": "메리츠 KAP 중국 위안화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610072",
+    "name": "메리츠 KAP 레버리지 중국 위안화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610073",
+    "name": "메리츠 KAP 인버스 2X 중국 위안화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610074",
+    "name": "메리츠 미국채10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610075",
+    "name": "메리츠 3X 레버리지 미국채10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610076",
+    "name": "메리츠 인버스 3X 미국채10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610077",
+    "name": "메리츠 미국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610078",
+    "name": "메리츠 3X 레버리지 미국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610079",
+    "name": "메리츠 인버스 3X 미국채30년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610080",
+    "name": "메리츠 멕시코 페소화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610081",
+    "name": "메리츠 레버리지 멕시코 페소화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610082",
+    "name": "메리츠 인도 루피화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610083",
+    "name": "메리츠 레버리지 인도 루피화 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610084",
+    "name": "메리츠 미국채30년 스트립 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610085",
+    "name": "메리츠 레버리지 미국채30년 스트립 ETN(H",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610086",
+    "name": "메리츠 인버스2X 미국채30년 스트립 ETN(H",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610087",
+    "name": "메리츠 WTI원유 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610088",
+    "name": "메리츠 레버리지 WTI원유 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610089",
+    "name": "메리츠 인버스 2X WTI원유 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610090",
+    "name": "메리츠 일본 국채 10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610091",
+    "name": "메리츠 3X 레버리지 일본 국채 10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610092",
+    "name": "메리츠 인버스 일본 국채 10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610093",
+    "name": "메리츠 인버스 3X 일본 국채 10년 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610094",
+    "name": "메리츠 천연가스 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610095",
+    "name": "메리츠 레버리지 천연가스 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610096",
+    "name": "메리츠 인버스 2X 천연가스 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610097",
+    "name": "메리츠 미국채30년스트립 커버드콜 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610098",
+    "name": "메리츠 미국채30년 풋라이트 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610099",
+    "name": "메리츠 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610100",
+    "name": "메리츠 레버리지 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q610101",
+    "name": "메리츠 인버스 2X 은 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700011",
+    "name": "하나 레버리지 옥수수 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700012",
+    "name": "하나 인버스 2X 옥수수 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700013",
+    "name": "하나 레버리지 콩 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700014",
+    "name": "하나 인버스 2X 콩 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700017",
+    "name": "하나 레버리지 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700018",
+    "name": "하나 인버스 2X 코스닥150 선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700022",
+    "name": "하나 Solactive US Tech Top 10 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700023",
+    "name": "하나 Solactive 2X US Tech Top 10 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700025",
+    "name": "하나 블룸버그 2X 천연가스 선물 ETN(H) B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700026",
+    "name": "하나 CD금리투자 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700027",
+    "name": "하나 반도체 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700028",
+    "name": "하나 레버리지 반도체 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700029",
+    "name": "하나 S&P 레버리지 WTI원유 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700030",
+    "name": "하나 S&P 인버스 2X WTI원유 선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700031",
+    "name": "하나 레버리지 천연가스 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700032",
+    "name": "하나 인버스 2X 천연가스 선물 ETN(H)",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700033",
+    "name": "하나 K방산TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700034",
+    "name": "하나 레버리지 K방산TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700035",
+    "name": "하나 인버스 2X K방산TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q700036",
+    "name": "하나 인버스 2X 반도체 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760004",
+    "name": "키움 인버스 미국달러선물 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760005",
+    "name": "키움 INDXX 미국테크탑10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760006",
+    "name": "키움 KPOP ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760007",
+    "name": "키움 코스피 200 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760008",
+    "name": "키움 코스닥 150 TR ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760009",
+    "name": "키움 CD금리투자 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760010",
+    "name": "키움 2차전지산업 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760011",
+    "name": "키움 레버리지 2차전지산업 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760012",
+    "name": "키움 반도체TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760013",
+    "name": "키움 레버리지 반도체TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760014",
+    "name": "키움 바이오TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760015",
+    "name": "키움 레버리지 바이오TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760016",
+    "name": "키움 레버리지 조선TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760017",
+    "name": "키움 조선TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760018",
+    "name": "키움 미국달러선물 ETN B",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760019",
+    "name": "키움 리츠부동산인프라 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760020",
+    "name": "키움 레버리지 리츠부동산인프라 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760021",
+    "name": "키움 코스피200 선물 달러노출 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760022",
+    "name": "키움 K방산 TOP5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760023",
+    "name": "키움 레버리지 K방산 TOP5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760024",
+    "name": "키움 인버스 2X K방산 TOP5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760025",
+    "name": "키움 전력 TOP5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760026",
+    "name": "키움 레버리지 전력 TOP5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760027",
+    "name": "키움 인버스 2X 전력 TOP5 ETN",
+    "market": "KOSPI",
+    "aliases": []
+  },
+  {
+    "code": "Q760028",
+    "name": "키움 인버스 2X 반도체TOP10 ETN",
+    "market": "KOSPI",
+    "aliases": []
   }
 ]

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios from "axios";
 import dotenv from "dotenv";
-import { buildBalanceParams, formatPercent } from "./balance.js";
+import { buildBalanceParams, formatBalanceReport } from "./balance.js";
 import {
   createCashOrderRequest,
   formatOrderResult,
@@ -271,23 +271,7 @@ async function getBalance() {
     buildBalanceParams(KIS_ACCOUNT_NO),
   );
 
-  const summary = data.output2?.[0] || {};
-  const holdings = data.output1 || [];
-
-  const stockList = holdings
-    .map((h) => `- ${h.prdt_name} (${h.pdno}): ${h.hldg_qty}주 (평가금액: ${h.evlu_amt}원)`)
-    .join("\n");
-
-  return `
-[계좌 잔고 현황]
-- 총 평가금액: ${summary.tot_evlu_amt}원
-- 순자산금액: ${summary.pchs_amt_smtl_amt}원
-- 총 손익: ${summary.evlu_pfls_smtl_amt}원 (수익률: ${formatPercent(summary.evlu_pfls_rt)})
-- 예수금: ${summary.dnca_tot_amt}원
-
-[보유 종목 리스트]
-${stockList || "보유 종목이 없습니다."}
-  `.trim();
+  return formatBalanceReport(data);
 }
 
 async function placeOrder(args) {

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -297,7 +297,8 @@ async function placeOrder(args) {
   const stockName = String(args?.stock_name ?? "").trim() || stockCode;
   const side = String(args?.side ?? "").trim().toUpperCase();
   const quantity = args?.quantity;
-  const price = args?.price;
+  const orderType = String(args?.order_type ?? "LIMIT").trim().toUpperCase();
+  const price = args?.price ?? 0;
   const orderEnv = String(args?.order_env ?? "demo").trim().toLowerCase();
   const request = createCashOrderRequest({
     accountNo: KIS_ACCOUNT_NO,
@@ -307,6 +308,7 @@ async function placeOrder(args) {
     stockCode,
     quantity,
     price,
+    orderType,
   });
 
   const data = await kisPost(request.pathname, request.trId, request.body);
@@ -316,6 +318,7 @@ async function placeOrder(args) {
     side,
     quantity,
     price,
+    orderType,
     data,
   });
 }
@@ -374,7 +377,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: "place_order",
-      description: "한국투자증권 Open API로 국내 주식 현금 지정가 주문을 실행합니다.",
+      description: "한국투자증권 Open API로 국내 주식 현금 주문을 실행합니다.",
       inputSchema: {
         type: "object",
         properties: {
@@ -398,8 +401,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           },
           price: {
             type: "integer",
-            minimum: 1,
-            description: "지정가",
+            minimum: 0,
+            description: "지정가. 시장가 주문은 0 또는 생략",
+          },
+          order_type: {
+            type: "string",
+            enum: ["LIMIT", "MARKET"],
+            description: "지정가 또는 시장가",
           },
           order_env: {
             type: "string",
@@ -407,7 +415,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             description: "모의투자 또는 실계좌",
           },
         },
-        required: ["stock_code", "side", "quantity", "price", "order_env"],
+        required: ["stock_code", "side", "quantity", "order_env"],
       },
     },
   ],

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -11,6 +11,10 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios from "axios";
 import dotenv from "dotenv";
+import {
+  createCashOrderRequest,
+  formatOrderResult,
+} from "./order.js";
 
 // Redirect console.log to console.error to prevent breaking MCP JSON-RPC on stdout
 console.log = console.error;
@@ -176,6 +180,26 @@ async function kisGet(pathname, trId, params) {
   return data;
 }
 
+async function kisPost(pathname, trId, body) {
+  const token = await getAccessToken();
+  const response = await axios.post(`${KIS_URL}${pathname}`, body, {
+    headers: {
+      "Content-Type": "application/json",
+      authorization: `Bearer ${token}`,
+      appkey: KIS_API_KEY,
+      appsecret: KIS_API_SECRET,
+      tr_id: trId,
+      custtype: "P",
+    },
+  });
+
+  const data = response.data;
+  if (data.rt_cd !== "0") {
+    throw new Error(`KIS API 오류: ${data.msg1 || data.msg_cd || "알 수 없는 오류"}`);
+  }
+  return data;
+}
+
 function formatWon(value) {
   if (value === undefined || value === null || value === "") return "-";
   return `${Number(value).toLocaleString("ko-KR")}원`;
@@ -276,6 +300,36 @@ ${stockList || "보유 종목이 없습니다."}
   `.trim();
 }
 
+async function placeOrder(args) {
+  requireKisCredentials({ accountRequired: true });
+
+  const stockCode = String(args?.stock_code ?? "").trim() || resolveStock(args?.stock_name).code;
+  const stockName = String(args?.stock_name ?? "").trim() || stockCode;
+  const side = String(args?.side ?? "").trim().toUpperCase();
+  const quantity = args?.quantity;
+  const price = args?.price;
+  const orderEnv = String(args?.order_env ?? "demo").trim().toLowerCase();
+  const request = createCashOrderRequest({
+    accountNo: KIS_ACCOUNT_NO,
+    kisUrl: KIS_URL,
+    orderEnv,
+    side,
+    stockCode,
+    quantity,
+    price,
+  });
+
+  const data = await kisPost(request.pathname, request.trId, request.body);
+  return formatOrderResult({
+    stockName,
+    stockCode,
+    side,
+    quantity,
+    price,
+    data,
+  });
+}
+
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
@@ -328,6 +382,44 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ["stock_name"],
       },
     },
+    {
+      name: "place_order",
+      description: "한국투자증권 Open API로 국내 주식 현금 지정가 주문을 실행합니다.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          stock_name: {
+            type: "string",
+            description: "주식 종목명 또는 6자리 종목코드",
+          },
+          stock_code: {
+            type: "string",
+            description: "KIS API용 종목코드",
+          },
+          side: {
+            type: "string",
+            enum: ["BUY", "SELL"],
+            description: "매수 또는 매도",
+          },
+          quantity: {
+            type: "integer",
+            minimum: 1,
+            description: "주문 수량",
+          },
+          price: {
+            type: "integer",
+            minimum: 1,
+            description: "지정가",
+          },
+          order_env: {
+            type: "string",
+            enum: ["demo", "real"],
+            description: "모의투자 또는 실계좌",
+          },
+        },
+        required: ["stock_code", "side", "quantity", "price", "order_env"],
+      },
+    },
   ],
 }));
 
@@ -352,6 +444,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     if (name === "get_investor_trading") {
       return { content: [{ type: "text", text: await getInvestorTrading(args?.stock_name) }] };
+    }
+
+    if (name === "place_order") {
+      return { content: [{ type: "text", text: await placeOrder(args) }] };
     }
   } catch (error) {
     const prefix = name === "get_balance" ? "잔고 조회 중" : `${name} 실행 중`;

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -16,6 +16,7 @@ import {
   createCashOrderRequest,
   formatOrderResult,
 } from "./order.js";
+import { resolveStock } from "./stock-master.js";
 
 // Redirect console.log to console.error to prevent breaking MCP JSON-RPC on stdout
 console.log = console.error;
@@ -32,7 +33,6 @@ const {
 } = process.env;
 
 const KIS_BALANCE_TR_ID = KIS_URL?.includes("openapivts") ? "VTTC8434R" : "TTTC8434R";
-const STOCKS_PATH = path.join(__dirname, "data", "stocks.json");
 const TOKEN_TTL_MARGIN_MS = 60_000;
 const TOKEN_CACHE_PATH = process.env.KIS_TOKEN_CACHE_PATH || path.join(
   os.tmpdir(),
@@ -95,43 +95,6 @@ function writeTokenCache(cache) {
   } catch (error) {
     console.error(`KIS token cache write failed: ${error.message}`);
   }
-}
-
-function loadStocks() {
-  const text = fs.readFileSync(STOCKS_PATH, "utf8");
-  return JSON.parse(text);
-}
-
-function normalizeStockInput(value) {
-  return String(value ?? "").trim();
-}
-
-function resolveStock(stockName) {
-  const input = normalizeStockInput(stockName);
-  if (!input) {
-    throw new Error("stock_name 파라미터가 누락되었습니다.");
-  }
-
-  if (/^\d{6}$/.test(input)) {
-    return { code: input, name: input, market: "UNKNOWN" };
-  }
-
-  const stocks = loadStocks();
-  const matches = stocks.filter((stock) => {
-    const aliases = Array.isArray(stock.aliases) ? stock.aliases : [];
-    return stock.name === input || aliases.includes(input);
-  });
-
-  if (matches.length === 0) {
-    throw new Error(`'${input}'의 종목 코드를 찾을 수 없습니다. mcp-trading/data/stocks.json을 갱신하세요.`);
-  }
-
-  if (matches.length > 1) {
-    const candidates = matches.map((stock) => `${stock.name}(${stock.code}, ${stock.market})`).join(", ");
-    throw new Error(`'${input}'의 종목 매칭이 모호합니다: ${candidates}. 6자리 종목코드를 직접 입력하세요.`);
-  }
-
-  return matches[0];
 }
 
 async function getAccessToken() {

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -30,6 +30,7 @@ const {
   KIS_API_SECRET,
   KIS_ACCOUNT_NO,
   KIS_URL,
+  KIS_REAL_ORDER_ENABLED,
 } = process.env;
 
 const KIS_BALANCE_TR_ID = KIS_URL?.includes("openapivts") ? "VTTC8434R" : "TTTC8434R";
@@ -256,6 +257,7 @@ async function placeOrder(args) {
     quantity,
     price,
     orderType,
+    realOrderEnabled: KIS_REAL_ORDER_ENABLED === "true",
   });
 
   const data = await kisPost(request.pathname, request.trId, request.body);

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -11,6 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios from "axios";
 import dotenv from "dotenv";
+import { buildBalanceParams, formatPercent } from "./balance.js";
 import {
   createCashOrderRequest,
   formatOrderResult,
@@ -267,18 +268,7 @@ async function getBalance() {
   const data = await kisGet(
     "/uapi/domestic-stock/v1/trading/inquire-balance",
     KIS_BALANCE_TR_ID,
-    {
-      CANO: KIS_ACCOUNT_NO.substring(0, 8),
-      ACNT_PRDT_CD: KIS_ACCOUNT_NO.substring(8, 10),
-      AFHR_FLPR_YN: "N",
-      OFL_YN: "",
-      INQR_DVSN: "02",
-      UNPR_DVSN: "01",
-      FUND_STTL_ICLD_YN: "N",
-      FRLG_AMT_UNIT_CD: "00",
-      CTX_AREA_FK100: "",
-      CTX_AREA_NK100: "",
-    },
+    buildBalanceParams(KIS_ACCOUNT_NO),
   );
 
   const summary = data.output2?.[0] || {};
@@ -292,7 +282,7 @@ async function getBalance() {
 [계좌 잔고 현황]
 - 총 평가금액: ${summary.tot_evlu_amt}원
 - 순자산금액: ${summary.pchs_amt_smtl_amt}원
-- 총 손익: ${summary.evlu_pfls_smtl_amt}원 (수익률: ${summary.evlu_pfls_rt}%)
+- 총 손익: ${summary.evlu_pfls_smtl_amt}원 (수익률: ${formatPercent(summary.evlu_pfls_rt)})
 - 예수금: ${summary.dnca_tot_amt}원
 
 [보유 종목 리스트]

--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -1,0 +1,88 @@
+function normalizeSide(side) {
+  const normalized = String(side ?? "").trim().toUpperCase();
+  if (normalized !== "BUY" && normalized !== "SELL") {
+    throw new Error("side는 BUY 또는 SELL이어야 합니다.");
+  }
+  return normalized;
+}
+
+function normalizeOrderEnv(orderEnv) {
+  const normalized = String(orderEnv ?? "demo").trim().toLowerCase();
+  if (normalized !== "demo" && normalized !== "real") {
+    throw new Error("order_env는 demo 또는 real이어야 합니다.");
+  }
+  return normalized;
+}
+
+function assertPositiveInteger(value, fieldName) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error(`${fieldName}는 양의 정수여야 합니다.`);
+  }
+  return number;
+}
+
+export function selectCashOrderTrId({ orderEnv, side }) {
+  const env = normalizeOrderEnv(orderEnv);
+  const normalizedSide = normalizeSide(side);
+
+  if (env === "demo") {
+    return normalizedSide === "BUY" ? "VTTC0012U" : "VTTC0011U";
+  }
+  return normalizedSide === "BUY" ? "TTTC0012U" : "TTTC0011U";
+}
+
+export function validateOrderEnvMatchesUrl({ orderEnv, kisUrl }) {
+  const env = normalizeOrderEnv(orderEnv);
+  const url = String(kisUrl ?? "");
+  const isPaperUrl = url.includes("openapivts");
+
+  if (env === "demo" && !isPaperUrl) {
+    throw new Error("모의투자 주문은 모의투자 KIS_URL(openapivts)이 필요합니다.");
+  }
+  if (env === "real" && isPaperUrl) {
+    throw new Error("실계좌 주문은 실전 KIS_URL이 필요합니다.");
+  }
+}
+
+export function buildCashOrderBody({ accountNo, stockCode, quantity, price }) {
+  const account = String(accountNo ?? "").trim();
+  const code = String(stockCode ?? "").trim();
+  const orderQuantity = assertPositiveInteger(quantity, "quantity");
+  const orderPrice = assertPositiveInteger(price, "price");
+
+  if (account.length < 10) {
+    throw new Error("KIS_ACCOUNT_NO가 올바르지 않습니다. 계좌번호 앞 8자리와 상품코드 2자리를 붙여 설정하세요.");
+  }
+  if (!/^\d{6,7}$/.test(code)) {
+    throw new Error("stock_code는 6자리 또는 7자리 종목코드여야 합니다.");
+  }
+
+  return {
+    CANO: account.substring(0, 8),
+    ACNT_PRDT_CD: account.substring(8, 10),
+    PDNO: code,
+    ORD_DVSN: "00",
+    ORD_QTY: String(orderQuantity),
+    ORD_UNPR: String(orderPrice),
+    EXCG_ID_DVSN_CD: "SOR",
+    SLL_TYPE: "",
+    CNDT_PRIC: "",
+  };
+}
+
+export function formatOrderResult({ stockName, stockCode, side, quantity, price, data }) {
+  const output = data?.output || {};
+  const message = data?.msg1 || data?.msg_cd || "주문 요청이 접수되었습니다.";
+  const orderNo = output.ODNO || "-";
+  const orderTime = output.ORD_TMD || "-";
+
+  return [
+    `[${stockName}] ${normalizeSide(side)} 주문 접수`,
+    `- 종목코드: ${stockCode}`,
+    `- 수량/가격: ${Number(quantity).toLocaleString("ko-KR")}주 / ${Number(price).toLocaleString("ko-KR")}원`,
+    `- 주문번호: ${orderNo}`,
+    `- 주문시간: ${orderTime}`,
+    `- 메시지: ${message}`,
+  ].join("\n");
+}

--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -14,6 +14,14 @@ function normalizeOrderEnv(orderEnv) {
   return normalized;
 }
 
+function normalizeOrderType(orderType) {
+  const normalized = String(orderType ?? "LIMIT").trim().toUpperCase();
+  if (normalized !== "LIMIT" && normalized !== "MARKET") {
+    throw new Error("order_type은 LIMIT 또는 MARKET이어야 합니다.");
+  }
+  return normalized;
+}
+
 function assertPositiveInteger(value, fieldName) {
   const number = Number(value);
   if (!Number.isInteger(number) || number <= 0) {
@@ -45,11 +53,12 @@ export function validateOrderEnvMatchesUrl({ orderEnv, kisUrl }) {
   }
 }
 
-export function buildCashOrderBody({ accountNo, stockCode, quantity, price }) {
+export function buildCashOrderBody({ accountNo, stockCode, quantity, price, orderType }) {
   const account = String(accountNo ?? "").trim();
   const code = String(stockCode ?? "").trim();
   const orderQuantity = assertPositiveInteger(quantity, "quantity");
-  const orderPrice = assertPositiveInteger(price, "price");
+  const normalizedOrderType = normalizeOrderType(orderType);
+  const orderPrice = normalizedOrderType === "MARKET" ? 0 : assertPositiveInteger(price, "price");
 
   if (account.length < 10) {
     throw new Error("KIS_ACCOUNT_NO가 올바르지 않습니다. 계좌번호 앞 8자리와 상품코드 2자리를 붙여 설정하세요.");
@@ -62,7 +71,7 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price }) {
     CANO: account.substring(0, 8),
     ACNT_PRDT_CD: account.substring(8, 10),
     PDNO: code,
-    ORD_DVSN: "00",
+    ORD_DVSN: normalizedOrderType === "MARKET" ? "01" : "00",
     ORD_QTY: String(orderQuantity),
     ORD_UNPR: String(orderPrice),
     EXCG_ID_DVSN_CD: "SOR",
@@ -71,7 +80,7 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price }) {
   };
 }
 
-export function createCashOrderRequest({ accountNo, kisUrl, orderEnv, side, stockCode, quantity, price }) {
+export function createCashOrderRequest({ accountNo, kisUrl, orderEnv, side, stockCode, quantity, price, orderType }) {
   validateOrderEnvMatchesUrl({ orderEnv, kisUrl });
   return {
     pathname: "/uapi/domestic-stock/v1/trading/order-cash",
@@ -81,20 +90,24 @@ export function createCashOrderRequest({ accountNo, kisUrl, orderEnv, side, stoc
       stockCode,
       quantity,
       price,
+      orderType,
     }),
   };
 }
 
-export function formatOrderResult({ stockName, stockCode, side, quantity, price, data }) {
+export function formatOrderResult({ stockName, stockCode, side, quantity, price, orderType, data }) {
   const output = data?.output || {};
   const message = data?.msg1 || data?.msg_cd || "주문 요청이 접수되었습니다.";
   const orderNo = output.ODNO || "-";
   const orderTime = output.ORD_TMD || "-";
+  const priceText = normalizeOrderType(orderType) === "MARKET"
+    ? "시장가"
+    : `${Number(price).toLocaleString("ko-KR")}원`;
 
   return [
     `[${stockName}] ${normalizeSide(side)} 주문 접수`,
     `- 종목코드: ${stockCode}`,
-    `- 수량/가격: ${Number(quantity).toLocaleString("ko-KR")}주 / ${Number(price).toLocaleString("ko-KR")}원`,
+    `- 수량/가격: ${Number(quantity).toLocaleString("ko-KR")}주 / ${priceText}`,
     `- 주문번호: ${orderNo}`,
     `- 주문시간: ${orderTime}`,
     `- 메시지: ${message}`,

--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -71,6 +71,20 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price }) {
   };
 }
 
+export function createCashOrderRequest({ accountNo, kisUrl, orderEnv, side, stockCode, quantity, price }) {
+  validateOrderEnvMatchesUrl({ orderEnv, kisUrl });
+  return {
+    pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+    trId: selectCashOrderTrId({ orderEnv, side }),
+    body: buildCashOrderBody({
+      accountNo,
+      stockCode,
+      quantity,
+      price,
+    }),
+  };
+}
+
 export function formatOrderResult({ stockName, stockCode, side, quantity, price, data }) {
   const output = data?.output || {};
   const message = data?.msg1 || data?.msg_cd || "주문 요청이 접수되었습니다.";

--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -53,6 +53,13 @@ export function validateOrderEnvMatchesUrl({ orderEnv, kisUrl }) {
   }
 }
 
+export function validateRealOrderGuard({ orderEnv, realOrderEnabled }) {
+  const env = normalizeOrderEnv(orderEnv);
+  if (env === "real" && realOrderEnabled !== true) {
+    throw new Error("실계좌 주문은 KIS_REAL_ORDER_ENABLED=true 설정이 필요합니다.");
+  }
+}
+
 export function buildCashOrderBody({ accountNo, stockCode, quantity, price, orderType }) {
   const account = String(accountNo ?? "").trim();
   const code = String(stockCode ?? "").trim();
@@ -80,7 +87,18 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price, orde
   };
 }
 
-export function createCashOrderRequest({ accountNo, kisUrl, orderEnv, side, stockCode, quantity, price, orderType }) {
+export function createCashOrderRequest({
+  accountNo,
+  kisUrl,
+  orderEnv,
+  side,
+  stockCode,
+  quantity,
+  price,
+  orderType,
+  realOrderEnabled = false,
+}) {
+  validateRealOrderGuard({ orderEnv, realOrderEnabled });
   validateOrderEnvMatchesUrl({ orderEnv, kisUrl });
   return {
     pathname: "/uapi/domestic-stock/v1/trading/order-cash",

--- a/mcp-trading/package.json
+++ b/mcp-trading/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/mcp-trading/scripts/update_stock_master.py
+++ b/mcp-trading/scripts/update_stock_master.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import json
 import shutil
-import ssl
 import tempfile
 import urllib.request
 import zipfile
@@ -40,8 +39,7 @@ def load_existing_aliases():
 
 def download_source(source, target_dir):
     archive_path = target_dir / f"{source['market'].lower()}_code.mst.zip"
-    context = ssl._create_unverified_context()
-    with urllib.request.urlopen(source["url"], context=context) as response:
+    with urllib.request.urlopen(source["url"]) as response:
         with archive_path.open("wb") as archive_file:
             shutil.copyfileobj(response, archive_file)
     with zipfile.ZipFile(archive_path) as archive:

--- a/mcp-trading/scripts/update_stock_master.py
+++ b/mcp-trading/scripts/update_stock_master.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import json
+import shutil
+import ssl
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+STOCKS_PATH = ROOT_DIR / "data" / "stocks.json"
+SOURCES = [
+    {
+        "market": "KOSPI",
+        "url": "https://new.real.download.dws.co.kr/common/master/kospi_code.mst.zip",
+        "file_name": "kospi_code.mst",
+        "tail_width": 228,
+    },
+    {
+        "market": "KOSDAQ",
+        "url": "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip",
+        "file_name": "kosdaq_code.mst",
+        "tail_width": 222,
+    },
+]
+
+
+def load_existing_aliases():
+    if not STOCKS_PATH.exists():
+        return {}
+    stocks = json.loads(STOCKS_PATH.read_text(encoding="utf-8"))
+    aliases_by_code = {}
+    for stock in stocks:
+        aliases = stock.get("aliases")
+        if isinstance(aliases, list):
+            aliases_by_code[str(stock.get("code", ""))] = aliases
+    return aliases_by_code
+
+
+def download_source(source, target_dir):
+    archive_path = target_dir / f"{source['market'].lower()}_code.mst.zip"
+    context = ssl._create_unverified_context()
+    with urllib.request.urlopen(source["url"], context=context) as response:
+        with archive_path.open("wb") as archive_file:
+            shutil.copyfileobj(response, archive_file)
+    with zipfile.ZipFile(archive_path) as archive:
+        archive.extract(source["file_name"], target_dir)
+    return target_dir / source["file_name"]
+
+
+def parse_master_rows(file_path, *, market, tail_width, aliases_by_code):
+    stocks = []
+    with file_path.open(encoding="cp949") as file:
+        for row in file:
+            header = row[: len(row.rstrip("\n")) - tail_width]
+            code = header[:9].strip()
+            name = header[21:].strip()
+            if not code or not name:
+                continue
+            stocks.append(
+                {
+                    "code": code,
+                    "name": name,
+                    "market": market,
+                    "aliases": aliases_by_code.get(code, []),
+                }
+            )
+    return stocks
+
+
+def main():
+    aliases_by_code = load_existing_aliases()
+    with tempfile.TemporaryDirectory() as temp_name:
+        temp_dir = Path(temp_name)
+        stocks = []
+        for source in SOURCES:
+            file_path = download_source(source, temp_dir)
+            stocks.extend(
+                parse_master_rows(
+                    file_path,
+                    market=source["market"],
+                    tail_width=source["tail_width"],
+                    aliases_by_code=aliases_by_code,
+                )
+            )
+
+    stocks.sort(key=lambda stock: (stock["market"], stock["code"]))
+    next_text = json.dumps(stocks, ensure_ascii=False, indent=2) + "\n"
+    STOCKS_PATH.write_text(next_text, encoding="utf-8")
+    print(f"updated {STOCKS_PATH} with {len(stocks)} stocks")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const DEFAULT_STOCKS_PATH = path.join(__dirname, "data", "stocks.json");
+
+export function loadStocks(stocksPath = DEFAULT_STOCKS_PATH) {
+  const text = fs.readFileSync(stocksPath, "utf8");
+  return JSON.parse(text);
+}
+
+export function normalizeStockInput(value) {
+  return String(value ?? "").trim();
+}
+
+export function resolveStock(stockName, stocks = loadStocks()) {
+  const input = normalizeStockInput(stockName);
+  if (!input) {
+    throw new Error("stock_name 파라미터가 누락되었습니다.");
+  }
+
+  if (/^[A-Z0-9]{6,7}$/i.test(input)) {
+    const code = input.toUpperCase();
+    return { code, name: code, market: "UNKNOWN", aliases: [] };
+  }
+
+  const matches = stocks.filter((stock) => {
+    const aliases = Array.isArray(stock.aliases) ? stock.aliases : [];
+    return stock.name === input || aliases.includes(input);
+  });
+
+  if (matches.length === 0) {
+    throw new Error(
+      `'${input}'의 종목 코드를 찾을 수 없습니다. ` +
+        "6자리 종목코드로 직접 입력하거나 mcp-trading/data/stocks.json을 갱신하세요.",
+    );
+  }
+
+  if (matches.length > 1) {
+    const candidates = matches
+      .map((stock) => `${stock.name}(${stock.code}, ${stock.market})`)
+      .join(", ");
+    throw new Error(`'${input}'의 종목 매칭이 모호합니다: ${candidates}. 6자리 종목코드를 직접 입력하세요.`);
+  }
+
+  return {
+    aliases: [],
+    ...matches[0],
+  };
+}

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -48,7 +48,11 @@ test("buildBalanceParams includes required KIS inquire-balance fields", () => {
 
 test("formatPercent avoids undefined balance rates", () => {
   assert.equal(formatPercent(undefined), "-");
-  assert.equal(formatPercent("1.23"), "1.23%");
+  assert.equal(formatPercent("1.23"), "🔴 ▲ +1.23%");
+  assert.equal(formatPercent("-1.23"), "🔵 ▼ -1.23%");
+  assert.equal(formatPercent("0.00"), "⚪ 0.00%");
+  assert.equal(formatPercent("0.02079000"), "🔴 ▲ +0.02%");
+  assert.equal(formatPercent("-0.251"), "🔵 ▼ -0.26%");
 });
 
 test("formatBalanceReport displays unsettled cash fields and account return rate", () => {
@@ -59,9 +63,19 @@ test("formatBalanceReport displays unsettled cash fields and account return rate
           prdt_name: "삼성전자",
           pdno: "005930",
           hldg_qty: "3",
+          pchs_avg_pric: "67000",
           evlu_amt: "210000",
           evlu_pfls_amt: "9000",
           evlu_pfls_rt: "4.48",
+        },
+        {
+          prdt_name: "NAVER",
+          pdno: "035420",
+          hldg_qty: "1",
+          pchs_avg_pric: "201000",
+          evlu_amt: "200500",
+          evlu_pfls_amt: "-500",
+          evlu_pfls_rt: "-0.25",
         },
       ],
       output2: [
@@ -81,14 +95,60 @@ test("formatBalanceReport displays unsettled cash fields and account return rate
     `[계좌 잔고 현황]
 - 총 평가금액: 1,210,000원
 - 순자산금액: 1,210,000원
-- 총 손익: 9,000원 (수익률: 0.75%)
+- 총 손익: 9,000원 (수익률: 🔴 ▲ +0.75%)
 - 예수금총액: 1,000,000원
 - 가수도정산금액: 1,009,000원
 - 익일정산금액: 790,000원
 - 금일 매수/매도: 210,000원 / 0원
 
 [보유 종목 리스트]
-- 삼성전자 (005930): 3주 (평가금액: 210,000원, 평가손익: 9,000원, 수익률: 4.48%)`,
+- 삼성전자 (005930) · 3주
+  평단가 67,000원 → 평가금액 210,000원
+  손익 +9,000원 · 수익률 🔴 ▲ +4.48%
+
+- NAVER (035420) · 1주
+  평단가 201,000원 → 평가금액 200,500원
+  손익 -500원 · 수익률 🔵 ▼ -0.25%`,
+  );
+});
+
+test("formatBalanceReport highlights negative return rates", () => {
+  assert.equal(
+    formatBalanceReport({
+      output1: [
+        {
+          prdt_name: "삼성전자",
+          pdno: "005930",
+          hldg_qty: "3",
+          pchs_avg_pric: "66666.67",
+          evlu_amt: "190000",
+          evlu_pfls_amt: "-10000",
+          evlu_pfls_rt: "-5.00",
+        },
+      ],
+      output2: [
+        {
+          tot_evlu_amt: "1190000",
+          nass_amt: "1190000",
+          evlu_pfls_smtl_amt: "-10000",
+          asst_icdc_erng_rt: "-0.84",
+          dnca_tot_amt: "1000000",
+        },
+      ],
+    }),
+    `[계좌 잔고 현황]
+- 총 평가금액: 1,190,000원
+- 순자산금액: 1,190,000원
+- 총 손익: -10,000원 (수익률: 🔵 ▼ -0.84%)
+- 예수금총액: 1,000,000원
+- 가수도정산금액: -
+- 익일정산금액: -
+- 금일 매수/매도: - / -
+
+[보유 종목 리스트]
+- 삼성전자 (005930) · 3주
+  평단가 66,666.67원 → 평가금액 190,000원
+  손익 -10,000원 · 수익률 🔵 ▼ -5.00%`,
   );
 });
 

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildCashOrderBody,
+  createCashOrderRequest,
   formatOrderResult,
   selectCashOrderTrId,
   validateOrderEnvMatchesUrl,
@@ -61,5 +62,34 @@ test("formatOrderResult includes order number when present", () => {
       data: { output: { ODNO: "12345", ORD_TMD: "101010" }, msg1: "주문이 완료되었습니다" },
     }),
     "[삼성전자] BUY 주문 접수\n- 종목코드: 005930\n- 수량/가격: 1주 / 70,000원\n- 주문번호: 12345\n- 주문시간: 101010\n- 메시지: 주문이 완료되었습니다",
+  );
+});
+
+test("createCashOrderRequest builds KIS endpoint, TR ID, and body", () => {
+  assert.deepEqual(
+    createCashOrderRequest({
+      accountNo: "1234567801",
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      orderEnv: "demo",
+      side: "SELL",
+      stockCode: "005930",
+      quantity: 3,
+      price: 68000,
+    }),
+    {
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0011U",
+      body: {
+        CANO: "12345678",
+        ACNT_PRDT_CD: "01",
+        PDNO: "005930",
+        ORD_DVSN: "00",
+        ORD_QTY: "3",
+        ORD_UNPR: "68000",
+        EXCG_ID_DVSN_CD: "SOR",
+        SLL_TYPE: "",
+        CNDT_PRIC: "",
+      },
+    },
   );
 });

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildCashOrderBody,
+  formatOrderResult,
+  selectCashOrderTrId,
+  validateOrderEnvMatchesUrl,
+} from "../order.js";
+
+test("selectCashOrderTrId maps demo buy and sell to paper TR IDs", () => {
+  assert.equal(selectCashOrderTrId({ orderEnv: "demo", side: "BUY" }), "VTTC0012U");
+  assert.equal(selectCashOrderTrId({ orderEnv: "demo", side: "SELL" }), "VTTC0011U");
+});
+
+test("selectCashOrderTrId maps real buy and sell to production TR IDs", () => {
+  assert.equal(selectCashOrderTrId({ orderEnv: "real", side: "BUY" }), "TTTC0012U");
+  assert.equal(selectCashOrderTrId({ orderEnv: "real", side: "SELL" }), "TTTC0011U");
+});
+
+test("validateOrderEnvMatchesUrl fails closed on env and URL mismatch", () => {
+  assert.throws(
+    () => validateOrderEnvMatchesUrl({ orderEnv: "demo", kisUrl: "https://openapi.koreainvestment.com:9443" }),
+    /모의투자 주문은 모의투자 KIS_URL/,
+  );
+  assert.throws(
+    () => validateOrderEnvMatchesUrl({ orderEnv: "real", kisUrl: "https://openapivts.koreainvestment.com:29443" }),
+    /실계좌 주문은 실전 KIS_URL/,
+  );
+});
+
+test("buildCashOrderBody creates uppercase KIS order body", () => {
+  assert.deepEqual(
+    buildCashOrderBody({
+      accountNo: "1234567801",
+      stockCode: "005930",
+      quantity: 2,
+      price: 70000,
+    }),
+    {
+      CANO: "12345678",
+      ACNT_PRDT_CD: "01",
+      PDNO: "005930",
+      ORD_DVSN: "00",
+      ORD_QTY: "2",
+      ORD_UNPR: "70000",
+      EXCG_ID_DVSN_CD: "SOR",
+      SLL_TYPE: "",
+      CNDT_PRIC: "",
+    },
+  );
+});
+
+test("formatOrderResult includes order number when present", () => {
+  assert.equal(
+    formatOrderResult({
+      stockName: "삼성전자",
+      stockCode: "005930",
+      side: "BUY",
+      quantity: 1,
+      price: 70000,
+      data: { output: { ODNO: "12345", ORD_TMD: "101010" }, msg1: "주문이 완료되었습니다" },
+    }),
+    "[삼성전자] BUY 주문 접수\n- 종목코드: 005930\n- 수량/가격: 1주 / 70,000원\n- 주문번호: 12345\n- 주문시간: 101010\n- 메시지: 주문이 완료되었습니다",
+  );
+});

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildBalanceParams, formatPercent } from "../balance.js";
+import { buildBalanceParams, formatBalanceReport, formatPercent } from "../balance.js";
 import {
   buildCashOrderBody,
   createCashOrderRequest,
@@ -49,6 +49,47 @@ test("buildBalanceParams includes required KIS inquire-balance fields", () => {
 test("formatPercent avoids undefined balance rates", () => {
   assert.equal(formatPercent(undefined), "-");
   assert.equal(formatPercent("1.23"), "1.23%");
+});
+
+test("formatBalanceReport displays unsettled cash fields and account return rate", () => {
+  assert.equal(
+    formatBalanceReport({
+      output1: [
+        {
+          prdt_name: "삼성전자",
+          pdno: "005930",
+          hldg_qty: "3",
+          evlu_amt: "210000",
+          evlu_pfls_amt: "9000",
+          evlu_pfls_rt: "4.48",
+        },
+      ],
+      output2: [
+        {
+          tot_evlu_amt: "1210000",
+          nass_amt: "1210000",
+          evlu_pfls_smtl_amt: "9000",
+          asst_icdc_erng_rt: "0.75",
+          dnca_tot_amt: "1000000",
+          nxdy_excc_amt: "790000",
+          prvs_rcdl_excc_amt: "1009000",
+          thdt_buy_amt: "210000",
+          thdt_sll_amt: "0",
+        },
+      ],
+    }),
+    `[계좌 잔고 현황]
+- 총 평가금액: 1,210,000원
+- 순자산금액: 1,210,000원
+- 총 손익: 9,000원 (수익률: 0.75%)
+- 예수금총액: 1,000,000원
+- 가수도정산금액: 1,009,000원
+- 익일정산금액: 790,000원
+- 금일 매수/매도: 210,000원 / 0원
+
+[보유 종목 리스트]
+- 삼성전자 (005930): 3주 (평가금액: 210,000원, 평가손익: 9,000원, 수익률: 4.48%)`,
+  );
 });
 
 test("buildCashOrderBody creates uppercase KIS order body", () => {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { buildBalanceParams, formatPercent } from "../balance.js";
 import {
   buildCashOrderBody,
   createCashOrderRequest,
@@ -27,6 +28,27 @@ test("validateOrderEnvMatchesUrl fails closed on env and URL mismatch", () => {
     () => validateOrderEnvMatchesUrl({ orderEnv: "real", kisUrl: "https://openapivts.koreainvestment.com:29443" }),
     /실계좌 주문은 실전 KIS_URL/,
   );
+});
+
+test("buildBalanceParams includes required KIS inquire-balance fields", () => {
+  assert.deepEqual(buildBalanceParams("1234567801"), {
+    CANO: "12345678",
+    ACNT_PRDT_CD: "01",
+    AFHR_FLPR_YN: "N",
+    OFL_YN: "",
+    INQR_DVSN: "02",
+    UNPR_DVSN: "01",
+    FUND_STTL_ICLD_YN: "N",
+    FNCG_AMT_AUTO_RDPT_YN: "N",
+    PRCS_DVSN: "00",
+    CTX_AREA_FK100: "",
+    CTX_AREA_NK100: "",
+  });
+});
+
+test("formatPercent avoids undefined balance rates", () => {
+  assert.equal(formatPercent(undefined), "-");
+  assert.equal(formatPercent("1.23"), "1.23%");
 });
 
 test("buildCashOrderBody creates uppercase KIS order body", () => {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -30,6 +30,40 @@ test("validateOrderEnvMatchesUrl fails closed on env and URL mismatch", () => {
   );
 });
 
+test("createCashOrderRequest rejects real order when real-order guard is disabled", () => {
+  assert.throws(
+    () => createCashOrderRequest({
+      accountNo: "1234567801",
+      kisUrl: "https://openapi.koreainvestment.com:9443",
+      orderEnv: "real",
+      side: "BUY",
+      stockCode: "005930",
+      quantity: 1,
+      price: 0,
+      orderType: "MARKET",
+      realOrderEnabled: false,
+    }),
+    /KIS_REAL_ORDER_ENABLED=true/,
+  );
+});
+
+test("createCashOrderRequest allows real order when real-order guard is enabled", () => {
+  assert.equal(
+    createCashOrderRequest({
+      accountNo: "1234567801",
+      kisUrl: "https://openapi.koreainvestment.com:9443",
+      orderEnv: "real",
+      side: "SELL",
+      stockCode: "005930",
+      quantity: 1,
+      price: 70000,
+      orderType: "LIMIT",
+      realOrderEnabled: true,
+    }).trId,
+    "TTTC0011U",
+  );
+});
+
 test("buildBalanceParams includes required KIS inquire-balance fields", () => {
   assert.deepEqual(buildBalanceParams("1234567801"), {
     CANO: "12345678",

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -58,6 +58,7 @@ test("buildCashOrderBody creates uppercase KIS order body", () => {
       stockCode: "005930",
       quantity: 2,
       price: 70000,
+      orderType: "LIMIT",
     }),
     {
       CANO: "12345678",
@@ -73,6 +74,29 @@ test("buildCashOrderBody creates uppercase KIS order body", () => {
   );
 });
 
+test("buildCashOrderBody creates market KIS order body", () => {
+  assert.deepEqual(
+    buildCashOrderBody({
+      accountNo: "1234567801",
+      stockCode: "005930",
+      quantity: 2,
+      price: 0,
+      orderType: "MARKET",
+    }),
+    {
+      CANO: "12345678",
+      ACNT_PRDT_CD: "01",
+      PDNO: "005930",
+      ORD_DVSN: "01",
+      ORD_QTY: "2",
+      ORD_UNPR: "0",
+      EXCG_ID_DVSN_CD: "SOR",
+      SLL_TYPE: "",
+      CNDT_PRIC: "",
+    },
+  );
+});
+
 test("formatOrderResult includes order number when present", () => {
   assert.equal(
     formatOrderResult({
@@ -81,6 +105,7 @@ test("formatOrderResult includes order number when present", () => {
       side: "BUY",
       quantity: 1,
       price: 70000,
+      orderType: "LIMIT",
       data: { output: { ODNO: "12345", ORD_TMD: "101010" }, msg1: "주문이 완료되었습니다" },
     }),
     "[삼성전자] BUY 주문 접수\n- 종목코드: 005930\n- 수량/가격: 1주 / 70,000원\n- 주문번호: 12345\n- 주문시간: 101010\n- 메시지: 주문이 완료되었습니다",
@@ -97,6 +122,7 @@ test("createCashOrderRequest builds KIS endpoint, TR ID, and body", () => {
       stockCode: "005930",
       quantity: 3,
       price: 68000,
+      orderType: "LIMIT",
     }),
     {
       pathname: "/uapi/domestic-stock/v1/trading/order-cash",
@@ -108,6 +134,36 @@ test("createCashOrderRequest builds KIS endpoint, TR ID, and body", () => {
         ORD_DVSN: "00",
         ORD_QTY: "3",
         ORD_UNPR: "68000",
+        EXCG_ID_DVSN_CD: "SOR",
+        SLL_TYPE: "",
+        CNDT_PRIC: "",
+      },
+    },
+  );
+});
+
+test("createCashOrderRequest builds market order body", () => {
+  assert.deepEqual(
+    createCashOrderRequest({
+      accountNo: "1234567801",
+      kisUrl: "https://openapivts.koreainvestment.com:29443",
+      orderEnv: "demo",
+      side: "BUY",
+      stockCode: "005930",
+      quantity: 3,
+      price: 0,
+      orderType: "MARKET",
+    }),
+    {
+      pathname: "/uapi/domestic-stock/v1/trading/order-cash",
+      trId: "VTTC0012U",
+      body: {
+        CANO: "12345678",
+        ACNT_PRDT_CD: "01",
+        PDNO: "005930",
+        ORD_DVSN: "01",
+        ORD_QTY: "3",
+        ORD_UNPR: "0",
         EXCG_ID_DVSN_CD: "SOR",
         SLL_TYPE: "",
         CNDT_PRIC: "",

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveStock } from "../stock-master.js";
+
+test("resolveStock resolves names from the expanded domestic stock master", () => {
+  assert.deepEqual(resolveStock("카카오"), {
+    code: "035720",
+    name: "카카오",
+    market: "KOSPI",
+    aliases: [],
+  });
+});
+
+test("resolveStock keeps 6 digit stock codes available without master entries", () => {
+  assert.deepEqual(resolveStock("123456"), {
+    code: "123456",
+    name: "123456",
+    market: "UNKNOWN",
+    aliases: [],
+  });
+});
+
+test("resolveStock keeps alphanumeric KIS stock codes available without master entries", () => {
+  assert.deepEqual(resolveStock("0001a0"), {
+    code: "0001A0",
+    name: "0001A0",
+    market: "UNKNOWN",
+    aliases: [],
+  });
+});
+
+test("resolveStock guides users to 6 digit stock codes when a name is missing", () => {
+  assert.throws(
+    () => resolveStock("없는종목"),
+    /6자리 종목코드로 직접 입력/,
+  );
+});

--- a/mcp-trading/tests/test_update_stock_master.py
+++ b/mcp-trading/tests/test_update_stock_master.py
@@ -1,0 +1,60 @@
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "update_stock_master.py"
+
+
+def load_update_stock_master():
+    spec = importlib.util.spec_from_file_location("update_stock_master", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_download_source_uses_default_tls_verification(monkeypatch, tmp_path):
+    module = load_update_stock_master()
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def read(self, size=-1):
+            return b""
+
+    class FakeZipFile:
+        def __init__(self, archive_path):
+            self.archive_path = archive_path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def extract(self, file_name, target_dir):
+            (target_dir / file_name).write_text("", encoding="utf-8")
+
+    def fake_urlopen(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return FakeResponse()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(module.zipfile, "ZipFile", FakeZipFile)
+
+    source = {
+        "market": "KOSPI",
+        "url": "https://example.com/kospi.zip",
+        "file_name": "kospi_code.mst",
+    }
+
+    file_path = module.download_source(source, tmp_path)
+
+    assert file_path == tmp_path / "kospi_code.mst"
+    assert captured == {"url": source["url"], "kwargs": {}}


### PR DESCRIPTION
## 📝 개요

Telegram에서 국내 주식 수동 주문을 준비하고, 확인 후 실행할 수 있는 매매 명령 흐름을 추가합니다. `/buy`, `/sell`과 자연어 주문 문장은 주문을 즉시 실행하지 않고 대기 주문을 만들며, 사용자가 `/confirm` 또는 Telegram 인라인 버튼으로 확정해야 실제 주문 경로로 전달됩니다.

Telegram 수동 매매는 NAT을 경유하지 않습니다. 주문 의도 해석, 대기 주문 생성, 확인 버튼 처리, 최종 `mcp-trading` 주문 호출은 backend Telegram command handler가 담당하며, NAT fallback은 주문으로 해석되지 않은 일반 Telegram 대화에만 사용됩니다.

잔고 조회 결과도 실제 KIS 응답 필드에 맞춰 예수금/정산금/수익률/보유종목 표시를 보강했습니다. 종목명 기반 주문/조회가 4개 고정 목록에 묶이지 않도록 KIS 공개 코스피·코스닥 종목 마스터 기반 캐시도 확장했습니다.

## 🚀 변경 사항
- Telegram `/buy`, `/sell`, `/confirm`, `/cancel` 명령과 주문 만료/중복 실행 방지 흐름 추가
- 지정가 생략 시 시장가 주문 준비, 주문 확인 메시지의 인라인 확정/취소 버튼 추가
- 주문 확인 버튼에 주문별 callback token을 붙여 예전 메시지 버튼이 최신 대기 주문을 실행하지 못하도록 보강
- `삼성전자 1주 시장가로 매수해줘` 같은 자연어 매수·매도 문장을 backend parser로 해석해 기존 주문 확인 대기 흐름에 연결
- Telegram 수동 주문은 NAT을 경유하지 않고 backend에서 직접 로컬 `mcp-trading`을 호출하도록 경계 명시
- `mcp-trading` KIS 주문 실행 도구와 주문 payload 헬퍼 추가
- `mcp-trading` 직접 호출 경로에도 `KIS_REAL_ORDER_ENABLED=true` 실계좌 주문 가드 추가
- KIS 잔고 조회 포맷 개선: 예수금총액, 정산금, 당일 매수/매도, 계좌/종목 수익률, 평단가 표시
- 수익률 방향 이모지와 소수점 둘째 자리 내림 표시 적용
- KIS 코스피·코스닥 종목 마스터 기반 `stocks.json` 확장 및 갱신 스크립트 추가
- 종목 마스터 갱신 스크립트의 TLS 인증서 검증 비활성화 제거
- Telegram 명령, notifier, 주문 도메인, mcp-trading 주문/잔고/종목 해석 테스트 보강

## 🔗 관련 이슈
- Related to #43

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)

<img width="347" height="409" alt="image" src="https://github.com/user-attachments/assets/fa4b580e-93ea-42a9-af46-eff528ad57dd" />

<img width="337" height="408" alt="image" src="https://github.com/user-attachments/assets/86594fb7-f7e9-4914-97fb-0628381695e9" />
