### PR TITLE
fix: MCP 서버 deprecated API 제거

### DIFF
--- a/mcp-dart/index.js
+++ b/mcp-dart/index.js
@@ -4,12 +4,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import AdmZip from "adm-zip";
 import { XMLParser } from "fast-xml-parser";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 
 console.log = console.error;
 
@@ -52,10 +49,7 @@ function loadRootEnv() {
 
 loadRootEnv();
 
-const server = new Server(
-  { name: "mcp-dart", version: "1.0.0" },
-  { capabilities: { tools: {} } },
-);
+const server = new McpServer({ name: "mcp-dart", version: "1.0.0" });
 
 function isMissingCredential(value) {
   const normalized = String(value ?? "").trim();
@@ -380,50 +374,31 @@ async function getDisclosureSignal(stockName) {
   return formatDisclosureSignal(corp, window, disclosures, majorStocks, eleStocks);
 }
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
-    {
-      name: "get_disclosure_signal",
-      description: "OpenDART 공식 API로 5% 룰 및 임원/주요주주 지분공시 signal을 조회합니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 또는 6자리 종목코드",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
-  ],
-}));
+server.registerTool(
+  "get_disclosure_signal",
+  {
+    description: "OpenDART 공식 API로 5% 룰 및 임원/주요주주 지분공시 signal을 조회합니다.",
+    inputSchema: z.object({
+      stock_name: z.string().describe("주식 종목명 또는 6자리 종목코드"),
+    }),
+  },
+  async (args) => {
+    const stockName = args?.stock_name;
+    if (!stockName) {
+      return {
+        content: [{ type: "text", text: "에러: stock_name 파라미터가 누락되었습니다." }],
+        isError: true,
+      };
+    }
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-
-  if (name !== "get_disclosure_signal") {
-    return {
-      content: [{ type: "text", text: "에러: 존재하지 않는 도구입니다." }],
-      isError: true,
-    };
-  }
-
-  const stockName = args?.stock_name;
-  if (!stockName) {
-    return {
-      content: [{ type: "text", text: "에러: stock_name 파라미터가 누락되었습니다." }],
-      isError: true,
-    };
-  }
-
-  try {
-    const signal = await getDisclosureSignal(stockName);
-    return { content: [{ type: "text", text: signal }] };
-  } catch (error) {
-    return { content: [{ type: "text", text: `에러 발생: ${error.message}` }], isError: true };
-  }
-});
+    try {
+      const signal = await getDisclosureSignal(stockName);
+      return { content: [{ type: "text", text: signal }] };
+    } catch (error) {
+      return { content: [{ type: "text", text: `에러 발생: ${error.message}` }], isError: true };
+    }
+  },
+);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/mcp-dart/package-lock.json
+++ b/mcp-dart/package-lock.json
@@ -8,9 +8,10 @@
       "name": "mcp-dart",
       "version": "1.0.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.21.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "adm-zip": "^0.5.16",
-        "fast-xml-parser": "^5.3.2"
+        "fast-xml-parser": "^5.3.2",
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@hono/node-server": {
@@ -25,6 +26,8 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1028,6 +1031,8 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/mcp-dart/package.json
+++ b/mcp-dart/package.json
@@ -6,11 +6,13 @@
   "description": "Fin-Us MCP server for official OpenDART disclosure signals",
   "main": "index.js",
   "scripts": {
-    "check": "node --check index.js"
+    "check": "node --check index.js",
+    "test": "node --test tests/*.test.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.21.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "adm-zip": "^0.5.16",
-    "fast-xml-parser": "^5.3.2"
+    "fast-xml-parser": "^5.3.2",
+    "zod": "^4.4.3"
   }
 }

--- a/mcp-dart/tests/mcp-server.test.js
+++ b/mcp-dart/tests/mcp-server.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function withClient(callback) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["index.js"],
+    cwd: process.cwd(),
+  });
+  const client = new Client({ name: "mcp-dart-test", version: "1.0.0" });
+  await client.connect(transport);
+
+  try {
+    return await callback(client);
+  } finally {
+    await client.close();
+  }
+}
+
+test("registers disclosure signal tool with required stock_name schema", async () => {
+  await withClient(async (client) => {
+    const { tools } = await client.listTools();
+
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].name, "get_disclosure_signal");
+    assert.deepEqual(tools[0].inputSchema.required, ["stock_name"]);
+  });
+});

--- a/mcp-news/index.js
+++ b/mcp-news/index.js
@@ -1,12 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 
 // Redirect console.log to console.error to prevent breaking MCP JSON-RPC on stdout
 console.log = console.error;
