### PR TITLE
feat: Telegram 버튼 UX 확장

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 /alerts status  # 현재 알림 모드 확인
 /help           # 사용 가능한 Telegram 명령 확인
 /balance        # 예수금·총자산·보유 종목 조회
+/trade          # 수동 매수·매도 입력 안내
+/lookup         # 현재가·수급 조회 입력 안내
 /quote <종목명> # 현재가 조회
 /trend <종목명> # 외국인·기관·개인 수급 조회
 /buy <종목명|6자리코드> <수량> [지정가]  # 60초 매수 확인 대기 생성
@@ -173,9 +175,9 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 
 `/buy`와 `/sell`은 60초 동안 유효한 주문 확인 대기를 만들고, 지정가를 생략하면 시장가 주문으로 준비합니다. 주문 확인 메시지의 `확정`/`취소` 버튼 또는 `/confirm`/`/cancel` 명령으로 처리할 수 있습니다. `/confirm`은 로컬 `mcp-trading`의 `place_order` 도구를 통해 한국투자증권 Open API 현금 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령도 같은 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
 
-Telegram 명령은 슬래시 명령을 계속 지원하면서 일부 응답에 버튼을 함께 제공합니다. `/help`는 잔고 조회와 알림 상태 버튼을 제공하고, `/alerts` 응답은 `🚨 긴급만`·`📣 전체`·`🔕 끄기`·`🔎 현재 상태` 버튼으로 모드를 바꿀 수 있습니다. `/balance` 결과는 새로고침 버튼을 제공하며, `/quote`와 `/trend` 결과는 같은 종목의 현재가·수급 조회를 오가는 버튼을 제공합니다.
+Telegram 명령은 슬래시 명령을 계속 지원하면서 일부 응답에 버튼을 함께 제공합니다. `/help`는 잔고 조회와 알림 상태 버튼을 제공하고, `/alerts` 응답은 `🚨 긴급만`·`📣 전체`·`🔕 끄기`·`🔎 현재 상태` 버튼으로 모드를 바꿀 수 있습니다. `/trade`는 수동 매수·매도 입력을 안내하고, `/lookup`은 현재가·수급 조회 입력을 안내합니다. `/balance` 결과는 새로고침 버튼을 제공하며, `/quote`와 `/trend` 결과는 같은 종목의 현재가·수급 조회를 오가는 버튼을 제공합니다.
 
-봇 시작 시 Telegram Bot Command Menu도 등록합니다. Telegram 채팅방의 명령 메뉴에서 `/help`, `/balance`, `/alerts`, `/quote`, `/trend`, `/buy`, `/sell`, `/confirm`, `/cancel`을 선택할 수 있으며, 기존 슬래시 명령과 인라인 버튼은 그대로 사용할 수 있습니다.
+봇 시작 시 Telegram Bot Command Menu도 등록합니다. Telegram 채팅방의 명령 메뉴에는 인자 없이 시작하는 `/help`, `/balance`, `/alerts`, `/trade`, `/lookup` 진입점을 노출합니다. 기존 슬래시 명령인 `/buy`, `/sell`, `/quote`, `/trend`, `/confirm`, `/cancel`과 인라인 버튼은 메뉴 노출 여부와 관계없이 계속 사용할 수 있습니다.
 
 슬래시 명령 대신 `삼성전자 1주 시장가로 매수해줘`, `NAVER 2주 200,000원에 매도해줘`처럼 입력해도 같은 주문 확인 대기가 생성됩니다. 자연어 주문도 실제 제출 전에는 반드시 `확정` 버튼 또는 `/confirm`이 필요합니다.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 
 `/buy`와 `/sell`은 60초 동안 유효한 주문 확인 대기를 만들고, 지정가를 생략하면 시장가 주문으로 준비합니다. 주문 확인 메시지의 `확정`/`취소` 버튼 또는 `/confirm`/`/cancel` 명령으로 처리할 수 있습니다. `/confirm`은 로컬 `mcp-trading`의 `place_order` 도구를 통해 한국투자증권 Open API 현금 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령도 같은 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
 
-Telegram 명령은 슬래시 명령을 계속 지원하면서 일부 응답에 버튼을 함께 제공합니다. `/help`는 잔고 조회와 알림 상태 버튼을 제공하고, `/alerts` 응답은 `긴급만`·`전체`·`끄기`·`현재 상태` 버튼으로 모드를 바꿀 수 있습니다. `/balance` 결과는 새로고침 버튼을 제공하며, `/quote`와 `/trend` 결과는 같은 종목의 현재가·수급 조회를 오가는 버튼을 제공합니다.
+Telegram 명령은 슬래시 명령을 계속 지원하면서 일부 응답에 버튼을 함께 제공합니다. `/help`는 잔고 조회와 알림 상태 버튼을 제공하고, `/alerts` 응답은 `🚨 긴급만`·`📣 전체`·`🔕 끄기`·`🔎 현재 상태` 버튼으로 모드를 바꿀 수 있습니다. `/balance` 결과는 새로고침 버튼을 제공하며, `/quote`와 `/trend` 결과는 같은 종목의 현재가·수급 조회를 오가는 버튼을 제공합니다.
 
 슬래시 명령 대신 `삼성전자 1주 시장가로 매수해줘`, `NAVER 2주 200,000원에 매도해줘`처럼 입력해도 같은 주문 확인 대기가 생성됩니다. 자연어 주문도 실제 제출 전에는 반드시 `확정` 버튼 또는 `/confirm`이 필요합니다.
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 
 Telegram 명령은 슬래시 명령을 계속 지원하면서 일부 응답에 버튼을 함께 제공합니다. `/help`는 잔고 조회와 알림 상태 버튼을 제공하고, `/alerts` 응답은 `🚨 긴급만`·`📣 전체`·`🔕 끄기`·`🔎 현재 상태` 버튼으로 모드를 바꿀 수 있습니다. `/balance` 결과는 새로고침 버튼을 제공하며, `/quote`와 `/trend` 결과는 같은 종목의 현재가·수급 조회를 오가는 버튼을 제공합니다.
 
