### PR TITLE
fix: 종목 마스터 품질 개선

### DIFF
--- a/mcp-trading/data/stocks.json
+++ b/mcp-trading/data/stocks.json
@@ -24796,30 +24796,6 @@
     "aliases": []
   },
   {
-    "code": "Q570055",
-    "name": "한투 금선물 ETN",
-    "market": "KOSPI",
-    "aliases": []
-  },
-  {
-    "code": "Q570056",
-    "name": "한투 인버스금선물 ETN",
-    "market": "KOSPI",
-    "aliases": []
-  },
-  {
-    "code": "Q570057",
-    "name": "한투 은선물 ETN",
-    "market": "KOSPI",
-    "aliases": []
-  },
-  {
-    "code": "Q570058",
-    "name": "한투 인버스은선물 ETN",
-    "market": "KOSPI",
-    "aliases": []
-  },
-  {
     "code": "Q570059",
     "name": "한투 레버리지금선물 ETN",
     "market": "KOSPI",

--- a/mcp-trading/scripts/update_stock_master.py
+++ b/mcp-trading/scripts/update_stock_master.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import os
 import shutil
 import tempfile
 import urllib.request
@@ -67,6 +68,37 @@ def parse_master_rows(file_path, *, market, tail_width, aliases_by_code):
     return stocks
 
 
+def deduplicate_stocks(stocks):
+    deduped_by_market_name = {}
+    for stock in stocks:
+        key = (stock["market"], stock["name"])
+        deduped_by_market_name[key] = stock
+    return list(deduped_by_market_name.values())
+
+
+def write_stocks(stocks, stocks_path=STOCKS_PATH):
+    if not stocks:
+        raise ValueError("종목 마스터 갱신 결과가 비어 있습니다.")
+
+    next_text = json.dumps(stocks, ensure_ascii=False, indent=2) + "\n"
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=stocks_path.parent,
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            temp_file.write(next_text)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, stocks_path)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+
+
 def main():
     aliases_by_code = load_existing_aliases()
     with tempfile.TemporaryDirectory() as temp_name:
@@ -83,9 +115,9 @@ def main():
                 )
             )
 
+    stocks = deduplicate_stocks(stocks)
     stocks.sort(key=lambda stock: (stock["market"], stock["code"]))
-    next_text = json.dumps(stocks, ensure_ascii=False, indent=2) + "\n"
-    STOCKS_PATH.write_text(next_text, encoding="utf-8")
+    write_stocks(stocks)
     print(f"updated {STOCKS_PATH} with {len(stocks)} stocks")
 
 

--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -12,11 +12,24 @@ export function loadStocks(stocksPath = DEFAULT_STOCKS_PATH) {
   return JSON.parse(text);
 }
 
+let cachedStocks;
+
+export function clearStocksCache() {
+  cachedStocks = undefined;
+}
+
+export function getDefaultStocks() {
+  if (cachedStocks === undefined) {
+    cachedStocks = loadStocks();
+  }
+  return cachedStocks;
+}
+
 export function normalizeStockInput(value) {
   return String(value ?? "").trim();
 }
 