@@ -46,10 +43,7 @@ const NAVER_CLIENT_SECRET = process.env.NAVER_CLIENT_SECRET;
 const DEFAULT_DISPLAY_COUNT = 3;
 const REQUEST_TIMEOUT_MS = 8000;
 
-const server = new Server(
-  { name: "news-tool", version: "1.0.0" },
-  { capabilities: { tools: {} } },
-);
+const server = new McpServer({ name: "news-tool", version: "1.0.0" });
 
 function isMissingCredential(value) {
   return !value || value.startsWith("your_") || value.includes("_here");
@@ -130,57 +124,34 @@ function deprecatedToolMessage(toolName) {
   );
 }
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
-    {
-      name: "get_market_news",
-      description: "네이버 뉴스 검색 API로 특정 주식 종목의 최신 뉴스 3개를 가져옵니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 (예: 삼성전자, SK하이닉스)",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
-    {
-      name: "get_investor_trading",
-      description: "deprecated: mcp-trading의 get_investor_trading으로 이동되었습니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 (예: 삼성전자, SK하이닉스)",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
-    {
-      name: "get_research_reports",
-      description: "deprecated: 공식 대체 API가 확정되지 않아 비활성화되었습니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 (예: 삼성전자, SK하이닉스)",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
-  ],
-}));
+const stockNameSchema = z.object({
+  stock_name: z.string().describe("주식 종목명 (예: 삼성전자, SK하이닉스)"),
+});
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  const stockName = args?.stock_name;
+server.registerTool(
+  "get_market_news",
+  {
+    description: "네이버 뉴스 검색 API로 특정 주식 종목의 최신 뉴스 3개를 가져옵니다.",
+    inputSchema: stockNameSchema,
+  },
+  async ({ stock_name: stockName }) => {
+    if (!stockName) {
+      return {
+        content: [{ type: "text", text: "에러: stock_name 파라미터가 누락되었습니다." }],
+        isError: true,
+      };
+    }
 
+    try {
+      const news = await fetchMarketNews(stockName);
+      return { content: [{ type: "text", text: news }] };
+    } catch (error) {
+      return { content: [{ type: "text", text: `에러 발생: ${error.message}` }], isError: true };
+    }
+  },
+);
+
+async function handleDeprecatedTool(name, stockName) {
   if (!stockName) {
     return {
       content: [{ type: "text", text: "에러: stock_name 파라미터가 누락되었습니다." }],
@@ -188,24 +159,29 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     };
   }
 
-  try {
-    if (name === "get_market_news") {
-      const news = await fetchMarketNews(stockName);
-      return { content: [{ type: "text", text: news }] };
-    }
+  return {
+    content: [{ type: "text", text: deprecatedToolMessage(name) }],
+    isError: true,
+  };
+}
 
-    if (name === "get_investor_trading" || name === "get_research_reports") {
-      return {
-        content: [{ type: "text", text: deprecatedToolMessage(name) }],
-        isError: true,
-      };
-    }
-  } catch (error) {
-    return { content: [{ type: "text", text: `에러 발생: ${error.message}` }], isError: true };
-  }
+server.registerTool(
+  "get_investor_trading",
+  {
+    description: "deprecated: mcp-trading의 get_investor_trading으로 이동되었습니다.",
+    inputSchema: stockNameSchema,
+  },
+  async ({ stock_name: stockName }) => handleDeprecatedTool("get_investor_trading", stockName),
+);
 
-  throw new Error("존재하지 않는 도구입니다.");
-});
+server.registerTool(
+  "get_research_reports",
+  {
+    description: "deprecated: 공식 대체 API가 확정되지 않아 비활성화되었습니다.",
+    inputSchema: stockNameSchema,
+  },
+  async ({ stock_name: stockName }) => handleDeprecatedTool("get_research_reports", stockName),
+);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/mcp-news/package-lock.json
+++ b/mcp-news/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "nodemon": "^3.1.14"
@@ -1470,9 +1471,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/mcp-news/package.json
+++ b/mcp-news/package.json
@@ -4,14 +4,16 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "check": "node --check index.js",
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"