+봇 시작 시 Telegram Bot Command Menu도 등록합니다. Telegram 채팅방의 명령 메뉴에서 `/help`, `/balance`, `/alerts`, `/quote`, `/trend`, `/buy`, `/sell`, `/confirm`, `/cancel`을 선택할 수 있으며, 기존 슬래시 명령과 인라인 버튼은 그대로 사용할 수 있습니다.
+
 슬래시 명령 대신 `삼성전자 1주 시장가로 매수해줘`, `NAVER 2주 200,000원에 매도해줘`처럼 입력해도 같은 주문 확인 대기가 생성됩니다. 자연어 주문도 실제 제출 전에는 반드시 `확정` 버튼 또는 `/confirm`이 필요합니다.
 
 `mcp-trading/data/stocks.json`은 KIS 공개 코스피/코스닥 종목 마스터 기반의 종목명 해석 캐시입니다. 신규 상장 등으로 종목명이 잡히지 않으면 6자리 종목코드를 직접 입력하거나 아래 명령으로 캐시를 갱신합니다.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 
 `/buy`와 `/sell`은 60초 동안 유효한 주문 확인 대기를 만들고, 지정가를 생략하면 시장가 주문으로 준비합니다. 주문 확인 메시지의 `확정`/`취소` 버튼 또는 `/confirm`/`/cancel` 명령으로 처리할 수 있습니다. `/confirm`은 로컬 `mcp-trading`의 `place_order` 도구를 통해 한국투자증권 Open API 현금 주문을 제출합니다. `/cancel`은 Telegram 확인 대기만 취소하며 이미 증권사에 제출된 주문은 취소하지 않습니다. `/balance`, `/quote`, `/trend` 조회 명령도 같은 로컬 `mcp-trading`을 사용합니다. 실계좌 주문은 `KIS_ORDER_ENV=real`과 `KIS_REAL_ORDER_ENABLED=true`가 모두 설정되어야 실행됩니다.
 
+Telegram 명령은 슬래시 명령을 계속 지원하면서 일부 응답에 버튼을 함께 제공합니다. `/help`는 잔고 조회와 알림 상태 버튼을 제공하고, `/alerts` 응답은 `긴급만`·`전체`·`끄기`·`현재 상태` 버튼으로 모드를 바꿀 수 있습니다. `/balance` 결과는 새로고침 버튼을 제공하며, `/quote`와 `/trend` 결과는 같은 종목의 현재가·수급 조회를 오가는 버튼을 제공합니다.
+
 슬래시 명령 대신 `삼성전자 1주 시장가로 매수해줘`, `NAVER 2주 200,000원에 매도해줘`처럼 입력해도 같은 주문 확인 대기가 생성됩니다. 자연어 주문도 실제 제출 전에는 반드시 `확정` 버튼 또는 `/confirm`이 필요합니다.
 
 `mcp-trading/data/stocks.json`은 KIS 공개 코스피/코스닥 종목 마스터 기반의 종목명 해석 캐시입니다. 신규 상장 등으로 종목명이 잡히지 않으면 6자리 종목코드를 직접 입력하거나 아래 명령으로 캐시를 갱신합니다.

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -63,6 +63,17 @@ TELEGRAM_INTERACTIVE_HELP = "\n".join(
         "일반 문장은 NAT에게 바로 질문합니다.",
     ]
 )
+TELEGRAM_BOT_COMMANDS = [
+    {"command": "help", "description": "사용 가능한 명령 확인"},
+    {"command": "balance", "description": "예수금·총자산·보유 종목 조회"},
+    {"command": "alerts", "description": "Telegram 알림 모드 변경"},
+    {"command": "quote", "description": "현재가 조회"},
+    {"command": "trend", "description": "외국인·기관·개인 수급 조회"},
+    {"command": "buy", "description": "매수 주문 준비"},
+    {"command": "sell", "description": "매도 주문 준비"},
+    {"command": "confirm", "description": "대기 주문 확정"},
+    {"command": "cancel", "description": "대기 주문 취소"},
+]
 QUOTE_COMMAND_HELP = "사용법: /quote <종목명>"
 TREND_COMMAND_HELP = "사용법: /trend <종목명>"
 TELEGRAM_MESSAGE_LIMIT = 4000
@@ -810,9 +821,7 @@ class TelegramCommandPoller:
     async def run(self) -> None:
         if not self.notifier.enabled:
             return
-        load_bot_username = getattr(self.notifier, "load_bot_username", None)
-        if callable(load_bot_username):
-            await load_bot_username()
+        await self._setup_bot_profile()
 
         while True:
             try:
@@ -827,6 +836,21 @@ class TelegramCommandPoller:
             except Exception as exc:
                 logger.error("Telegram command polling failed: %s", exc)
                 await asyncio.sleep(5)
+
+    async def _setup_bot_profile(self) -> None:
+        load_bot_username = getattr(self.notifier, "load_bot_username", None)
+        if callable(load_bot_username):
+            try:
+                await load_bot_username()
+            except Exception as exc:
+                logger.error("Telegram bot username setup failed: %s", exc)
+
+        set_bot_commands = getattr(self.notifier, "set_bot_commands", None)
+        if callable(set_bot_commands):
+            try:
+                await set_bot_commands(TELEGRAM_BOT_COMMANDS)
+            except Exception as exc:
+                logger.error("Telegram bot command menu setup failed: %s", exc)
 
     async def _get_updates(self) -> list[dict[str, Any]]:
         url = f"https://api.telegram.org/bot{self.notifier.bot_token}/getUpdates"

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -44,6 +44,11 @@ MARKET_QUOTE_CALLBACK = "market:quote"
 MARKET_TREND_CALLBACK = "market:trend"
 MARKET_STALE_CALLBACK_TEXT = "이전 조회 버튼입니다. 최신 조회 메시지에서 다시 선택하세요."
 MARKET_CALLBACK_LIMIT = 100
