### PR TITLE
fix: mcp-news deprecated 도구 ListTools 목록 제거 (#75)

### DIFF
--- a/finus_nat/configs/agents/monitoring_agent.yml
+++ b/finus_nat/configs/agents/monitoring_agent.yml
@@ -14,7 +14,6 @@ functions:
     tool_names:
       - kis-trading-mcp-tool
       - mcp-news-get-market-news
-      - mcp-news-get-investor-trading
       - mcp-dart-get-disclosure-signal
       - add_user_memory
       - get_user_memory
@@ -29,7 +28,7 @@ functions:
     accept_direct_answer_without_react_format: false
     additional_instructions: |
       === 에이전트 요약 ===
-      포트폴리오 모니터링, 잔고, 뉴스·수급·DART 공시 점검. 잔고는 Kis Trading MCP, 뉴스·수급은 `mcp-news`, 지분공시는 `mcp-dart`를 쓰되 관찰·알림·건전성 관점으로 답합니다.
+      포트폴리오 모니터링, 잔고, 뉴스·수급·DART 공시 점검. 잔고·수급은 Kis Trading MCP, 뉴스는 `mcp-news`, 지분공시는 `mcp-dart`를 쓰되 관찰·알림·건전성 관점으로 답합니다.
       가능한 주어진 tool을 사용하여 정량적인 데이터를 가지고 사용자에게 답변하세요.
       사용자가 성격, 선호, 투자 성향, 답변 스타일처럼 오래 유지될 정보를 말하면 `add_user_memory`에 저장하고,
       개인화가 필요하면 `get_user_memory`로 먼저 확인하십시오.

--- a/finus_nat/configs/agents/news_agent.yml
+++ b/finus_nat/configs/agents/news_agent.yml
@@ -15,7 +15,6 @@ functions:
       - kis-trading-mcp-tool
       # news agent가 실수로 주식거래를 해버리는 위험을 막기 위해 향후에 다른 것으로 변경
       - mcp-news-get-market-news
-      - mcp-news-get-investor-trading
       - mcp-dart-get-disclosure-signal
       - add_user_memory
       - get_user_memory
@@ -31,7 +30,6 @@ functions:
       개인화가 필요하면 `get_user_memory`로 먼저 확인하십시오.
 
       - 최신 뉴스·헤드라인: `mcp-news-get-market-news` (stock_name = 종목명 또는 6자리 코드).
-      - 투자자별 수급(외인·기관 등): `mcp-news-get-investor-trading` (동일하게 stock_name).
       - DART 지분공시 signal(5% 룰·임원/주요주주): `mcp-dart-get-disclosure-signal` (stock_name). 매매 지시가 아닌 리스크·맥락 참고용.
       - `kis-trading-mcp-tool`: 보유종목/포트폴리오 확인이 필요할 때 사용합니다.
         기본 잔고 조회는 `api_type:"inquire_balance"`, `params:{{"env_dv":"real","inqr_dvsn":"01"}}`로 시작하십시오.

--- a/finus_nat/configs/agents/recommend_agent.yml
+++ b/finus_nat/configs/agents/recommend_agent.yml
@@ -16,7 +16,6 @@ functions:
     tool_names:
       - kis-trading-mcp-tool
       - mcp-news-get-market-news
-      - mcp-news-get-investor-trading
       - add_user_memory
       - get_user_memory
     verbose: false
@@ -44,4 +43,4 @@ functions:
   recommend_branch_agent:
     _type: fe_branch
     inner_function_name: recommend_agent
-    tool_description: "Recommendations: KIS MCP context, Fin-Us mcp-news headlines/flows, and user memory when available."
+    tool_description: "Recommendations: KIS MCP context, Fin-Us mcp-news headlines, and user memory when available."

--- a/finus_nat/configs/agents/strategy_agent.yml
+++ b/finus_nat/configs/agents/strategy_agent.yml
@@ -14,7 +14,6 @@ functions:
     llm_name: strategy_openai_llm
     tool_names:
       - mcp-news-get-market-news
-      - mcp-news-get-investor-trading
       - mcp-dart-get-disclosure-signal
       - kis-trading-mcp-tool
       - add_user_memory
@@ -27,7 +26,7 @@ functions:
     accept_direct_answer_without_react_format: false
     additional_instructions: |
       === 에이전트 요약 ===
-      매매 규칙·시나리오·BUY/SELL/HOLD 관점의 전략 제안. 뉴스·수급(mcp-news)과 잔고·시세(Kis MCP) 결과를 근거로 한국어로 정리합니다.
+      매매 규칙·시나리오·BUY/SELL/HOLD 관점의 전략 제안. 뉴스(mcp-news)와 수급·잔고·시세(Kis MCP) 결과를 근거로 한국어로 정리합니다.
       직전 대화에서 다룬 종목·섹터가 있으면, 사용자가 한 줄만 덧붙여도 같은 맥락으로 이어갑니다.
       사용자의 투자 기간, 위험 선호, 선호 섹터, 답변 스타일처럼 오래 유지되는 개인화 정보는 필요할 때 get_user_memory로 확인합니다.
 
@@ -35,7 +34,7 @@ functions:
       - `kis-trading-mcp-tool`: ``api_type``·``params``(필요 시 ``tool_name``) JSON — trading 과 동일. ``find_api_detail`` 로 TR 확인. ``inquire_account_balance`` 에는 ``env_dv``·``inqr_dvsn_1:"00"`` 넣지 마세요.
       - 잔고/포트폴리오 조회 기본값: ``api_type:"inquire_balance"``, ``params:{{"env_dv":"real","inqr_dvsn":"01"}}``.
       - KIS API/validation 오류가 나면 오류를 최종 답변으로 쓰지 말고 ``find_api_detail`` → params 수정 → 원래 조회 재실행을 수행하세요. 성공 Observation을 얻거나 재시도 실패를 설명할 때만 최종 답변하세요.
-      - mcp-news: ``get_market_news`` / ``get_investor_trading`` (종목명·코드). mcp-dart: ``get_disclosure_signal`` 로 지분공시 리스크를 참고하되 자동 매매 근거로만 쓰지 마세요.
+      - mcp-news: ``get_market_news`` (종목명). 수급·정형 데이터는 Kis MCP로 조회합니다. mcp-dart: ``get_disclosure_signal`` 로 지분공시 리스크를 참고하되 자동 매매 근거로만 쓰지 마세요.
       - 도구 Observation 후 BUY/SELL/HOLD 근거를 제시하십시오.
       - 이미 직전 대화에 나온 뉴스·수급에 대해 "주가에 어떤 영향", "이유", "호재/악재", "전망"을 묻는 후속 질문이면 새 도구 호출 없이 그 대화 맥락만 근거로 판단하십시오. 이 경우 반드시 ``Thought:`` 다음 ``Final Answer:`` 형식으로 끝내고 ``Action:``을 쓰지 마세요.
       - 도구 호출이 필요해서 ``Action:``을 쓰는 경우, 반드시 바로 다음 줄에 ``Action Input:``을 쓰십시오. ``Action:``만 쓰고 멈추면 안 됩니다.

--- a/finus_nat/configs/agents/trading_agent.yml
+++ b/finus_nat/configs/agents/trading_agent.yml
@@ -21,7 +21,6 @@ functions:
     tool_names:
       - kis-trading-mcp-tool
       - mcp-news-get-market-news
-      - mcp-news-get-investor-trading
       - mcp-dart-get-disclosure-signal
       - add_user_memory
       - get_user_memory
@@ -65,4 +64,4 @@ functions:
   trading_branch_agent:
     _type: fe_branch
     inner_function_name: trading_agent_react
-    tool_description: "Trading: Kis Trading MCP; mcp-news; mcp-dart disclosure (reference only, no auto-trade)."
+    tool_description: "Trading: Kis Trading MCP; mcp-news headlines; mcp-dart disclosure (reference only, no auto-trade)."

--- a/finus_nat/configs/common.yml
+++ b/finus_nat/configs/common.yml
@@ -14,10 +14,6 @@ functions:
   mcp-news-get-market-news:
     _type: finus_market_news
 
-  # fin-us/mcp-news stdio: get_investor_trading
-  mcp-news-get-investor-trading:
-    _type: finus_investor_trading
-
   # fin-us/mcp-dart stdio: get_disclosure_signal
   mcp-dart-get-disclosure-signal:
     _type: finus_disclosure_signal

--- a/finus_nat/configs/router.yml
+++ b/finus_nat/configs/router.yml
@@ -44,7 +44,7 @@ functions:
         description: "보유·관심 포트폴리오 상태 점검, 리스크/하락/알림/건전성 모니터링."
       - name: news_agent
         function_name: news_branch_agent
-        description: "종목·시황 뉴스 헤드라인·요약, 투자자 수급(mcp-news: get_market_news, get_investor_trading)."
+        description: "종목·시황 뉴스 헤드라인·요약(mcp-news: get_market_news). 투자자 수급은 Kis Trading MCP 경로로 조회."
       - name: recommend_agent
         function_name: recommend_branch_agent
         description: "조건에 맞는 종목 후보 탐색, 대안 종목, 관심종목 아이디어 추천."

--- a/finus_nat/configs/router_nomemory.yml
+++ b/finus_nat/configs/router_nomemory.yml
@@ -25,7 +25,7 @@ functions:
         description: "보유·관심 포트폴리오 상태 점검, 리스크/하락/알림/건전성 모니터링."
       - name: news_agent
         function_name: news_branch_agent
-        description: "종목·시황 뉴스 헤드라인·요약, 투자자 수급(mcp-news: get_market_news, get_investor_trading)."
+        description: "종목·시황 뉴스 헤드라인·요약(mcp-news: get_market_news). 투자자 수급은 Kis Trading MCP 경로로 조회."
       - name: recommend_agent
         function_name: recommend_branch_agent
         description: "조건에 맞는 종목 후보 탐색, 대안 종목, 관심종목 아이디어 추천."

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -261,9 +261,6 @@ class FinusMarketNewsConfig(FunctionBaseConfig, name="finus_market_news"):
     timeout_sec: float = Field(default=120.0, ge=5.0, le=600.0)
 
 
-class FinusInvestorTradingConfig(FinusMarketNewsConfig, name="finus_investor_trading"):
-    """finus_market_news와 동일 필드"""
-
 class FinusDisclosureSignalConfig(FinusMarketNewsConfig, name="finus_disclosure_signal"):
     """mcp-dart stdio MCP — OpenDART 지분공시 signal."""
 
@@ -464,17 +461,6 @@ async def finus_market_news(config: FinusMarketNewsConfig, _builder: Builder):
         vendor_root=config.vendor_root,
         timeout_sec=config.timeout_sec,
         mcp_tool="get_market_news",
-        fn_doc=doc,
-    )
-
-
-@register_function(config_type=FinusInvestorTradingConfig)
-async def finus_investor_trading(config: FinusInvestorTradingConfig, _builder: Builder):
-    doc = "Fin-Us mcp-news stdio MCP: 투자자별 순매수·수급(약 5거래일), 종목명·코드 기준."
-    yield _mcp_news_stock_function_info(
-        vendor_root=config.vendor_root,
-        timeout_sec=config.timeout_sec,
-        mcp_tool="get_investor_trading",
         fn_doc=doc,
     )
 