--- a/mcp-news/tests/mcp-server.test.js
+++ b/mcp-news/tests/mcp-server.test.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function withClient(callback) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["index.js"],
+    cwd: process.cwd(),
+  });
+  const client = new Client({ name: "mcp-news-test", version: "1.0.0" });
+  await client.connect(transport);
+
+  try {
+    return await callback(client);
+  } finally {
+    await client.close();
+  }
+}
+
+test("registers news tools with required stock_name schema", async () => {
+  await withClient(async (client) => {
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
+
+    assert.deepEqual(toolNames, [
+      "get_market_news",
+      "get_investor_trading",
+      "get_research_reports",
+    ]);
+    for (const tool of tools) {
+      assert.deepEqual(tool.inputSchema.required, ["stock_name"]);
+    }
+  });
+});
+
+test("deprecated tools keep returning MCP error results", async () => {
+  await withClient(async (client) => {
+    const result = await client.callTool({
+      name: "get_research_reports",
+      arguments: { stock_name: "삼성전자" },
+    });
+
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /deprecated: get_research_reports/);
+  });
+});

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -3,14 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import crypto from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
 import axios from "axios";
 import dotenv from "dotenv";
+import { z } from "zod";
 import { buildBalanceParams, formatBalanceReport } from "./balance.js";
 import {
   createCashOrderRequest,
@@ -45,10 +42,7 @@ const TOKEN_CACHE_PATH = process.env.KIS_TOKEN_CACHE_PATH || path.join(
 );
 let tokenCache = null;
 
-const server = new Server(
-  { name: "trading-tool", version: "1.0.0" },
-  { capabilities: { tools: {} } },
-);
+const server = new McpServer({ name: "trading-tool", version: "1.0.0" });
 
 function isMissingCredential(value) {
   return !value || value.startsWith("your_") || value.includes("_here");
@@ -272,107 +266,20 @@ async function placeOrder(args) {
   });
 }
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
-    {
-      name: "get_balance",
-      description: "한국투자증권 계좌의 현재 잔고 및 자산 현황을 조회합니다.",
-      inputSchema: {
-        type: "object",
-        properties: {},
-      },
-    },
-    {
-      name: "resolve_stock_code",
-      description: "종목명 또는 6자리 종목코드를 KIS API용 6자리 종목코드로 변환합니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 또는 6자리 종목코드",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
-    {
-      name: "get_stock_quote",
-      description: "한국투자증권 Open API로 국내 주식 현재가 시세를 조회합니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 또는 6자리 종목코드",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
-    {
-      name: "get_investor_trading",
-      description: "한국투자증권 Open API로 외국인/기관/개인 투자자 매매동향을 조회합니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 또는 6자리 종목코드",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
-    {
-      name: "place_order",
-      description: "한국투자증권 Open API로 국내 주식 현금 주문을 실행합니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 또는 6자리 종목코드",
-          },
-          stock_code: {
-            type: "string",
-            description: "KIS API용 종목코드",
-          },
-          side: {
-            type: "string",
-            enum: ["BUY", "SELL"],
-            description: "매수 또는 매도",
-          },
-          quantity: {
-            type: "integer",
-            minimum: 1,
-            description: "주문 수량",
-          },
-          price: {
-            type: "integer",
-            minimum: 0,
-            description: "지정가. 시장가 주문은 0 또는 생략",
-          },
-          order_type: {
-            type: "string",
-            enum: ["LIMIT", "MARKET"],
-            description: "지정가 또는 시장가",
-          },
-          order_env: {
-            type: "string",
-            enum: ["demo", "real"],
-            description: "모의투자 또는 실계좌",
-          },
-        },
-        required: ["stock_code", "side", "quantity", "order_env"],
-      },
-    },
-  ],
-}));
+const stockNameSchema = z.object({
+  stock_name: z.string().describe("주식 종목명 또는 6자리 종목코드"),
+});
+const placeOrderSchema = z.object({
+  stock_name: z.string().optional().describe("주식 종목명 또는 6자리 종목코드"),
+  stock_code: z.string().describe("KIS API용 종목코드"),
+  side: z.enum(["BUY", "SELL"]).describe("매수 또는 매도"),
+  quantity: z.number().int().min(1).describe("주문 수량"),
+  price: z.number().int().min(0).optional().describe("지정가. 시장가 주문은 0 또는 생략"),
+  order_type: z.enum(["LIMIT", "MARKET"]).optional().describe("지정가 또는 시장가"),
+  order_env: z.enum(["demo", "real"]).describe("모의투자 또는 실계좌"),
+});
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-
+async function callTradingTool(name, args = {}) {
   try {
     if (name === "get_balance") {
       return { content: [{ type: "text", text: await getBalance() }] };
@@ -405,7 +312,52 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 
   throw new Error("존재하지 않는 도구입니다.");
-});
+}
+
+server.registerTool(
+  "get_balance",
+  {
+    description: "한국투자증권 계좌의 현재 잔고 및 자산 현황을 조회합니다.",
+    inputSchema: z.object({}),
+  },
+  async () => callTradingTool("get_balance"),
+);
+
+server.registerTool(
+  "resolve_stock_code",
+  {
+    description: "종목명 또는 6자리 종목코드를 KIS API용 6자리 종목코드로 변환합니다.",
+    inputSchema: stockNameSchema,
+  },
+  async (args) => callTradingTool("resolve_stock_code", args),
+);
+
+server.registerTool(
+  "get_stock_quote",
+  {
+    description: "한국투자증권 Open API로 국내 주식 현재가 시세를 조회합니다.",
+    inputSchema: stockNameSchema,
+  },
+  async (args) => callTradingTool("get_stock_quote", args),
+);
+
+server.registerTool(
+  "get_investor_trading",
+  {
+    description: "한국투자증권 Open API로 외국인/기관/개인 투자자 매매동향을 조회합니다.",
+    inputSchema: stockNameSchema,
+  },
+  async (args) => callTradingTool("get_investor_trading", args),
+);
+
+server.registerTool(
+  "place_order",
+  {
+    description: "한국투자증권 Open API로 국내 주식 현금 주문을 실행합니다.",
+    inputSchema: placeOrderSchema,
+  },
+  async (args) => callTradingTool("place_order", args),
+);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/mcp-trading/package-lock.json
+++ b/mcp-trading/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.16.0",
-        "dotenv": "^17.4.2"
+        "dotenv": "^17.4.2",
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1266,9 +1267,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/mcp-trading/package.json
+++ b/mcp-trading/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.16.0",
-    "dotenv": "^17.4.2"
+    "dotenv": "^17.4.2",
+    "zod": "^4.4.3"
   }
 }

