### PR TITLE
fix: 알파뉴메릭 주문 코드 오류 개선

### DIFF
--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -70,6 +70,9 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price, orde
   if (account.length < 10) {
     throw new Error("KIS_ACCOUNT_NO가 올바르지 않습니다. 계좌번호 앞 8자리와 상품코드 2자리를 붙여 설정하세요.");
   }
+  if (/^[0-9A-Z]{6,7}$/i.test(code) && !/^\d{6,7}$/.test(code)) {
+    throw new Error("이 종목은 현재 주문을 지원하지 않습니다.");
+  }
   if (!/^\d{6,7}$/.test(code)) {
     throw new Error("stock_code는 6자리 또는 7자리 종목코드여야 합니다.");
   }

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -232,6 +232,19 @@ test("buildCashOrderBody creates market KIS order body", () => {
   );
 });
 
+test("buildCashOrderBody rejects alphanumeric stock codes as unsupported order targets", () => {
+  assert.throws(
+    () => buildCashOrderBody({
+      accountNo: "1234567801",
+      stockCode: "0001A0",
+      quantity: 1,
+      price: 10000,
+      orderType: "LIMIT",
+    }),
+    /이 종목은 현재 주문을 지원하지 않습니다/,
+  );
+});
+
 test("formatOrderResult includes order number when present", () => {
   assert.equal(
     formatOrderResult({


### PR DESCRIPTION
## 📝 개요

mcp-trading 주문 생성 단계에서 ETN/SPAC 등 알파뉴메릭 종목코드가 일반 형식 오류로 실패하던 문제를 수정합니다.

## 🚀 변경 사항
- 6~7자리 알파뉴메릭 종목코드를 주문 미지원 종목으로 분리해 명확한 오류 메시지 반환
- 알파뉴메릭 종목코드 주문 실패 메시지 회귀 테스트 추가

## 🔗 관련 이슈
- Related to #73

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)

없음