### PR TITLE
fix: frontend Dockerfile Vite 개발 서버 → nginx 프로덕션 빌드 (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,11 @@ cp .env.example .env
 # 2. Backend Orchestrator 실행
 # 프로젝트 루트 디렉토리에서 실행하는 것을 권장합니다.
 uv sync --project backend
-uv run --project backend uvicorn backend.main:app --host 0.0.0.0 --port 8787
+uv run --project backend uvicorn backend.main:app --host 0.0.0.0 --port 8000
 
-# 3. Frontend 실행 (Unity WebGL)
-cd frontend/Build
-python -m http.server 8080
+# 3. Frontend 실행
+cd frontend-react && npm install && npm run dev
 ```
-
-브라우저에서 `http://localhost:8080`을 엽니다.
-
-Unity WebGL 빌드는 `index.html`을 더블클릭해서 `file://` URL로 실행할 수 없습니다. 브라우저가 `Build/Build.data`, `Build/Build.wasm` 같은 Unity 산출물 다운로드를 차단하므로, 로컬 웹 서버로 `frontend/Build` 폴더를 서빙해야 합니다.
-
-프론트엔드 Unity 프로젝트를 수정하거나 다시 빌드해야 하는 경우에만 Unity Editor가 필요합니다. 단순 실행만 하는 팀원은 위 명령으로 커밋된 WebGL 빌드 결과물을 실행하면 됩니다.
 
 ## 📝 에이전트별 보유 스킬 (MCP Tools)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,8 @@ services:
     build:
       context: ./frontend-react
     ports:
-      - "5173:5173"
-    volumes:
-      - ./frontend-react:/app
-      - /app/node_modules
-    environment:
-      - VITE_API_BASE_URL=http://localhost:8000/api/v1
-      - VITE_BACKEND_TARGET=http://backend:8000
+      # nginx 컨테이너는 80번 포트로 서빙 (호스트 5173 → 컨테이너 80)
+      - "5173:80"
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend-react/Dockerfile
+++ b/frontend-react/Dockerfile
@@ -1,12 +1,23 @@
-FROM node:24-slim
+# ── 1단계: 빌드 ───────────────────────────────────────────────
+FROM node:24-slim AS build
 
 WORKDIR /app
 
+# 의존성만 먼저 복사해 레이어 캐시 활용
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
+# 소스 전체 복사 후 프로덕션 번들 생성
 COPY . .
+RUN npm run build
 
-EXPOSE 5173
+# ── 2단계: 서빙 ───────────────────────────────────────────────
+FROM nginx:alpine
 
-CMD ["npm", "run", "dev", "--", "--host"]
+# 빌드 결과물을 nginx 정적 파일 경로로 복사
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# /api, /health 경로를 backend 서비스로 프록시하는 nginx 설정 적용
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/frontend-react/nginx.conf
+++ b/frontend-react/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name _;
+
+    # 정적 파일 루트 (vite build 결과물)
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA 라우팅: 존재하지 않는 경로는 index.html로 폴백
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # /api 경로 → backend 서비스로 프록시 (WebSocket 업그레이드 포함)
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+
+        # WebSocket 핸드셰이크를 위한 헤더
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # /health 경로 → backend 서비스로 프록시
+    location /health {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/frontend-react/vite.config.ts
+++ b/frontend-react/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const backendTarget = process.env.VITE_BACKEND_TARGET || 'http://localhost:8787'
+const backendTarget = process.env.VITE_BACKEND_TARGET || 'http://localhost:8000'
 
 export default defineConfig({
   plugins: [react()],

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -42,11 +42,11 @@ else
   echo "  ✓ backend present"
 fi
 
-_env_backend="${FIN_BACKEND}/.env"
+_env_backend="${FIN_US_INTEGRATE_ROOT}/.env"
 if [[ -f "${_env_backend}" ]]; then
-  echo "  ✓ backend .env present (${_env_backend})"
+  echo "  ✓ root .env present (${_env_backend})"
 else
-  echo "  ! backend .env missing — copy backend/.env.example to backend/.env" >&2
+  echo "  ! root .env missing — copy .env.example to .env" >&2
   warn=1
 fi
 
@@ -89,6 +89,6 @@ if [[ "${ok}" -ne 0 ]]; then
   exit 1
 fi
 if [[ "${warn}" -ne 0 ]]; then
-  echo "Warnings only — set OPENAI_API_KEY (and optional keys) in backend/.env before using analyze/NAT."
+  echo "Warnings only — set OPENAI_API_KEY (and optional keys) in .env before using analyze/NAT."
 fi
 echo "OK."


### PR DESCRIPTION
## 📝 개요

프로덕션 컨테이너에서 Vite 개발 서버(`HMR`, 소스맵, 전체 소스 노출)를 그대로 서비스하던 문제 수정. `vite build` + nginx 멀티스테이지 빌드로 전환.

## 🚀 변경 사항
- `frontend-react/Dockerfile` — 멀티스테이지 빌드 (node:24-slim 빌드 → nginx:alpine 서빙)
- `frontend-react/nginx.conf` — `/api`, `/health` 경로를 backend로 프록시하는 nginx 설정 추가 (WebSocket 업그레이드 포함)
- `docker-compose.yml` — frontend 포트 매핑 조정 (`5173:5173` → `5173:80`), 개발 전용 볼륨·환경변수 제거

## 🔗 관련 이슈
- Closes #68

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?