--- a/mcp-trading/tests/mcp-server.test.js
+++ b/mcp-trading/tests/mcp-server.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function withClient(callback) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["index.js"],
+    cwd: process.cwd(),
+  });
+  const client = new Client({ name: "mcp-trading-test", version: "1.0.0" });
+  await client.connect(transport);
+
+  try {
+    return await callback(client);
+  } finally {
+    await client.close();
+  }
+}
+
+function toolByName(tools, name) {
+  const tool = tools.find((candidate) => candidate.name === name);
+  assert.ok(tool, `${name} tool should be registered`);
+  return tool;
+}
+
+test("registers trading tools with preserved required schemas", async () => {
+  await withClient(async (client) => {
+    const { tools } = await client.listTools();
+
+    assert.deepEqual(tools.map((tool) => tool.name), [
+      "get_balance",
+      "resolve_stock_code",
+      "get_stock_quote",
+      "get_investor_trading",
+      "place_order",
+    ]);
+    assert.deepEqual(toolByName(tools, "get_balance").inputSchema.required ?? [], []);
+    assert.deepEqual(toolByName(tools, "resolve_stock_code").inputSchema.required, ["stock_name"]);
+    assert.deepEqual(toolByName(tools, "get_stock_quote").inputSchema.required, ["stock_name"]);
+    assert.deepEqual(toolByName(tools, "get_investor_trading").inputSchema.required, ["stock_name"]);
+    assert.deepEqual(toolByName(tools, "place_order").inputSchema.required, [
+      "stock_code",
+      "side",
+      "quantity",
+      "order_env",
+    ]);
+  });
+});
+
+test("resolve_stock_code still works through the registered MCP tool", async () => {
+  await withClient(async (client) => {
+    const result = await client.callTool({
+      name: "resolve_stock_code",
+      arguments: { stock_name: "삼성전자" },
+    });
+
+    assert.equal(result.isError, undefined);
+    assert.match(result.content[0].text, /삼성전자 \(005930/);
+  });
+});


### PR DESCRIPTION
## 📝 개요

MCP TypeScript SDK의 deprecated `Server` 사용을 제거하고, 로컬 MCP 서버 3종을 `McpServer.registerTool` 기반으로 전환합니다.

## 🚀 변경 사항
- `mcp-trading`, `mcp-news`, `mcp-dart`의 deprecated `Server` 및 수동 request handler 제거
- `McpServer.registerTool` 전환 및 기존 tool 이름/필수 입력 schema 유지
- `zod` 명시 의존성 추가와 `mcp-dart` SDK 버전 범위 정렬
- stdio MCP smoke test 추가

## 🔗 관련 이슈
- Closes #59

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요? (해당 없음: 런타임 API 마이그레이션 및 테스트 보강)

## 📸 스크린샷 (선택 사항)

N/A
