### PR TITLE
fix: README·vite.config·check_env 포트/경로 불일치 수정 (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,11 @@ cp .env.example .env
 # 2. Backend Orchestrator 실행
 # 프로젝트 루트 디렉토리에서 실행하는 것을 권장합니다.
 uv sync --project backend
-uv run --project backend uvicorn backend.main:app --host 0.0.0.0 --port 8787
+uv run --project backend uvicorn backend.main:app --host 0.0.0.0 --port 8000
 
-# 3. Frontend 실행 (Unity WebGL)
-cd frontend/Build
-python -m http.server 8080
+# 3. Frontend 실행
+cd frontend-react && npm install && npm run dev
 ```
-
-브라우저에서 `http://localhost:8080`을 엽니다.
-
-Unity WebGL 빌드는 `index.html`을 더블클릭해서 `file://` URL로 실행할 수 없습니다. 브라우저가 `Build/Build.data`, `Build/Build.wasm` 같은 Unity 산출물 다운로드를 차단하므로, 로컬 웹 서버로 `frontend/Build` 폴더를 서빙해야 합니다.
-
-프론트엔드 Unity 프로젝트를 수정하거나 다시 빌드해야 하는 경우에만 Unity Editor가 필요합니다. 단순 실행만 하는 팀원은 위 명령으로 커밋된 WebGL 빌드 결과물을 실행하면 됩니다.
 
 ## 📝 에이전트별 보유 스킬 (MCP Tools)
 

--- a/frontend-react/vite.config.ts
+++ b/frontend-react/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const backendTarget = process.env.VITE_BACKEND_TARGET || 'http://localhost:8787'
+const backendTarget = process.env.VITE_BACKEND_TARGET || 'http://localhost:8000'
 
 export default defineConfig({
   plugins: [react()],

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -42,11 +42,11 @@ else
   echo "  ✓ backend present"
 fi
 
-_env_backend="${FIN_BACKEND}/.env"
+_env_backend="${FIN_US_INTEGRATE_ROOT}/.env"
 if [[ -f "${_env_backend}" ]]; then
-  echo "  ✓ backend .env present (${_env_backend})"
+  echo "  ✓ root .env present (${_env_backend})"
 else
-  echo "  ! backend .env missing — copy backend/.env.example to backend/.env" >&2
+  echo "  ! root .env missing — copy .env.example to .env" >&2
   warn=1
 fi
 
@@ -89,6 +89,6 @@ if [[ "${ok}" -ne 0 ]]; then
   exit 1
 fi
 if [[ "${warn}" -ne 0 ]]; then
-  echo "Warnings only — set OPENAI_API_KEY (and optional keys) in backend/.env before using analyze/NAT."
+  echo "Warnings only — set OPENAI_API_KEY (and optional keys) in .env before using analyze/NAT."
 fi
 echo "OK."


### PR DESCRIPTION
## 📝 개요

`README.md`, `vite.config.ts`, `check_env.sh` 세 곳에 잔존하던 포트·경로 불일치를 수정. 새 기여자가 문서만 보고 잘못된 환경을 구성하는 문제 방지.

## 🚀 변경 사항
- `README.md` — backend 포트 `8787` → `8000`, frontend Quick Start를 React(`frontend-react/`) 기준으로 수정
- `frontend-react/vite.config.ts` — proxy 폴백 포트 `8787` → `8000`
- `scripts/check_env.sh` — `.env` 검사 경로를 `backend/.env`에서 루트 `.env`로 수정

## 🔗 관련 이슈
- Closes #77

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?