--- a/finus_nat/src/nat_finus_nat/register.py
+++ b/finus_nat/src/nat_finus_nat/register.py
@@ -24,7 +24,6 @@ _STRICT_TOOL_SUBSTR = (
     "kis-api-daily-trades",
     "mcp-news",
     "finus_market_news",
-    "finus_investor_trading",
     "mcp-dart",
     "finus_disclosure",
 )

--- a/mcp-news/index.js
+++ b/mcp-news/index.js
@@ -146,34 +146,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ["stock_name"],
       },
     },
-    {
-      name: "get_investor_trading",
-      description: "deprecated: mcp-trading의 get_investor_trading으로 이동되었습니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 (예: 삼성전자, SK하이닉스)",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
-    {
-      name: "get_research_reports",
-      description: "deprecated: 공식 대체 API가 확정되지 않아 비활성화되었습니다.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          stock_name: {
-            type: "string",
-            description: "주식 종목명 (예: 삼성전자, SK하이닉스)",
-          },
-        },
-        required: ["stock_name"],
-      },
-    },
   ],
 }));
 


### PR DESCRIPTION
## 📝 개요

`mcp-news`의 `ListTools` 응답에서 deprecated 도구(`get_investor_trading`, `get_research_reports`)를 제거. 기존에는 목록에 노출돼 LLM이 호출을 시도하고 에러를 받는 불필요한 왕복이 발생했음.

## 🚀 변경 사항
- `mcp-news/index.js` — `ListToolsRequestSchema` 핸들러에서 `get_investor_trading`, `get_research_reports` 항목 제거
- `finus_nat/configs/agents/news_agent.yml` — `mcp-news-get-investor-trading` 툴 화이트리스트에서 제거

## 🔗 관련 이슈
- Closes #75

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?