+ALERT_MODE_EMOJIS = {
+    "urgent": "🚨",
+    "all": "📣",
+    "off": "🔕",
+}
 TELEGRAM_INTERACTIVE_HELP = "\n".join(
     [
         "사용 가능한 명령:",
@@ -337,7 +342,7 @@ class TelegramCommandHandler:
             if action == "status":
                 mode = await state.get_telegram_alert_mode()
                 await self._send_text_or_raise(
-                    f"현재 Telegram 알림 모드: {mode}",
+                    f"현재 Telegram 알림 모드: {self._format_alert_mode(mode)}",
                     reply_markup=self._alerts_reply_markup(),
                 )
                 return
@@ -351,7 +356,7 @@ class TelegramCommandHandler:
 
             await state.set_telegram_alert_mode(action)
             await self._send_text_or_raise(
-                f"Telegram 알림 모드가 {action}(으)로 변경되었습니다.",
+                f"Telegram 알림 모드가 {self._format_alert_mode(action)}(으)로 변경되었습니다.",
                 reply_markup=self._alerts_reply_markup(),
             )
 
@@ -622,6 +627,12 @@ class TelegramCommandHandler:
                 ],
             ]
         }
+
+    def _format_alert_mode(self, mode: str) -> str:
+        emoji = ALERT_MODE_EMOJIS.get(mode)
+        if emoji is None:
+            return mode
+        return f"{emoji} {mode}"
 
     def _balance_reply_markup(self) -> dict[str, Any]:
         return {

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -40,6 +40,8 @@ ORDER_CANCEL_CALLBACK = "order:cancel"
 ORDER_STALE_CALLBACK_TEXT = "이전 주문 버튼입니다. 최신 주문 메시지에서 다시 선택하세요."
 ALERT_CALLBACK_PREFIX = "alerts:"
 BALANCE_REFRESH_CALLBACK = "balance:refresh"
+TRADE_CALLBACK_PREFIX = "trade:"
+LOOKUP_CALLBACK_PREFIX = "lookup:"
 MARKET_QUOTE_CALLBACK = "market:quote"
 MARKET_TREND_CALLBACK = "market:trend"
 MARKET_STALE_CALLBACK_TEXT = "이전 조회 버튼입니다. 최신 조회 메시지에서 다시 선택하세요."
@@ -54,6 +56,8 @@ TELEGRAM_INTERACTIVE_HELP = "\n".join(
         "사용 가능한 명령:",
         "/alerts urgent|all|off|status - Telegram 알림 모드 변경",
         "/balance - 예수금·총자산·보유 종목 조회",
+        "/trade - 매수·매도 주문 입력 안내",
+        "/lookup - 현재가·수급 조회 입력 안내",
         "/quote <종목명> - 현재가 조회",
         "/trend <종목명> - 외국인·기관·개인 수급 조회",
         "/buy <종목명> <수량> [지정가] - 매수 주문 준비",
@@ -67,15 +71,26 @@ TELEGRAM_BOT_COMMANDS = [
     {"command": "help", "description": "사용 가능한 명령 확인"},
     {"command": "balance", "description": "예수금·총자산·보유 종목 조회"},
     {"command": "alerts", "description": "Telegram 알림 모드 변경"},
-    {"command": "quote", "description": "현재가 조회"},
-    {"command": "trend", "description": "외국인·기관·개인 수급 조회"},
-    {"command": "buy", "description": "매수 주문 준비"},
-    {"command": "sell", "description": "매도 주문 준비"},
-    {"command": "confirm", "description": "대기 주문 확정"},
-    {"command": "cancel", "description": "대기 주문 취소"},
+    {"command": "trade", "description": "매수·매도 주문 입력 안내"},
+    {"command": "lookup", "description": "현재가·수급 조회 입력 안내"},
 ]
 QUOTE_COMMAND_HELP = "사용법: /quote <종목명>"
 TREND_COMMAND_HELP = "사용법: /trend <종목명>"
+TRADE_COMMAND_HELP = "\n".join(
+    [
+        "매매 주문 입력 안내:",
+        f"{BUY_COMMAND_HELP}  예: /buy 삼성전자 1",
+        f"{SELL_COMMAND_HELP}  예: /sell NAVER 1 200000",
+        "주문은 실제 제출 전 반드시 확정이 필요합니다.",
+    ]
+)
+LOOKUP_COMMAND_HELP = "\n".join(
+    [
+        "조회 입력 안내:",
+        f"{QUOTE_COMMAND_HELP}  예: /quote 삼성전자",
+        f"{TREND_COMMAND_HELP}  예: /trend 삼성전자",
+    ]
+)
 TELEGRAM_MESSAGE_LIMIT = 4000
 TELEGRAM_TRUNCATION_SUFFIX = "...(이하 생략)"
 _telegram_command_task: asyncio.Task | None = None
@@ -167,6 +182,18 @@ class TelegramCommandHandler:
         if self._matches_command(command, bot_username, "/balance"):
             await self._handle_balance()
             return
+        if self._matches_command(command, bot_username, "/trade"):
+            await self._send_text_or_raise(
+                TRADE_COMMAND_HELP,
+                reply_markup=self._trade_reply_markup(),
+            )
+            return
+        if self._matches_command(command, bot_username, "/lookup"):
+            await self._send_text_or_raise(
+                LOOKUP_COMMAND_HELP,
+                reply_markup=self._lookup_reply_markup(),
+            )
+            return
         if self._matches_command(command, bot_username, "/quote"):
             await self._handle_quote(argument, str(chat.get("id", "")).strip())
             return
@@ -253,6 +280,14 @@ class TelegramCommandHandler:
             await self._handle_balance()
             return
 
+        if data.startswith(TRADE_CALLBACK_PREFIX):
+            await self._handle_trade_callback(callback_query_id, data)
+            return
+
+        if data.startswith(LOOKUP_CALLBACK_PREFIX):
+            await self._handle_lookup_callback(callback_query_id, data)
+            return
+
         if data.startswith(f"{MARKET_QUOTE_CALLBACK}:"):
             await self._handle_market_callback(callback_query_id, chat_id, "quote", data)
             return
@@ -307,6 +342,50 @@ class TelegramCommandHandler:
 
         await self._answer_callback_query(callback_query_id)
         await self._handle_alerts(action)
+
+    async def _handle_trade_callback(
+        self,
+        callback_query_id: str,
+        data: str,
+    ) -> None:
+        action = data.removeprefix(TRADE_CALLBACK_PREFIX).strip()
+        if action == "menu":
+            text = TRADE_COMMAND_HELP
+            reply_markup = self._trade_reply_markup()
+        elif action == "buy":
+            text = BUY_COMMAND_HELP
+            reply_markup = None
+        elif action == "sell":
+            text = SELL_COMMAND_HELP
+            reply_markup = None
+        else:
+            await self._answer_callback_query(callback_query_id, text="지원하지 않는 버튼입니다.")
+            return
+
+        await self._answer_callback_query(callback_query_id)
+        await self._send_text_or_raise(text, reply_markup=reply_markup)
+
+    async def _handle_lookup_callback(
+        self,
+        callback_query_id: str,
+        data: str,
+    ) -> None:
+        action = data.removeprefix(LOOKUP_CALLBACK_PREFIX).strip()
+        if action == "menu":
+            text = LOOKUP_COMMAND_HELP
+            reply_markup = self._lookup_reply_markup()
+        elif action == "quote":
+            text = QUOTE_COMMAND_HELP
+            reply_markup = None
+        elif action == "trend":
+            text = TREND_COMMAND_HELP
+            reply_markup = None
+        else:
+            await self._answer_callback_query(callback_query_id, text="지원하지 않는 버튼입니다.")
+            return
+
+        await self._answer_callback_query(callback_query_id)
+        await self._send_text_or_raise(text, reply_markup=reply_markup)
 
     async def _handle_market_callback(
         self,
@@ -621,7 +700,11 @@ class TelegramCommandHandler:
                 [
                     {"text": "💰 잔고", "callback_data": BALANCE_REFRESH_CALLBACK},
                     {"text": "🔔 알림", "callback_data": f"{ALERT_CALLBACK_PREFIX}status"},
-                ]
+                ],
+                [
+                    {"text": "🧾 매매", "callback_data": f"{TRADE_CALLBACK_PREFIX}menu"},
+                    {"text": "🔎 조회", "callback_data": f"{LOOKUP_CALLBACK_PREFIX}menu"},
+                ],
             ]
         }
 
