### PR TITLE
fix: CORS credentials 제거 및 허용 범위 축소

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -51,9 +51,9 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOW_ORIGINS,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_credentials=False,
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type"],
 )
 
 


### PR DESCRIPTION
## 📝 개요

홈서버 환경에서도 브라우저를 통한 CSRF 공격에 노출될 수 있는 CORS 설정을 수정합니다.
`allow_credentials=True` 상태에서는 악성 사이트가 JS로 로컬 백엔드에 요청을 보낼 수 있습니다.

## 🚀 변경 사항

- `allow_credentials=True` → `False` (인증 시스템 없으므로 불필요)
- `allow_methods=["*"]` → `["GET", "POST"]` (실제 사용 메서드만 허용)
- `allow_headers=["*"]` → `["Content-Type"]`

## 🔗 관련 이슈

- Related to #61

## ✅ 체크리스트

- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)