### PR TITLE
fix: agents.py 오타 수정 및 pytest-asyncio asyncio_mode 설정 (#67)

### DIFF
--- a/finus_nat/pyproject.toml
+++ b/finus_nat/pyproject.toml
@@ -43,3 +43,6 @@ dev = [
   "pytest-asyncio>=1.3,<2",
 ]
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -94,7 +94,7 @@ def chat_response_plain_text(result: ChatResponse | str) -> str:
 def _is_holdings_news_request(chat_request: ChatRequest) -> bool:
     latest = latest_user_plain_text(chat_request.messages)
     wants_news = "뉴스" in latest or "뉴" in latest
-    refers_holdings = any(word in latest for word in ("보유", "포트폴리오", "종목", "보요유종목"))
+    refers_holdings = any(word in latest for word in ("보유", "포트폴리오", "종목", "보유종목"))
     return wants_news and refers_holdings
 
 


### PR DESCRIPTION
## 📝 개요

`agents.py`의 키워드 오타(`보요유종목` → `보유종목`) 수정 및 `pytest-asyncio` `asyncio_mode` 설정 누락 보완.

## 🚀 변경 사항
- `finus_nat/src/nat_finus_nat/agents.py:97` — `"보요유종목"` → `"보유종목"` 오타 수정
- `finus_nat/pyproject.toml` — `[tool.pytest.ini_options]` 섹션에 `asyncio_mode = "auto"` 추가

## 🔗 관련 이슈
- Closes #67

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?