@@ -649,6 +732,32 @@ class TelegramCommandHandler:
         return {
             "inline_keyboard": [
                 [{"text": "🔄 새로고침", "callback_data": BALANCE_REFRESH_CALLBACK}]
+            ]
+        }
+
+    def _trade_reply_markup(self) -> dict[str, Any]:
+        return {
+            "inline_keyboard": [
+                [
+                    {"text": "🛒 매수 입력법", "callback_data": f"{TRADE_CALLBACK_PREFIX}buy"},
+                    {"text": "💸 매도 입력법", "callback_data": f"{TRADE_CALLBACK_PREFIX}sell"},
+                ]
+            ]
+        }
+
+    def _lookup_reply_markup(self) -> dict[str, Any]:
+        return {
+            "inline_keyboard": [
+                [
+                    {
+                        "text": "💵 현재가 입력법",
+                        "callback_data": f"{LOOKUP_CALLBACK_PREFIX}quote",
+                    },
+                    {
+                        "text": "📊 수급 입력법",
+                        "callback_data": f"{LOOKUP_CALLBACK_PREFIX}trend",
+                    },
+                ]
             ]
         }
 

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -613,12 +613,12 @@ class TelegramCommandHandler:
         return {
             "inline_keyboard": [
                 [
-                    {"text": "긴급만", "callback_data": f"{ALERT_CALLBACK_PREFIX}urgent"},
-                    {"text": "전체", "callback_data": f"{ALERT_CALLBACK_PREFIX}all"},
-                    {"text": "끄기", "callback_data": f"{ALERT_CALLBACK_PREFIX}off"},
+                    {"text": "🚨 긴급만", "callback_data": f"{ALERT_CALLBACK_PREFIX}urgent"},
+                    {"text": "📣 전체", "callback_data": f"{ALERT_CALLBACK_PREFIX}all"},
+                    {"text": "🔕 끄기", "callback_data": f"{ALERT_CALLBACK_PREFIX}off"},
                 ],
                 [
-                    {"text": "현재 상태", "callback_data": f"{ALERT_CALLBACK_PREFIX}status"}
+                    {"text": "🔎 현재 상태", "callback_data": f"{ALERT_CALLBACK_PREFIX}status"}
                 ],
             ]
         }

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -38,6 +38,12 @@ ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 ORDER_CONFIRM_CALLBACK = "order:confirm"
 ORDER_CANCEL_CALLBACK = "order:cancel"
 ORDER_STALE_CALLBACK_TEXT = "이전 주문 버튼입니다. 최신 주문 메시지에서 다시 선택하세요."
