### PR TITLE
fix: CI hadolint 매트릭스 누락 및 npm ci/omit-dev 수정 (#79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
         dockerfile:
           - backend/Dockerfile
           - finus_nat/Dockerfile
+          - frontend-react/Dockerfile
+          - mcp-news/Dockerfile
+          - mcp-trading/Dockerfile
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ uv sync --project backend
 uv run --project backend uvicorn backend.main:app --host 0.0.0.0 --port 8000
 
 # 3. Frontend 실행
-cd frontend-react && npm install && npm run dev
+cd frontend-react && npm ci && npm run dev
+```
 
 ## 📝 에이전트별 보유 스킬 (MCP Tools)
 

--- a/README.md
+++ b/README.md
@@ -85,18 +85,10 @@ cp .env.example .env
 # 2. Backend Orchestrator 실행
 # 프로젝트 루트 디렉토리에서 실행하는 것을 권장합니다.
 uv sync --project backend
-uv run --project backend uvicorn backend.main:app --host 0.0.0.0 --port 8787
+uv run --project backend uvicorn backend.main:app --host 0.0.0.0 --port 8000
 
-# 3. Frontend 실행 (Unity WebGL)
-cd frontend/Build
-python -m http.server 8080
-```
-
-브라우저에서 `http://localhost:8080`을 엽니다.
-
-Unity WebGL 빌드는 `index.html`을 더블클릭해서 `file://` URL로 실행할 수 없습니다. 브라우저가 `Build/Build.data`, `Build/Build.wasm` 같은 Unity 산출물 다운로드를 차단하므로, 로컬 웹 서버로 `frontend/Build` 폴더를 서빙해야 합니다.
-
-프론트엔드 Unity 프로젝트를 수정하거나 다시 빌드해야 하는 경우에만 Unity Editor가 필요합니다. 단순 실행만 하는 팀원은 위 명령으로 커밋된 WebGL 빌드 결과물을 실행하면 됩니다.
+# 3. Frontend 실행
+cd frontend-react && npm install && npm run dev
 
 ## 📝 에이전트별 보유 스킬 (MCP Tools)
 

--- a/finus_nat/Dockerfile
+++ b/finus_nat/Dockerfile
@@ -23,13 +23,13 @@ COPY mcp-trading /workspace/mcp-trading
 COPY mcp-dart /workspace/mcp-dart
 
 WORKDIR /workspace/mcp-news
-RUN npm ci
+RUN npm ci --omit=dev
 
 WORKDIR /workspace/mcp-trading
-RUN npm ci
+RUN npm ci --omit=dev
 
 WORKDIR /workspace/mcp-dart
-RUN npm ci
+RUN npm ci --omit=dev
 
 WORKDIR /workspace/finus_nat
 RUN uv sync --no-dev

--- a/frontend-react/Dockerfile
+++ b/frontend-react/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24-slim
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 COPY . .
 

--- a/frontend-react/vite.config.ts
+++ b/frontend-react/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const backendTarget = process.env.VITE_BACKEND_TARGET || 'http://localhost:8787'
+const backendTarget = process.env.VITE_BACKEND_TARGET || 'http://localhost:8000'
 
 export default defineConfig({
   plugins: [react()],

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -42,11 +42,11 @@ else
   echo "  ✓ backend present"
 fi
 
-_env_backend="${FIN_BACKEND}/.env"
+_env_backend="${FIN_US_INTEGRATE_ROOT}/.env"
 if [[ -f "${_env_backend}" ]]; then
-  echo "  ✓ backend .env present (${_env_backend})"
+  echo "  ✓ root .env present (${_env_backend})"
 else
-  echo "  ! backend .env missing — copy backend/.env.example to backend/.env" >&2
+  echo "  ! root .env missing — copy .env.example to .env" >&2
   warn=1
 fi
 
@@ -89,6 +89,6 @@ if [[ "${ok}" -ne 0 ]]; then
   exit 1
 fi
 if [[ "${warn}" -ne 0 ]]; then
-  echo "Warnings only — set OPENAI_API_KEY (and optional keys) in backend/.env before using analyze/NAT."
+  echo "Warnings only — set OPENAI_API_KEY (and optional keys) in .env before using analyze/NAT."
 fi
 echo "OK."


### PR DESCRIPTION
## 📝 개요

CI hadolint 매트릭스에서 누락된 Dockerfile 3개를 추가하고, 재현성 없는 `npm install`을 `npm ci`로, `--omit=dev` 누락 항목을 보완.

## 🚀 변경 사항
- `.github/workflows/ci.yml` — hadolint 매트릭스에 `frontend-react/Dockerfile`, `mcp-news/Dockerfile`, `mcp-trading/Dockerfile` 추가
- `frontend-react/Dockerfile` — `npm install` → `npm ci`로 교체 (빌드 재현성 확보)
- `finus_nat/Dockerfile` — `npm ci` → `npm ci --omit=dev` (devDependencies 이미지 제외)

## 🔗 관련 이슈
- Closes #79

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?