### PR TITLE
fix: mcp-trading 주문 중복 제출 방지

### DIFF
--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -10,6 +10,10 @@ import dotenv from "dotenv";
 import { z } from "zod";
 import { buildBalanceParams, formatBalanceReport } from "./balance.js";
 import {
+  OrderDedupStore,
+  createOrderDedupKey,
+} from "./order-dedup.js";
+import {
   createCashOrderRequest,
   formatOrderResult,
 } from "./order.js";
@@ -45,6 +49,7 @@ let tokenCache = null;
 const server = new McpServer({ name: "trading-tool", version: "1.0.0" });
 // KIS API 호출용 axios 인스턴스 — 8초 타임아웃으로 무기한 블로킹 방지
 const kisAxios = axios.create({ timeout: 8000 });
+const orderDedupStore = new OrderDedupStore();
 
 function isMissingCredential(value) {
   return !value || value.startsWith("your_") || value.includes("_here");
@@ -141,22 +146,48 @@ async function kisGet(pathname, trId, params) {
   return data;
 }
 
-async function kisPost(pathname, trId, body) {
-  const token = await getAccessToken();
-  const response = await kisAxios.post(`${KIS_URL}${pathname}`, body, {
+async function createKisHashKey(body) {
+  const response = await kisAxios.post(`${KIS_URL}/uapi/hashkey`, body, {
     headers: {
       "Content-Type": "application/json",
-      authorization: `Bearer ${token}`,
       appkey: KIS_API_KEY,
       appsecret: KIS_API_SECRET,
-      tr_id: trId,
-      custtype: "P",
     },
   });
+  const hashKey = response.data?.HASH;
+  if (!hashKey) {
+    throw new Error("KIS hashkey 발급 실패");
+  }
+  return hashKey;
+}
+
+async function kisPost(pathname, trId, body, { useHashKey = false } = {}) {
+  const token = await getAccessToken();
+  const headers = {
+    "Content-Type": "application/json",
+    authorization: `Bearer ${token}`,
+    appkey: KIS_API_KEY,
+    appsecret: KIS_API_SECRET,
+    tr_id: trId,
+    custtype: "P",
+  };
+  if (useHashKey) {
+    headers.hashkey = await createKisHashKey(body);
+  }
+
+  let response;
+  try {
+    response = await kisAxios.post(`${KIS_URL}${pathname}`, body, { headers });
+  } catch (error) {
+    error.kisOrderSubmittedMaybe = true;
+    throw error;
+  }
 
   const data = response.data;
   if (data.rt_cd !== "0") {
-    throw new Error(`KIS API 오류: ${data.msg1 || data.msg_cd || "알 수 없는 오류"}`);
+    const error = new Error(`KIS API 오류: ${data.msg1 || data.msg_cd || "알 수 없는 오류"}`);
+    error.kisOrderRejected = true;
+    throw error;
   }
   return data;
 }
@@ -255,8 +286,32 @@ async function placeOrder(args) {
     orderType,
     realOrderEnabled: KIS_REAL_ORDER_ENABLED === "true",
   });
+  const dedupKey = createOrderDedupKey({
+    accountNo: KIS_ACCOUNT_NO,
+    orderEnv,
+    stockCode,
+    side,
+    quantity,
+    price,
+    orderType,
+  });
 
-  const data = await kisPost(request.pathname, request.trId, request.body);
+  orderDedupStore.reserve(dedupKey, {
+    pathname: request.pathname,
+    trId: request.trId,
+    body: request.body,
+  });
+
+  let data;
+  try {
+    data = await kisPost(request.pathname, request.trId, request.body, { useHashKey: true });
+    orderDedupStore.markSucceeded(dedupKey, data);
+  } catch (error) {
+    if (!error.kisOrderSubmittedMaybe || error.kisOrderRejected) {
+      orderDedupStore.release(dedupKey);
+    }
+    throw error;
+  }
   return formatOrderResult({
     stockName,
     stockCode,

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -410,7 +410,7 @@ server.registerTool(
 server.registerTool(
   "place_order",
   {
-    description: "한국투자증권 Open API로 국내 주식 현금 주문을 실행합니다.",
+    description: "한국투자증권 Open API로 국내 주식 현금 주문을 실행합니다. 동일 주문은 중복 방지 TTL 동안 차단되므로 자동 재시도하지 마세요.",
     inputSchema: placeOrderSchema,
   },
   async (args) => callTradingTool("place_order", args),

--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -23,14 +23,15 @@ export function createOrderDedupKey({
   price,
   orderType,
 }) {
+  const normalizedOrderType = String(orderType ?? "LIMIT").trim().toUpperCase();
   const payload = {
     accountNo: String(accountNo ?? "").trim(),
     orderEnv: String(orderEnv ?? "demo").trim().toLowerCase(),
     stockCode: String(stockCode ?? "").trim(),
     side: String(side ?? "").trim().toUpperCase(),
     quantity: String(quantity ?? "").trim(),
-    price: String(price ?? 0).trim(),
-    orderType: String(orderType ?? "LIMIT").trim().toUpperCase(),
+    price: normalizedOrderType === "MARKET" ? "0" : String(price ?? 0).trim(),
+    orderType: normalizedOrderType,
   };
 
   return crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");

--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -1,0 +1,122 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_ORDER_DEDUP_TTL_MS = 120_000;
+const DEFAULT_ORDER_DEDUP_PATH = path.join(os.tmpdir(), "finus-kis-order-dedup.json");
+
+export class DuplicateOrderError extends Error {
+  constructor(entry) {
+    super("중복 주문 방지를 위해 동일 주문 재요청을 차단했습니다. 잠시 후 주문 내역을 확인하세요.");
+    this.name = "DuplicateOrderError";
+    this.entry = entry;
+  }
+}
+
+export function createOrderDedupKey({
+  accountNo,
+  orderEnv,
+  stockCode,
+  side,
+  quantity,
+  price,
+  orderType,
+}) {
+  const payload = {
+    accountNo: String(accountNo ?? "").trim(),
+    orderEnv: String(orderEnv ?? "demo").trim().toLowerCase(),
+    stockCode: String(stockCode ?? "").trim(),
+    side: String(side ?? "").trim().toUpperCase(),
+    quantity: String(quantity ?? "").trim(),
+    price: String(price ?? 0).trim(),
+    orderType: String(orderType ?? "LIMIT").trim().toUpperCase(),
+  };
+
+  return crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export class OrderDedupStore {
+  constructor({
+    filePath = process.env.KIS_ORDER_DEDUP_PATH || DEFAULT_ORDER_DEDUP_PATH,
+    ttlMs = parsePositiveInteger(process.env.KIS_ORDER_DEDUP_TTL_MS, DEFAULT_ORDER_DEDUP_TTL_MS),
+    now = () => Date.now(),
+  } = {}) {
+    this.filePath = filePath;
+    this.ttlMs = ttlMs;
+    this.now = now;
+  }
+
+  reserve(key, request) {
+    const now = this.now();
+    const ledger = this.#readLedger(now);
+    const existing = ledger[key];
+    if (existing && Number(existing.expiresAt) > now) {
+      throw new DuplicateOrderError(existing);
+    }
+
+    const entry = {
+      status: "in_flight",
+      reservedAt: now,
+      expiresAt: now + this.ttlMs,
+      request,
+    };
+    ledger[key] = entry;
+    this.#writeLedger(ledger);
+    return entry;
+  }
+
+  markSucceeded(key, response) {
+    const now = this.now();
+    const ledger = this.#readLedger(now);
+    const existing = ledger[key];
+    if (!existing) return;
+
+    ledger[key] = {
+      ...existing,
+      status: "succeeded",
+      completedAt: now,
+      response,
+    };
+    this.#writeLedger(ledger);
+  }
+
+  release(key) {
+    const ledger = this.#readLedger(this.now());
+    if (!ledger[key]) return;
+    delete ledger[key];
+    this.#writeLedger(ledger);
+  }
+
+  #readLedger(now) {
+    let ledger = {};
+    try {
+      ledger = JSON.parse(fs.readFileSync(this.filePath, "utf8"));
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        console.error(`KIS order dedup ledger read failed: ${error.message}`);
+      }
+    }
+
+    if (!ledger || typeof ledger !== "object" || Array.isArray(ledger)) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(ledger).filter(([, entry]) => Number(entry?.expiresAt) > now),
+    );
+  }
+
+  #writeLedger(ledger) {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, JSON.stringify(ledger), { mode: 0o600 });
+  }
+}

--- a/mcp-trading/tests/mcp-server.test.js
+++ b/mcp-trading/tests/mcp-server.test.js
@@ -46,6 +46,7 @@ test("registers trading tools with preserved required schemas", async () => {
       "quantity",
       "order_env",
     ]);
+    assert.match(toolByName(tools, "place_order").description, /자동 재시도하지 마세요/);
   });
 });
 

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -36,6 +36,22 @@ test("createOrderDedupKey normalizes equivalent order arguments", () => {
   assert.equal(first, second);
 });
 
+test("createOrderDedupKey ignores original price for market orders", () => {
+  const baseOrder = {
+    accountNo: "1234567801",
+    orderEnv: "demo",
+    stockCode: "005930",
+    side: "BUY",
+    quantity: 1,
+    orderType: "MARKET",
+  };
+
+  assert.equal(
+    createOrderDedupKey({ ...baseOrder, price: 0 }),
+    createOrderDedupKey({ ...baseOrder, price: 50_000 }),
+  );
+});
+
 test("OrderDedupStore blocks duplicate reservations before TTL expires", () => {
   const store = new OrderDedupStore({
     filePath: tempLedgerPath(),

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  DuplicateOrderError,
+  OrderDedupStore,
+  createOrderDedupKey,
+} from "../order-dedup.js";
+
+function tempLedgerPath() {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "finus-order-dedup-test-")), "ledger.json");
+}
+
+test("createOrderDedupKey normalizes equivalent order arguments", () => {
+  const first = createOrderDedupKey({
+    accountNo: "1234567801",
+    orderEnv: "DEMO",
+    stockCode: "005930",
+    side: "buy",
+    quantity: 1,
+    price: 0,
+    orderType: "market",
+  });
+  const second = createOrderDedupKey({
+    accountNo: " 1234567801 ",
+    orderEnv: "demo",
+    stockCode: "005930",
+    side: "BUY",
+    quantity: "1",
+    price: "0",
+    orderType: "MARKET",
+  });
+
+  assert.equal(first, second);
+});
+
+test("OrderDedupStore blocks duplicate reservations before TTL expires", () => {
+  const store = new OrderDedupStore({
+    filePath: tempLedgerPath(),
+    ttlMs: 60_000,
+    now: () => 1_000,
+  });
+
+  store.reserve("same-order", { stockCode: "005930" });
+
+  assert.throws(
+    () => store.reserve("same-order", { stockCode: "005930" }),
+    DuplicateOrderError,
+  );
+});
+
+test("OrderDedupStore allows reservation after TTL expires", () => {
+  let now = 1_000;
+  const store = new OrderDedupStore({
+    filePath: tempLedgerPath(),
+    ttlMs: 60_000,
+    now: () => now,
+  });
+
+  store.reserve("same-order", { stockCode: "005930" });
+  now = 61_001;
+
+  assert.doesNotThrow(() => store.reserve("same-order", { stockCode: "005930" }));
+});
+
+test("OrderDedupStore releases failed reservations", () => {
+  const store = new OrderDedupStore({
+    filePath: tempLedgerPath(),
+    ttlMs: 60_000,
+    now: () => 1_000,
+  });
+
+  store.reserve("same-order", { stockCode: "005930" });
+  store.release("same-order");
+
+  assert.doesNotThrow(() => store.reserve("same-order", { stockCode: "005930" }));
+});


### PR DESCRIPTION
## 📝 개요

mcp-trading `place_order`가 동일 주문 재요청을 KIS에 중복 제출하지 않도록 TTL 기반 중복 방지 원장을 추가했습니다. 주문 POST에는 KIS hashkey 헤더를 붙이고, MCP 도구 설명에 자동 재시도 금지 안내를 명시했습니다.

## 🚀 변경 사항
- 주문 인자를 정규화한 dedup key와 파일 기반 TTL 원장 추가
- `place_order` 실행 전 중복 예약 검사 및 KIS `/uapi/hashkey` 기반 주문 POST 적용
- 동일 주문 자동 재시도 금지 안내와 회귀 테스트 추가

## 🔗 관련 이슈
- Related to #72

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)

N/A