+ALERT_CALLBACK_PREFIX = "alerts:"
+BALANCE_REFRESH_CALLBACK = "balance:refresh"
+MARKET_QUOTE_CALLBACK = "market:quote"
+MARKET_TREND_CALLBACK = "market:trend"
+MARKET_STALE_CALLBACK_TEXT = "이전 조회 버튼입니다. 최신 조회 메시지에서 다시 선택하세요."
+MARKET_CALLBACK_LIMIT = 100
 TELEGRAM_INTERACTIVE_HELP = "\n".join(
     [
         "사용 가능한 명령:",
@@ -115,6 +121,7 @@ class TelegramCommandHandler:
         self.trade_recorder = trade_recorder
         self.now_factory = now_factory or (lambda: datetime.now(KST))
         self.pending_orders: dict[str, PendingOrder] = {}
+        self.market_callbacks: dict[str, tuple[str, str]] = {}
 
     async def handle_update(self, update: dict[str, Any]) -> None:
         callback_query = update.get("callback_query") or {}
@@ -136,16 +143,19 @@ class TelegramCommandHandler:
             await self._handle_alerts(argument)
             return
         if self._matches_command(command, bot_username, "/help"):
-            await self._send_text_or_raise(TELEGRAM_INTERACTIVE_HELP)
+            await self._send_text_or_raise(
+                TELEGRAM_INTERACTIVE_HELP,
+                reply_markup=self._help_reply_markup(),
+            )
             return
         if self._matches_command(command, bot_username, "/balance"):
             await self._handle_balance()
             return
         if self._matches_command(command, bot_username, "/quote"):
-            await self._handle_quote(argument)
+            await self._handle_quote(argument, str(chat.get("id", "")).strip())
             return
         if self._matches_command(command, bot_username, "/trend"):
-            await self._handle_trend(argument)
+            await self._handle_trend(argument, str(chat.get("id", "")).strip())
             return
         if self._matches_command(command, bot_username, "/buy"):
             await self._handle_order_command("BUY", argument, str(chat.get("id", "")).strip())
@@ -160,7 +170,10 @@ class TelegramCommandHandler:
             await self._handle_cancel(str(chat.get("id", "")).strip())
             return
         if text.startswith("/"):
-            await self._send_text_or_raise(TELEGRAM_INTERACTIVE_HELP)
+            await self._send_text_or_raise(
+                TELEGRAM_INTERACTIVE_HELP,
+                reply_markup=self._help_reply_markup(),
+            )
             return
 
         if self._looks_like_natural_order(text):
@@ -215,6 +228,23 @@ class TelegramCommandHandler:
             )
             return
 
+        if data.startswith(ALERT_CALLBACK_PREFIX):
+            await self._handle_alerts_callback(callback_query_id, data)
+            return
+
+        if data == BALANCE_REFRESH_CALLBACK:
+            await self._answer_callback_query(callback_query_id)
+            await self._handle_balance()
+            return
+
+        if data.startswith(f"{MARKET_QUOTE_CALLBACK}:"):
+            await self._handle_market_callback(callback_query_id, chat_id, "quote", data)
+            return
+
+        if data.startswith(f"{MARKET_TREND_CALLBACK}:"):
+            await self._handle_market_callback(callback_query_id, chat_id, "trend", data)
+            return
+
         await self._answer_callback_query(callback_query_id, text="지원하지 않는 버튼입니다.")
 
     async def _handle_order_callback(
@@ -249,6 +279,49 @@ class TelegramCommandHandler:
             return
         await self.notifier.answer_callback_query(callback_query_id, text=text)
 
+    async def _handle_alerts_callback(
+        self,
+        callback_query_id: str,
+        data: str,
+    ) -> None:
+        action = data.removeprefix(ALERT_CALLBACK_PREFIX).strip()
+        if action != "status" and action not in TELEGRAM_ALERT_MODES:
+            await self._answer_callback_query(callback_query_id, text="지원하지 않는 버튼입니다.")
+            return
+
+        await self._answer_callback_query(callback_query_id)
+        await self._handle_alerts(action)
+
+    async def _handle_market_callback(
+        self,
+        callback_query_id: str,
+        chat_id: str,
+        action: str,
+        data: str,
+    ) -> None:
+        token = self._extract_callback_token(data)
+        context = self.market_callbacks.pop(token, None) if token else None
+        if context is None:
+            await self._answer_callback_query(
+                callback_query_id,
+                text=MARKET_STALE_CALLBACK_TEXT,
+            )
+            return
+
+        callback_chat_id, stock = context
+        if callback_chat_id != chat_id:
+            await self._answer_callback_query(
+                callback_query_id,
+                text=MARKET_STALE_CALLBACK_TEXT,
+            )
+            return
+
+        await self._answer_callback_query(callback_query_id)
+        if action == "quote":
+            await self._handle_quote(stock, chat_id)
+            return
+        await self._handle_trend(stock, chat_id)
+
     def _matches_command(self, command: str, bot_username: str, expected: str) -> bool:
         if command != expected:
             return False
@@ -263,16 +336,23 @@ class TelegramCommandHandler:
         async with self._state() as state:
             if action == "status":
                 mode = await state.get_telegram_alert_mode()
-                await self._send_text_or_raise(f"현재 Telegram 알림 모드: {mode}")
+                await self._send_text_or_raise(
+                    f"현재 Telegram 알림 모드: {mode}",
+                    reply_markup=self._alerts_reply_markup(),
+                )
                 return
 
             if action not in TELEGRAM_ALERT_MODES:
-                await self._send_text_or_raise(ALERT_COMMAND_HELP)
+                await self._send_text_or_raise(
+                    ALERT_COMMAND_HELP,
+                    reply_markup=self._alerts_reply_markup(),
+                )
                 return
 
             await state.set_telegram_alert_mode(action)
             await self._send_text_or_raise(
-                f"Telegram 알림 모드가 {action}(으)로 변경되었습니다."
+                f"Telegram 알림 모드가 {action}(으)로 변경되었습니다.",
+                reply_markup=self._alerts_reply_markup(),
             )
 
     async def _handle_balance(self) -> None:
@@ -282,9 +362,12 @@ class TelegramCommandHandler:
         except Exception as exc:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
-        await self._send_text_or_raise(_telegram_text(str(result)))
+        await self._send_text_or_raise(
+            _telegram_text(str(result)),
+            reply_markup=self._balance_reply_markup(),
+        )
 
-    async def _handle_quote(self, argument: str) -> None:
+    async def _handle_quote(self, argument: str, chat_id: str) -> None:
         if not argument:
             await self._send_text_or_raise(QUOTE_COMMAND_HELP)
             return
@@ -300,7 +383,10 @@ class TelegramCommandHandler:
         except Exception as exc:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
-        await self._send_text_or_raise(_telegram_text(str(result)))
+        await self._send_text_or_raise(
+            _telegram_text(str(result)),
+            reply_markup=self._market_reply_markup("trend", chat_id, stock),
+        )
 
     async def _handle_order_command(self, side: str, argument: str, chat_id: str) -> None:
         usage = BUY_COMMAND_HELP if side == "BUY" else SELL_COMMAND_HELP
@@ -505,10 +591,76 @@ class TelegramCommandHandler:
     def _extract_order_callback_token(self, data: str) -> str | None:
         if data in {ORDER_CONFIRM_CALLBACK, ORDER_CANCEL_CALLBACK}:
             return None
+        return self._extract_callback_token(data)
+
+    def _extract_callback_token(self, data: str) -> str | None:
         _, separator, token = data.rpartition(":")
         if not separator:
             return None
         return token.strip() or None
+
+    def _help_reply_markup(self) -> dict[str, Any]:
+        return {
+            "inline_keyboard": [
+                [
+                    {"text": "💰 잔고", "callback_data": BALANCE_REFRESH_CALLBACK},
+                    {"text": "🔔 알림", "callback_data": f"{ALERT_CALLBACK_PREFIX}status"},
+                ]
+            ]
+        }
+
+    def _alerts_reply_markup(self) -> dict[str, Any]:
+        return {
+            "inline_keyboard": [
+                [
+                    {"text": "긴급만", "callback_data": f"{ALERT_CALLBACK_PREFIX}urgent"},
+                    {"text": "전체", "callback_data": f"{ALERT_CALLBACK_PREFIX}all"},
+                    {"text": "끄기", "callback_data": f"{ALERT_CALLBACK_PREFIX}off"},
+                ],
+                [
+                    {"text": "현재 상태", "callback_data": f"{ALERT_CALLBACK_PREFIX}status"}
+                ],
+            ]
+        }
+
+    def _balance_reply_markup(self) -> dict[str, Any]:
+        return {
+            "inline_keyboard": [
+                [{"text": "🔄 새로고침", "callback_data": BALANCE_REFRESH_CALLBACK}]
+            ]
+        }
+
+    def _market_reply_markup(
+        self,
+        action: str,
+        chat_id: str,
+        stock: str,
+    ) -> dict[str, Any]:
+        token = secrets.token_urlsafe(8)
+        if len(self.market_callbacks) >= MARKET_CALLBACK_LIMIT:
+            self.market_callbacks.pop(next(iter(self.market_callbacks)), None)
+        self.market_callbacks[token] = (chat_id, stock)
+        if action == "quote":
+            return {
+                "inline_keyboard": [
+                    [
+                        {
+                            "text": "💵 현재가 보기",
+                            "callback_data": f"{MARKET_QUOTE_CALLBACK}:{token}",
+                        }
+                    ]
+                ]
+            }
+        return {
+            "inline_keyboard": [
+                [
+                    {
+                        "text": "📊 수급 보기",
+                        "callback_data": f"{MARKET_TREND_CALLBACK}:{token}",
+                    }
+                ]
+            ]
+        }
 
     def _order_reply_markup(self, order: PendingOrder) -> dict[str, Any]:
         return {
@@ -583,7 +735,7 @@ class TelegramCommandHandler:
                 return stripped
         return None
 
-    async def _handle_trend(self, argument: str) -> None:
+    async def _handle_trend(self, argument: str, chat_id: str) -> None:
         if not argument:
             await self._send_text_or_raise(TREND_COMMAND_HELP)
             return
@@ -599,7 +751,10 @@ class TelegramCommandHandler:
         except Exception as exc:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
-        await self._send_text_or_raise(_telegram_text(str(result)))
+        await self._send_text_or_raise(
+            _telegram_text(str(result)),
+            reply_markup=self._market_reply_markup("quote", chat_id, stock),
+        )
 
     async def _handle_chat_fallback(self, text: str, chat_id: str) -> None:
         await self.notifier.send_chat_action("typing")

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -194,6 +194,20 @@ class TelegramNotifier:
             logger.error("Telegram chat action send failed: %s", exc)
             return False
 
+    async def set_bot_commands(self, commands: list[dict[str, str]]) -> bool:
+        if not self.enabled:
+            return False
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/setMyCommands"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(url, json={"commands": commands})
+                response.raise_for_status()
+            return True
+        except Exception as exc:
+            logger.error("Telegram bot command menu setup failed: %s", exc)
+            return False
+
     async def load_bot_username(self) -> str:
         if not self.enabled:
             return ""

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -147,6 +147,38 @@ async def test_help_command_replies_with_supported_commands():
     assert "/confirm - 대기 주문 확정" in notifier.messages[-1]
     assert "/cancel - 대기 주문 취소" in notifier.messages[-1]
     assert "일반 문장은 NAT에게 바로 질문합니다." in notifier.messages[-1]
+    assert notifier.reply_markups[-1] == {
+        "inline_keyboard": [
+            [
+                {"text": "💰 잔고", "callback_data": "balance:refresh"},
+                {"text": "🔔 알림", "callback_data": "alerts:status"},
+            ]
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_alerts_button_updates_mode_and_replies():
+    state = FakeState()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, state_factory=lambda: state)
+
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "alert-callback",
+                "data": "alerts:off",
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert state.mode == "off"
+    assert notifier.callback_answers == [("alert-callback", None)]
+    assert "off" in notifier.messages[-1]
+    assert notifier.reply_markups[-1]["inline_keyboard"][0][0]["callback_data"] == (
+        "alerts:urgent"
+    )
 
 
 @pytest.mark.asyncio
@@ -226,6 +258,38 @@ async def test_balance_command_calls_mcp_runner():
     assert calls == [(TRADING_MCP_PARAMS, "get_balance", {})]
     assert notifier.actions == ["typing"]
     assert notifier.messages == ["잔고 응답"]
+    assert notifier.reply_markups[-1] == {
+        "inline_keyboard": [
+            [{"text": "🔄 새로고침", "callback_data": "balance:refresh"}]
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_balance_refresh_button_calls_mcp_runner():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        return "잔고 응답"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=mcp_runner)
+
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "balance-callback",
+                "data": "balance:refresh",
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert calls == [(TRADING_MCP_PARAMS, "get_balance", {})]
+    assert notifier.callback_answers == [("balance-callback", None)]
+    assert notifier.actions == ["typing"]
+    assert notifier.messages == ["잔고 응답"]
 
 
 @pytest.mark.asyncio
@@ -244,6 +308,42 @@ async def test_quote_command_calls_mcp_runner_with_stock_name():
     assert calls == [(TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": "삼성전자"})]
     assert notifier.actions == ["typing"]
     assert notifier.messages == ["현재가 응답"]
+    assert notifier.reply_markups[-1]["inline_keyboard"][0][0]["text"] == "📊 수급 보기"
+
+
+@pytest.mark.asyncio
+async def test_quote_result_trend_button_uses_same_stock_name():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "get_stock_quote":
+            return "현재가 응답"
+        if tool_name == "get_investor_trading":
+            return "수급 응답"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/quote 삼성전자"}})
+    callback_data = notifier.reply_markups[-1]["inline_keyboard"][0][0]["callback_data"]
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "trend-callback",
+                "data": callback_data,
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert calls == [
+        (TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": "삼성전자"}),
+        (TRADING_MCP_PARAMS, "get_investor_trading", {"stock_name": "삼성전자"}),
+    ]
+    assert notifier.callback_answers == [("trend-callback", None)]
+    assert notifier.messages[-1] == "수급 응답"
 
 
 @pytest.mark.asyncio
@@ -304,6 +404,69 @@ async def test_trend_command_calls_mcp_runner_with_stock_name():
     ]
     assert notifier.actions == ["typing"]
     assert notifier.messages == ["수급 응답"]
+    assert notifier.reply_markups[-1]["inline_keyboard"][0][0]["text"] == "💵 현재가 보기"
+
+
+@pytest.mark.asyncio
+async def test_trend_result_quote_button_uses_same_stock_name():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "get_stock_quote":
+            return "현재가 응답"
+        if tool_name == "get_investor_trading":
+            return "수급 응답"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/trend 삼성전자"}})
+    callback_data = notifier.reply_markups[-1]["inline_keyboard"][0][0]["callback_data"]
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "quote-callback",
+                "data": callback_data,
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert calls == [
+        (TRADING_MCP_PARAMS, "get_investor_trading", {"stock_name": "삼성전자"}),
+        (TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": "삼성전자"}),
+    ]
+    assert notifier.callback_answers == [("quote-callback", None)]
+    assert notifier.messages[-1] == "현재가 응답"
+
+
+@pytest.mark.asyncio
+async def test_stale_market_button_does_not_call_mcp_runner():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        return "응답"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=mcp_runner)
+
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "stale-market-callback",
+                "data": "market:quote:old-token",
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert calls == []
+    assert notifier.callback_answers == [
+        ("stale-market-callback", "이전 조회 버튼입니다. 최신 조회 메시지에서 다시 선택하세요.")
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -10,6 +10,8 @@ from backend.telegram_commands import (
     BUY_COMMAND_HELP,
     QUOTE_COMMAND_HELP,
     TELEGRAM_INTERACTIVE_HELP,
+    TRADE_COMMAND_HELP,
+    LOOKUP_COMMAND_HELP,
     TELEGRAM_MESSAGE_LIMIT,
     TELEGRAM_TRUNCATION_SUFFIX,
     TREND_COMMAND_HELP,
@@ -145,6 +147,8 @@ async def test_help_command_replies_with_supported_commands():
 
     assert notifier.messages == [TELEGRAM_INTERACTIVE_HELP]
     assert "/balance - 예수금·총자산·보유 종목 조회" in notifier.messages[-1]
+    assert "/trade - 매수·매도 주문 입력 안내" in notifier.messages[-1]
+    assert "/lookup - 현재가·수급 조회 입력 안내" in notifier.messages[-1]
     assert "/quote <종목명> - 현재가 조회" in notifier.messages[-1]
     assert "/trend <종목명> - 외국인·기관·개인 수급 조회" in notifier.messages[-1]
     assert "/buy <종목명> <수량> [지정가] - 매수 주문 준비" in notifier.messages[-1]
@@ -157,7 +161,11 @@ async def test_help_command_replies_with_supported_commands():
             [
                 {"text": "💰 잔고", "callback_data": "balance:refresh"},
                 {"text": "🔔 알림", "callback_data": "alerts:status"},
-            ]
+            ],
+            [
+                {"text": "🧾 매매", "callback_data": "trade:menu"},
+                {"text": "🔎 조회", "callback_data": "lookup:menu"},
+            ],
         ]
     }
 
@@ -198,6 +206,90 @@ async def test_unknown_slash_command_replies_with_help():
     await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/unknown"}})
 
     assert notifier.messages == [TELEGRAM_INTERACTIVE_HELP]
+
+
+@pytest.mark.asyncio
+async def test_trade_command_replies_with_entrypoint_buttons():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/trade"}})
+
+    assert notifier.messages == [TRADE_COMMAND_HELP]
+    assert notifier.reply_markups[-1] == {
+        "inline_keyboard": [
+            [
+                {"text": "🛒 매수 입력법", "callback_data": "trade:buy"},
+                {"text": "💸 매도 입력법", "callback_data": "trade:sell"},
+            ]
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_lookup_command_replies_with_entrypoint_buttons():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/lookup"}})
+
+    assert notifier.messages == [LOOKUP_COMMAND_HELP]
+    assert notifier.reply_markups[-1] == {
+        "inline_keyboard": [
+            [
+                {"text": "💵 현재가 입력법", "callback_data": "lookup:quote"},
+                {"text": "📊 수급 입력법", "callback_data": "lookup:trend"},
+            ]
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_trade_menu_button_replies_with_buy_and_sell_guidance():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "trade-menu",
+                "data": "trade:menu",
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert notifier.callback_answers == [("trade-menu", None)]
+    assert notifier.messages == [TRADE_COMMAND_HELP]
+
+
+@pytest.mark.asyncio
+async def test_lookup_quote_button_replies_with_quote_guidance():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier)
+
+    await handler.handle_update(
+        {
+            "callback_query": {
+                "id": "lookup-quote",
+                "data": "lookup:quote",
+                "message": {"chat": {"id": 123}},
+            }
+        }
+    )
+
+    assert notifier.callback_answers == [("lookup-quote", None)]
+    assert notifier.messages == [QUOTE_COMMAND_HELP]
+
+
+def test_bot_command_menu_uses_entrypoints_for_parameterized_commands():
+    commands = [command["command"] for command in telegram_commands.TELEGRAM_BOT_COMMANDS]
+
+    assert commands == ["help", "balance", "alerts", "trade", "lookup"]
+    assert "buy" not in commands
+    assert "sell" not in commands
+    assert "quote" not in commands
+    assert "trend" not in commands
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -114,7 +114,7 @@ async def test_alerts_status_reports_current_mode():
     await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/alerts status"}})
 
     assert state.mode == "off"
-    assert "off" in notifier.messages[-1]
+    assert notifier.messages[-1].startswith("현재 Telegram 알림 모드: 🔕 off")
 
 
 @pytest.mark.asyncio
@@ -175,7 +175,7 @@ async def test_alerts_button_updates_mode_and_replies():
 
     assert state.mode == "off"
     assert notifier.callback_answers == [("alert-callback", None)]
-    assert "off" in notifier.messages[-1]
+    assert "🔕 off" in notifier.messages[-1]
     assert notifier.reply_markups[-1]["inline_keyboard"][0][0]["text"] == "🚨 긴급만"
     assert notifier.reply_markups[-1]["inline_keyboard"][0][1]["text"] == "📣 전체"
     assert notifier.reply_markups[-1]["inline_keyboard"][0][2]["text"] == "🔕 끄기"

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -176,6 +176,10 @@ async def test_alerts_button_updates_mode_and_replies():
     assert state.mode == "off"
     assert notifier.callback_answers == [("alert-callback", None)]
     assert "off" in notifier.messages[-1]
+    assert notifier.reply_markups[-1]["inline_keyboard"][0][0]["text"] == "🚨 긴급만"
+    assert notifier.reply_markups[-1]["inline_keyboard"][0][1]["text"] == "📣 전체"
+    assert notifier.reply_markups[-1]["inline_keyboard"][0][2]["text"] == "🔕 끄기"
+    assert notifier.reply_markups[-1]["inline_keyboard"][1][0]["text"] == "🔎 현재 상태"
     assert notifier.reply_markups[-1]["inline_keyboard"][0][0]["callback_data"] == (
         "alerts:urgent"
     )

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -38,6 +38,7 @@ class FakeNotifier:
         self.send_text_result = send_text_result
         self.bot_username = bot_username
         self.loaded_bot_username = False
+        self.bot_commands = None
         self.messages = []
         self.reply_markups = []
         self.actions = []
@@ -59,6 +60,10 @@ class FakeNotifier:
     async def load_bot_username(self):
         self.loaded_bot_username = True
         return self.bot_username
+
+    async def set_bot_commands(self, commands):
+        self.bot_commands = commands
+        return True
 
 
 class FakeOrderGateway:
@@ -1350,6 +1355,34 @@ async def test_poller_loads_bot_username_before_updates(monkeypatch):
     async def fake_get_updates():
         assert notifier.loaded_bot_username is True
         raise RuntimeError("stop after username load")
+
+    async def stop_after_failure(delay):
+        raise pytest.fail.Exception("stop after first failed polling iteration")
+
+    monkeypatch.setattr(poller, "_get_updates", fake_get_updates)
+    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", stop_after_failure)
+
+    with pytest.raises(pytest.fail.Exception):
+        await poller.run()
+
+    assert poller.offset is None
+
+
+@pytest.mark.asyncio
+async def test_poller_sets_bot_command_menu_before_updates(monkeypatch):
+    notifier = FakeNotifier(bot_username="finus_bot")
+    notifier.enabled = True
+    notifier.bot_token = "token"
+
+    class NoopHandler:
+        async def handle_update(self, update):
+            return None
+
+    poller = TelegramCommandPoller(notifier=notifier, handler=NoopHandler())
+
+    async def fake_get_updates():
+        assert notifier.bot_commands == telegram_commands.TELEGRAM_BOT_COMMANDS
+        raise RuntimeError("stop after bot command setup")
 
     async def stop_after_failure(delay):
         raise pytest.fail.Exception("stop after first failed polling iteration")

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -250,6 +250,43 @@ async def test_send_chat_action_posts_typing_payload(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_set_bot_commands_posts_command_menu_payload(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def post(self, url, *, json):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    commands = [
+        {"command": "balance", "description": "잔고 조회"},
+        {"command": "alerts", "description": "알림 모드 변경"},
+    ]
+    monkeypatch.setattr("backend.telegram_notifier.httpx.AsyncClient", FakeAsyncClient)
+    notifier = TelegramNotifier("token", "123")
+
+    result = await notifier.set_bot_commands(commands)
+
+    assert result is True
+    assert captured["url"] == "https://api.telegram.org/bottoken/setMyCommands"
+    assert captured["json"] == {"commands": commands}
+
+
+@pytest.mark.asyncio
 async def test_load_bot_username_fetches_and_caches_get_me(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## 📝 개요

Issue #57에 따라 PR #56에서 도입한 Telegram 인라인 버튼 UX를 다른 Telegram 명령으로 확장합니다.

기존 슬래시 명령은 유지하면서, 반복 입력이 많은 조회·알림 명령에 버튼 진입점과 후속 액션을 추가했습니다. 추가로 Telegram Bot Command Menu는 인자 없이 시작할 수 있는 명령과 진입점만 노출하도록 정리했습니다.

## 🚀 변경 사항
- `/help` 응답에 잔고 조회·알림 상태·매매·조회 버튼 추가
- `/alerts` 응답에 `🚨 긴급만`·`📣 전체`·`🔕 끄기`·`🔎 현재 상태` 버튼 추가
- `/balance` 결과에 새로고침 버튼 추가
- `/quote`와 `/trend` 결과에 같은 종목의 현재가·수급 조회를 오가는 버튼 추가
- `/trade` 진입점으로 매수·매도 입력법 안내 추가
- `/lookup` 진입점으로 현재가·수급 입력법 안내 추가
- Bot API `setMyCommands`로 Telegram Bot Command Menu 등록
- Bot Command Menu에서 인자가 필요한 `/buy`, `/sell`, `/quote`, `/trend` 직접 노출 제외
- 기존 `/buy`, `/sell`, `/quote`, `/trend`, `/confirm`, `/cancel` 슬래시 명령 유지
- 조회 후속 버튼에 서버 측 token을 사용해 오래된 버튼 실행 방지
- Telegram 버튼 UX와 README 설명 업데이트

## 🔗 관련 이슈
- Related to #57

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)

<img width="590" height="1278" alt="IMG_3385" src="https://github.com/user-attachments/assets/ccf93c71-e1a8-4996-aec2-debf4de00468" />
<img width="590" height="1278" alt="스크린샷, 2026-05-27 오전 10 49 37" src="https://github.com/user-attachments/assets/41fa4e89-c4d5-443e-b94f-f93806654f08" />

## ✅ 검증
- `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q` → 84 passed
- `UV_CACHE_DIR=.uv-cache uv run --project backend python -m py_compile backend/telegram_commands.py backend/telegram_notifier.py`
- `git diff --check`