-export function resolveStock(stockName, stocks = loadStocks()) {
+export function resolveStock(stockName, stocks) {
   const input = normalizeStockInput(stockName);
   if (!input) {
     throw new Error("stock_name 파라미터가 누락되었습니다.");
@@ -27,7 +40,8 @@ export function resolveStock(stockName, stocks = loadStocks()) {
     return { code, name: code, market: "UNKNOWN", aliases: [] };
   }
 
-  const matches = stocks.filter((stock) => {
+  const stockList = stocks ?? getDefaultStocks();
+  const matches = stockList.filter((stock) => {
     const aliases = Array.isArray(stock.aliases) ? stock.aliases : [];
     return stock.name === input || aliases.includes(input);
   });

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import test from "node:test";
-import { resolveStock } from "../stock-master.js";
+import { clearStocksCache, DEFAULT_STOCKS_PATH, resolveStock } from "../stock-master.js";
 
 test("resolveStock resolves names from the expanded domestic stock master", () => {
   assert.deepEqual(resolveStock("카카오"), {
@@ -34,4 +35,63 @@ test("resolveStock guides users to 6 digit stock codes when a name is missing", 
     () => resolveStock("없는종목"),
     /6자리 종목코드로 직접 입력/,
   );
+});
+
+test("resolveStock reads the default stock master once per process cache", () => {
+  clearStocksCache();
+  const originalReadFileSync = fs.readFileSync;
+  let readCount = 0;
+
+  fs.readFileSync = function readFileSync(filePath, ...args) {
+    if (filePath === DEFAULT_STOCKS_PATH) {
+      readCount += 1;
+    }
+    return originalReadFileSync.call(this, filePath, ...args);
+  };
+
+  try {
+    resolveStock("카카오");
+    resolveStock("삼성전자");
+  } finally {
+    fs.readFileSync = originalReadFileSync;
+    clearStocksCache();
+  }
+
+  assert.equal(readCount, 1);
+});
+
+test("resolveStock does not read the default stock master for direct stock codes", () => {
+  clearStocksCache();
+  const originalReadFileSync = fs.readFileSync;
+  let readCount = 0;
+
+  fs.readFileSync = function readFileSync(filePath, ...args) {
+    if (filePath === DEFAULT_STOCKS_PATH) {
+      readCount += 1;
+    }
+    return originalReadFileSync.call(this, filePath, ...args);
+  };
+
+  try {
+    assert.deepEqual(resolveStock("123456"), {
+      code: "123456",
+      name: "123456",
+      market: "UNKNOWN",
+      aliases: [],
+    });
+  } finally {
+    fs.readFileSync = originalReadFileSync;
+    clearStocksCache();
+  }
+
+  assert.equal(readCount, 0);
+});
+
+test("resolveStock resolves deduplicated ETN names without ambiguity", () => {
+  assert.deepEqual(resolveStock("한투 금선물 ETN"), {
+    code: "Q570121",
+    name: "한투 금선물 ETN",
+    market: "KOSPI",
+    aliases: [],
+  });
 });

--- a/mcp-trading/tests/test_update_stock_master.py
+++ b/mcp-trading/tests/test_update_stock_master.py
@@ -1,5 +1,8 @@
 import importlib.util
+import json
 from pathlib import Path
+
+import pytest
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "update_stock_master.py"
@@ -58,3 +61,51 @@ def test_download_source_uses_default_tls_verification(monkeypatch, tmp_path):
 
     assert file_path == tmp_path / "kospi_code.mst"
     assert captured == {"url": source["url"], "kwargs": {}}
+
+
+def test_deduplicate_stocks_keeps_latest_market_name_pair():
+    module = load_update_stock_master()
+
+    stocks = [
+        {"code": "Q570055", "name": "한투 금선물 ETN", "market": "KOSPI", "aliases": []},
+        {"code": "Q570121", "name": "한투 금선물 ETN", "market": "KOSPI", "aliases": []},
+        {"code": "Q570055", "name": "한투 금선물 ETN", "market": "KOSDAQ", "aliases": []},
+    ]
+
+    assert module.deduplicate_stocks(stocks) == [
+        {"code": "Q570121", "name": "한투 금선물 ETN", "market": "KOSPI", "aliases": []},
+        {"code": "Q570055", "name": "한투 금선물 ETN", "market": "KOSDAQ", "aliases": []},
+    ]
+
+
+def test_write_stocks_rejects_empty_result(tmp_path):
+    module = load_update_stock_master()
+    stocks_path = tmp_path / "stocks.json"
+
+    with pytest.raises(ValueError, match="비어 있습니다"):
+        module.write_stocks([], stocks_path)
+
+    assert not stocks_path.exists()
+
+
+def test_write_stocks_replaces_target_atomically(monkeypatch, tmp_path):
+    module = load_update_stock_master()
+    stocks_path = tmp_path / "stocks.json"
+    stocks = [{"code": "005930", "name": "삼성전자", "market": "KOSPI", "aliases": []}]
+    replace_calls = []
+    original_replace = module.os.replace
+
+    def fake_replace(source, target):
+        replace_calls.append((Path(source), Path(target)))
+        original_replace(source, target)
+
+    monkeypatch.setattr(module.os, "replace", fake_replace)
+
+    module.write_stocks(stocks, stocks_path)
+
+    assert json.loads(stocks_path.read_text(encoding="utf-8")) == stocks
+    assert len(replace_calls) == 1
+    temp_path, replace_target = replace_calls[0]
+    assert temp_path.parent == tmp_path
+    assert replace_target == stocks_path
+    assert not temp_path.exists()


### PR DESCRIPTION
## 📝 개요

Issue #74 의 mcp-trading 종목 마스터 품질 문제를 수정합니다. 반복 동기 파일 읽기를 프로세스 메모리 캐시로 줄이고, 갱신 스크립트의 원자적 쓰기/빈 결과 방어/동명 중복 제거를 추가했습니다.

## 🚀 변경 사항
- `resolveStock()` 기본 마스터 로드를 lazy cache로 전환하고 직접 종목코드 입력은 파일 로드를 건너뛰도록 변경
- `update_stock_master.py`에 `(market, name)` 기준 중복 제거, 빈 결과 guard, `os.replace()` 기반 원자적 쓰기 추가
- `stocks.json`의 동명 ETN 중복 제거 및 Node/Python 회귀 테스트 추가

## 🔗 관련 이슈
- Related to #74

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)
