### PR TITLE
feat: Unity 시각화용 포트폴리오 API 추가

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -101,6 +101,58 @@ async def get_account_balance():
     return {"status": "success", "data": {"report": balance_text}}
 
 
+def _portfolio_current_price(portfolio: Portfolio) -> float:
+    return float(portfolio.current_price if portfolio.current_price is not None else portfolio.avg_price)
+
+
+def _portfolio_return_rate(current_price: float, avg_price: float) -> float:
+    if avg_price <= 0:
+        return 0.0
+    return round(((current_price - avg_price) / avg_price) * 100, 4)
+
+
+@app.get("/api/v1/portfolio", response_model=CommonResponse, tags=["Portfolio"])
+async def get_visualization_portfolio(session: Session = Depends(get_session)):
+    """Unity WebGL 시각화 화면에서 사용하는 포트폴리오 요약을 조회합니다."""
+    portfolios = session.exec(select(Portfolio)).all()
+    holdings = []
+    total_asset = 0.0
+    total_cost = 0.0
+    total_market_for_return = 0.0
+
+    for portfolio in portfolios:
+        current_price = _portfolio_current_price(portfolio)
+        avg_price = float(portfolio.avg_price)
+        quantity = portfolio.quantity
+        market_value = current_price * quantity
+        total_asset += market_value
+
+        if avg_price > 0:
+            total_cost += avg_price * quantity
+            total_market_for_return += market_value
+
+        holdings.append({
+            "name": portfolio.stock_name,
+            "current_price": current_price,
+            "avg_price": avg_price,
+            "return_rate": _portfolio_return_rate(current_price, avg_price),
+            "quantity": quantity,
+        })
+
+    total_return_rate = 0.0
+    if total_cost > 0:
+        total_return_rate = round(((total_market_for_return - total_cost) / total_cost) * 100, 4)
+
+    return {
+        "status": "success",
+        "data": {
+            "total_asset": total_asset,
+            "total_return_rate": total_return_rate,
+            "holdings": holdings,
+        },
+    }
+
+
 @app.get("/api/v1/db/portfolio", response_model=CommonResponse, tags=["Database"])
 async def get_db_portfolio(session: Session = Depends(get_session)):
     """저장된 포트폴리오 정보를 조회합니다."""

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -4,7 +4,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
 from ..main import app, get_session
-from ..models import Diary, AgentReport
+from ..models import Diary, AgentReport, Portfolio
 
 # 테스트용 인메모리 SQLite 엔진 설정
 @pytest.fixture(name="session")
@@ -33,6 +33,119 @@ def test_get_portfolio_empty(client: TestClient):
     assert response.status_code == 200
     assert response.json()["status"] == "success"
     assert response.json()["data"] == []
+
+
+def test_get_visualization_portfolio_empty(client: TestClient):
+    response = client.get("/api/v1/portfolio")
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "success",
+        "data": {
+            "total_asset": 0,
+            "total_return_rate": 0.0,
+            "holdings": [],
+        },
+        "message": None,
+    }
+
+
+def test_get_visualization_portfolio_maps_holdings(
+    client: TestClient,
+    session: Session,
+):
+    session.add(
+        Portfolio(
+            stock_code="005930",
+            stock_name="삼성전자",
+            quantity=10,
+            avg_price=70000,
+            current_price=77000,
+        )
+    )
+    session.add(
+        Portfolio(
+            stock_code="000660",
+            stock_name="SK하이닉스",
+            quantity=5,
+            avg_price=200000,
+            current_price=190000,
+        )
+    )
+    session.commit()
+
+    response = client.get("/api/v1/portfolio")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert response.json()["data"] == {
+        "total_asset": 1720000.0,
+        "total_return_rate": 1.1765,
+        "holdings": [
+            {
+                "name": "삼성전자",
+                "current_price": 77000.0,
+                "avg_price": 70000.0,
+                "return_rate": 10.0,
+                "quantity": 10,
+            },
+            {
+                "name": "SK하이닉스",
+                "current_price": 190000.0,
+                "avg_price": 200000.0,
+                "return_rate": -5.0,
+                "quantity": 5,
+            },
+        ],
+    }
+
+
+def test_get_visualization_portfolio_handles_missing_prices(
+    client: TestClient,
+    session: Session,
+):
+    session.add(
+        Portfolio(
+            stock_code="035720",
+            stock_name="카카오",
+            quantity=3,
+            avg_price=42000,
+            current_price=None,
+        )
+    )
+    session.add(
+        Portfolio(
+            stock_code="000000",
+            stock_name="평단가없음",
+            quantity=2,
+            avg_price=0,
+            current_price=1000,
+        )
+    )
+    session.commit()
+
+    response = client.get("/api/v1/portfolio")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "total_asset": 128000.0,
+        "total_return_rate": 0.0,
+        "holdings": [
+            {
+                "name": "카카오",
+                "current_price": 42000.0,
+                "avg_price": 42000.0,
+                "return_rate": 0.0,
+                "quantity": 3,
+            },
+            {
+                "name": "평단가없음",
+                "current_price": 1000.0,
+                "avg_price": 0.0,
+                "return_rate": 0.0,
+                "quantity": 2,
+            },
+        ],
+    }
 
 
 def test_create_and_get_diary(client: TestClient):


### PR DESCRIPTION
## 📝 개요

Unity WebGL 포트폴리오 시각화 화면(PR #88)이 사용할 수 있는 `/api/v1/portfolio` 백엔드 endpoint를 추가합니다.

기존 `/api/v1/db/portfolio` raw DB row 응답은 유지하고, 새 endpoint에서 시각화용 총 평가금액·전체 수익률·holdings shape를 제공합니다.

## 🚀 변경 사항
- `/api/v1/portfolio` endpoint 추가
- `Portfolio` row 기반 Unity 시각화 응답 shape 변환 로직 추가
- 빈 포트폴리오, 정상 holdings, 가격 누락/평단가 0 경계값 테스트 추가

## 🔗 관련 이슈
- Closes #95

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)

N/A
