### PR TITLE
fix: backend Dockerfile CMD --reload 플래그 제거 (#76)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,4 +40,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uv", "run", "--project", "./backend", "--locked", "--no-sync", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uv", "run", "--project", "./backend", "--locked", "--no-sync", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## 📝 개요

프로덕션 이미지의 `CMD`에 잔존하던 `--reload` 플래그 제거. 개발 환경용 watchdog이 프로덕션에서 동작해 불필요한 리소스를 소모하고 의도치 않은 재기동으로 요청이 드랍될 수 있었음.

## 🚀 변경 사항
- `backend/Dockerfile` — CMD에서 `--reload` 플래그 제거

## 🔗 관련 이슈
- Closes #76

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?