### PR TITLE
fix: MCP 호출 타임아웃 추가 — services.py + mcp-trading axios (#64)

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -348,7 +348,9 @@ async def run_mcp_tool(
     tool_name: str,
     arguments: dict[str, Any],
 ) -> str:
-    try:
+    import asyncio
+
+    async def _call() -> str:
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -361,6 +363,16 @@ async def run_mcp_tool(
                     return ""
                 block = result.content[0]
                 return getattr(block, "text", str(block))
+
+    try:
+        # MCP 서브프로세스 호출에 30초 타임아웃 적용 — 무기한 블로킹 방지
+        return await asyncio.wait_for(_call(), timeout=30.0)
+    except asyncio.TimeoutError as exc:
+        logger.error("MCP call_tool timed out for %s", tool_name)
+        raise HTTPException(
+            status_code=504,
+            detail=f"데이터 공급원({tool_name}) 응답 타임아웃 (30초)",
+        ) from exc
     except HTTPException:
         raise
     except Exception as exc:

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -11,6 +11,9 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios from "axios";
 import dotenv from "dotenv";
+
+// KIS API 호출용 axios 인스턴스 — 8초 타임아웃으로 무기한 블로킹 방지
+const kisAxios = axios.create({ timeout: 8000 });
 import { buildBalanceParams, formatBalanceReport } from "./balance.js";
 import {
   createCashOrderRequest,
@@ -106,7 +109,7 @@ async function getAccessToken() {
   if (cachedToken) return cachedToken;
 
   try {
-    const response = await axios.post(`${KIS_URL}/oauth2/tokenP`, {
+    const response = await kisAxios.post(`${KIS_URL}/oauth2/tokenP`, {
       grant_type: "client_credentials",
       appkey: KIS_API_KEY,
       appsecret: KIS_API_SECRET,
@@ -126,7 +129,7 @@ async function getAccessToken() {
 
 async function kisGet(pathname, trId, params) {
   const token = await getAccessToken();
-  const response = await axios.get(`${KIS_URL}${pathname}`, {
+  const response = await kisAxios.get(`${KIS_URL}${pathname}`, {
     headers: {
       "Content-Type": "application/json",
       authorization: `Bearer ${token}`,
@@ -147,7 +150,7 @@ async function kisGet(pathname, trId, params) {
 
 async function kisPost(pathname, trId, body) {
   const token = await getAccessToken();
-  const response = await axios.post(`${KIS_URL}${pathname}`, body, {
+  const response = await kisAxios.post(`${KIS_URL}${pathname}`, body, {
     headers: {
       "Content-Type": "application/json",
       authorization: `Bearer ${token}`,


### PR DESCRIPTION
## 📝 개요

백엔드 MCP 호출과 mcp-trading axios 요청에 타임아웃이 없어 무기한 블로킹이 가능했던 문제 수정. `services.py`에 `asyncio.wait_for` 30초, `mcp-trading`에 axios 8초 타임아웃 적용.

## 🚀 변경 사항
- `backend/services.py` — MCP 호출에 `asyncio.wait_for(..., timeout=30.0)` 적용
- `mcp-trading/index.js` — `axios.create({ timeout: 8000 })` 인스턴스로 `getAccessToken`, `kisGet`, `kisPost` 통일

## 🔗 관련 이슈
- Closes #64

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?