### PR TITLE
feat: 모닝 브리핑 자동 전송 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ docker compose exec backend uv run --project /app/backend python /app/backend/sc
 docker compose exec backend uv run --project /app/backend python /app/backend/scripts/send_test_telegram_alert.py --dry-run
 ```
 
+### Telegram 모닝 브리핑
+
+Backend 스케줄러는 매 거래일 오전 8시 30분에 Telegram 모닝 브리핑을 자동 전송합니다.
+
+브리핑은 `mcp-news`, `mcp-trading`, NAT Strategy Planner 흐름을 사용해 아래 항목을 요약합니다.
+
+- 오늘의 시장 요약: 전일 미국/선물 시장 동향과 주요 이슈
+- 관심종목 동향: `/watch` 관심 종목별 최신 뉴스와 외국인·기관 수급
+- 오늘의 트레이딩 아이디어: 장 시작 전 참고할 간략 시나리오
+- 주요 촉매 이벤트: 당일/금주 실적, 배당락, 공시 등 확인 필요 이벤트
+
+모닝 브리핑은 정기 브리핑 메시지이므로 긴급 분석 알림 게이트와 분리되어 있습니다. `/alerts urgent|all|off|status`는 스케줄러 분석 알림의 전송 범위를 제어하며, 모닝 브리핑 자체의 발송 스케줄은 APScheduler의 `morning_briefing` 작업으로 관리합니다.
+
 같은 Telegram 봇에서 명령을 사용할 수 있습니다. 기본 알림 모드는 긴급 분석만 전송하는 `urgent`입니다.
 
 ### 명령어 목록

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -315,7 +315,7 @@ def start_scheduler():
             "cron",
             day_of_week="mon-fri",
             hour=8,
-            minute=35,
+            minute=30,
             id="morning_briefing",
         )
         

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -9,7 +9,12 @@ from .ws_manager import manager
 from .database import engine
 from .config import NEWS_MCP_PARAMS, TRADING_MCP_PARAMS, DART_MCP_PARAMS
 from .redis_state import RedisSchedulerState, signal_hash, redis_state
-from .services import perform_stock_analysis, run_mcp_tool, check_signal_significance
+from .services import (
+    perform_stock_analysis,
+    run_mcp_tool,
+    check_signal_significance,
+    generate_morning_briefing,
+)
 from .watchlist_repo import SqliteWatchlistRepo
 from .telegram_notifier import telegram_notifier
 from .telegram_notifier import should_send_telegram_alert
@@ -271,6 +276,24 @@ async def ping_task():
         "status": "active"
     })
 
+
+async def morning_briefing_task(watchlist_repo: SqliteWatchlistRepo | None = None):
+    try:
+        if watchlist_repo is None:
+            watchlist_repo = SqliteWatchlistRepo(lambda: Session(engine))
+        try:
+            watchlist = await watchlist_repo.get_watchlist()
+        except Exception as e:
+            logger.error("모닝 브리핑 관심 종목 조회 중 오류: %s", e)
+            watchlist = []
+
+        briefing = await generate_morning_briefing(watchlist)
+        message = telegram_notifier.format_morning_briefing(briefing)
+        await telegram_notifier.send_text(message)
+    except Exception as e:
+        logger.error("모닝 브리핑 작업 중 오류: %s", e)
+
+
 def start_scheduler():
     """스케줄러를 시작하고 작업을 등록합니다."""
     if not scheduler.running:
@@ -284,6 +307,14 @@ def start_scheduler():
             minutes=10,
             id="market_monitoring",
             next_run_time=datetime.now(scheduler.timezone),
+        )
+        scheduler.add_job(
+            morning_briefing_task,
+            "cron",
+            day_of_week="mon-fri",
+            hour=8,
+            minute=30,
+            id="morning_briefing",
         )
         
         scheduler.start()

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -2,6 +2,7 @@ import os
 import logging
 from dataclasses import dataclass
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from typing import Any
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlmodel import Session
@@ -22,7 +23,8 @@ from .telegram_notifier import should_send_telegram_alert
 logger = logging.getLogger(__name__)
 
 # 비동기 스케줄러 인스턴스 생성
-scheduler = AsyncIOScheduler()
+KST = ZoneInfo("Asia/Seoul")
+scheduler = AsyncIOScheduler(timezone=KST)
 
 # 뉴스 필터링에 사용할 모델 제공자 (ollama 또는 openai)
 FILTER_PROVIDER = os.environ.get("NEWS_FILTER_PROVIDER", "ollama")
@@ -313,7 +315,7 @@ def start_scheduler():
             "cron",
             day_of_week="mon-fri",
             hour=8,
-            minute=30,
+            minute=35,
             id="morning_briefing",
         )
         

--- a/backend/services.py
+++ b/backend/services.py
@@ -160,7 +160,7 @@ async def generate_morning_briefing(watchlist: list[str] | None = None) -> dict[
         f"잔고:\n{balance_text}\n\n"
         f"관심종목 컨텍스트:\n{watchlist_context}"
     )
-    raw = await llm_chat("nat", prompt, conversation_id="morning-briefing")
+    raw = await llm_chat("nat", prompt, conversation_id=f"morning-briefing:{date.today().isoformat()}")
     return _morning_briefing_from_text(str(raw))
 
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -16,6 +16,7 @@ from .config import (
     ANTHROPIC_API_KEY, ANTHROPIC_CHAT_MODEL,
     OLLAMA_API_KEY, OLLAMA_MODEL, OLLAMA_BASE_URL,
     NAT_BASE_URL, NAT_CHAT_MODEL, NAT_CONVERSATION_ID,
+    NEWS_MCP_PARAMS, TRADING_MCP_PARAMS,
 )
 from .schemas import TradingSignal, AnalysisReport
 from .models import AgentReport
@@ -122,6 +123,83 @@ async def perform_stock_analysis(
         # DB 저장 실패해도 데이터는 반환함
 
     return data
+
+
+async def generate_morning_briefing(watchlist: list[str] | None = None) -> dict[str, Any]:
+    stocks = list(dict.fromkeys(watchlist or []))
+    market_summary_source = await _collect_morning_context(
+        NEWS_MCP_PARAMS,
+        "get_market_news",
+        {"stock_name": "미국 증시"},
+    )
+    balance_text = await _collect_morning_context(TRADING_MCP_PARAMS, "get_balance", {})
+
+    stock_blocks = []
+    for stock in stocks:
+        news = await _collect_morning_context(
+            NEWS_MCP_PARAMS,
+            "get_market_news",
+            {"stock_name": stock},
+        )
+        trading = await _collect_morning_context(
+            TRADING_MCP_PARAMS,
+            "get_investor_trading",
+            {"stock_name": stock},
+        )
+        stock_blocks.append(f"[{stock}]\n뉴스: {news}\n수급: {trading}")
+
+    watchlist_context = "\n\n".join(stock_blocks) if stock_blocks else "관심종목 없음"
+    prompt = (
+        "Strategy Planner 관점으로 오늘 장 시작 전 Telegram 모닝 브리핑을 작성하라.\n"
+        "반드시 다음 JSON 객체 한 개만 출력하라:\n"
+        '{"market_summary":"전일 미국/선물 시장 동향과 주요 이슈",'
+        '"watchlist":["종목별 뉴스 및 수급 요약"],'
+        '"trading_ideas":["오늘의 간략 시나리오"],'
+        '"catalysts":["당일/금주 주요 촉매 이벤트"]}\n\n'
+        f"시장 뉴스:\n{market_summary_source}\n\n"
+        f"잔고:\n{balance_text}\n\n"
+        f"관심종목 컨텍스트:\n{watchlist_context}"
+    )
+    raw = await llm_chat("nat", prompt, conversation_id="morning-briefing")
+    return _morning_briefing_from_text(str(raw))
+
+
+async def _collect_morning_context(
+    mcp_params: StdioServerParameters,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> str:
+    try:
+        return await run_mcp_tool(mcp_params, tool_name, arguments)
+    except Exception as exc:
+        logger.error("Morning briefing source failed for %s: %s", tool_name, exc)
+        return f"{tool_name} 조회 실패: {exc}"
+
+
+def _morning_briefing_from_text(raw: str) -> dict[str, Any]:
+    text = (raw or "").strip()
+    for data in _json_objects_from_text(text):
+        return {
+            "market_summary": str(data.get("market_summary") or ""),
+            "watchlist": _string_list(data.get("watchlist")),
+            "trading_ideas": _string_list(data.get("trading_ideas")),
+            "catalysts": _string_list(data.get("catalysts")),
+        }
+    return {
+        "market_summary": text or "모닝 브리핑 생성 결과가 비어 있습니다.",
+        "watchlist": [],
+        "trading_ideas": [],
+        "catalysts": [],
+    }
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if value:
+        return [str(value)]
+    return []
+
 
 async def check_signal_significance(
     stock: str,

--- a/backend/telegram_notifier.py
+++ b/backend/telegram_notifier.py
@@ -113,6 +113,30 @@ class TelegramNotifier:
             lines.append(f"Summary: {summary}")
         return "\n".join(lines)[:4000]
 
+    def format_morning_briefing(self, briefing: dict[str, Any]) -> str:
+        lines = [
+            "📰 오늘의 시장 요약",
+            str(briefing.get("market_summary") or "요약 없음"),
+            "",
+            "📊 관심종목 동향",
+            *self._format_bullets(briefing.get("watchlist")),
+            "",
+            "🎯 오늘의 트레이딩 아이디어",
+            *self._format_bullets(briefing.get("trading_ideas")),
+            "",
+            "⚡ 주요 촉매 이벤트",
+            *self._format_bullets(briefing.get("catalysts")),
+        ]
+        return "\n".join(lines)[:4000]
+
+    @staticmethod
+    def _format_bullets(items: Any) -> list[str]:
+        if not items:
+            return ["- 없음"]
+        if isinstance(items, str):
+            return [f"- {items}"]
+        return [f"- {item}" for item in items if str(item).strip()] or ["- 없음"]
+
     async def send_analysis_alert(
         self,
         stock: str,

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -77,6 +77,64 @@ def test_start_scheduler_runs_market_monitoring_immediately(monkeypatch):
     assert market_job["next_run_time"] is not None
 
 
+def test_start_scheduler_registers_weekday_morning_briefing(monkeypatch):
+    from .. import scheduler as scheduler_module
+
+    added_jobs = []
+
+    class FakeScheduler:
+        running = False
+        timezone = None
+
+        def add_job(self, *args, **kwargs):
+            added_jobs.append((args, kwargs))
+
+        def start(self):
+            self.running = True
+
+    fake_scheduler = FakeScheduler()
+    monkeypatch.setattr(scheduler_module, "scheduler", fake_scheduler)
+
+    scheduler_module.start_scheduler()
+
+    briefing_job = next(kwargs for _args, kwargs in added_jobs if kwargs["id"] == "morning_briefing")
+    assert briefing_job["day_of_week"] == "mon-fri"
+    assert briefing_job["hour"] == 8
+    assert briefing_job["minute"] == 30
+
+
+@pytest.mark.asyncio
+async def test_morning_briefing_task_sends_telegram_message(monkeypatch):
+    from ..scheduler import morning_briefing_task
+
+    calls = []
+    briefing = {
+        "market_summary": "미국 증시 상승",
+        "watchlist": ["삼성전자: 반도체 뉴스"],
+        "trading_ideas": ["삼성전자 눌림목 관찰"],
+        "catalysts": ["FOMC 의사록"],
+    }
+
+    async def fake_generate_morning_briefing(watchlist):
+        calls.append(watchlist)
+        return briefing
+
+    mock_format = MagicMock(return_value="모닝 브리핑 메시지")
+    mock_send = MagicMock(return_value=asyncio.Future())
+    mock_send.return_value.set_result(True)
+
+    monkeypatch.setattr("backend.scheduler.SqliteWatchlistRepo", lambda session_factory: FakeWatchlistRepo(["삼성전자"]))
+    monkeypatch.setattr("backend.scheduler.generate_morning_briefing", fake_generate_morning_briefing)
+    monkeypatch.setattr("backend.scheduler.telegram_notifier.format_morning_briefing", mock_format)
+    monkeypatch.setattr("backend.scheduler.telegram_notifier.send_text", mock_send)
+
+    await morning_briefing_task()
+
+    assert calls == [["삼성전자"]]
+    mock_format.assert_called_once_with(briefing)
+    mock_send.assert_called_once_with("모닝 브리핑 메시지")
+
+
 @pytest.mark.asyncio
 async def test_ping_task_execution(monkeypatch):
     """
@@ -140,14 +198,14 @@ async def test_monitor_market_task_filtering(monkeypatch):
     monkeypatch.setattr("backend.scheduler.redis_state", unavailable_redis_state)
     
     # 1. 첫 번째 실행: 뉴스가 처음이므로 분석 수행
-    await monitor_market_task()
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 3 # 삼성전자, SK하이닉스, 현대차
     assert mock_broadcast.call_count == 3
     
     # 2. 두 번째 실행: 뉴스가 동일하므로 분석 스킵
     mock_perform_analysis.reset_mock()
     mock_broadcast.reset_mock()
-    await monitor_market_task()
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 0
     assert mock_broadcast.call_count == 0
     
@@ -160,7 +218,7 @@ async def test_monitor_market_task_filtering(monkeypatch):
         return f"Latest news for {args.get('stock_name')}"
         
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool_changed)
-    await monitor_market_task()
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
     assert mock_perform_analysis.call_count == 1
     assert mock_broadcast.call_count == 1
     assert mock_perform_analysis.call_args[0][0] == "삼성전자"
@@ -416,7 +474,7 @@ async def test_monitor_market_task_uses_default_stocks_when_balance_empty(monkey
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
-    await monitor_market_task()
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     assert len(DEFAULT_MONITOR_STOCKS) == 4
     assert monitored_stocks == DEFAULT_MONITOR_STOCKS
@@ -458,8 +516,8 @@ async def test_monitor_market_task_uses_redis_hash_to_skip_duplicate_news(monkey
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
-    await monitor_market_task()
-    await monitor_market_task()
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     assert mock_perform_analysis.call_count == 1
     assert mock_broadcast.call_count == 1
@@ -500,7 +558,7 @@ async def test_monitor_market_task_processes_multiple_signal_sources_independent
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
-    await monitor_market_task()
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     assert mock_perform_analysis.call_count == 2
     assert [call.kwargs["trigger_source"] for call in mock_perform_analysis.call_args_list] == ["news", "sns"]
@@ -532,7 +590,7 @@ async def test_monitor_market_task_skips_when_scheduler_lock_is_held(monkeypatch
     )
     monkeypatch.setattr("backend.scheduler.run_mcp_tool", mock_run_mcp_tool)
 
-    await monitor_market_task()
+    await monitor_market_task(watchlist_repo=FakeWatchlistRepo())
 
     mock_run_mcp_tool.assert_not_called()
 
@@ -573,7 +631,10 @@ async def test_concurrent_monitor_market_task_runs_once_with_scheduler_lock(monk
     monkeypatch.setattr("backend.scheduler.perform_stock_analysis", mock_perform_analysis)
     monkeypatch.setattr("backend.scheduler.manager.broadcast", mock_broadcast)
 
-    await asyncio.gather(monitor_market_task(), monitor_market_task())
+    await asyncio.gather(
+        monitor_market_task(watchlist_repo=FakeWatchlistRepo()),
+        monitor_market_task(watchlist_repo=FakeWatchlistRepo()),
+    )
 
     assert mock_perform_analysis.call_count == 1
     assert mock_broadcast.call_count == 1

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -100,7 +100,7 @@ def test_start_scheduler_registers_weekday_morning_briefing(monkeypatch):
     briefing_job = next(kwargs for _args, kwargs in added_jobs if kwargs["id"] == "morning_briefing")
     assert briefing_job["day_of_week"] == "mon-fri"
     assert briefing_job["hour"] == 8
-    assert briefing_job["minute"] == 35
+    assert briefing_job["minute"] == 30
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -100,7 +100,7 @@ def test_start_scheduler_registers_weekday_morning_briefing(monkeypatch):
     briefing_job = next(kwargs for _args, kwargs in added_jobs if kwargs["id"] == "morning_briefing")
     assert briefing_job["day_of_week"] == "mon-fri"
     assert briefing_job["hour"] == 8
-    assert briefing_job["minute"] == 30
+    assert briefing_job["minute"] == 35
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -183,7 +183,7 @@ async def test_generate_morning_briefing_collects_market_watchlist_and_strategy(
         ("get_investor_trading", {"stock_name": "NAVER"}),
     ]
     assert prompts[0][0] == "nat"
-    assert prompts[0][2] == "morning-briefing"
+    assert prompts[0][2] == f"morning-briefing:{date.today().isoformat()}"
     assert "Strategy Planner" in prompts[0][1]
     assert "NAVER 뉴스" in prompts[0][1]
 

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -139,6 +139,55 @@ async def test_perform_stock_analysis_includes_trigger_signal(monkeypatch):
     assert '"source_signals"' in prompts[0][1]
 
 
+@pytest.mark.asyncio
+async def test_generate_morning_briefing_collects_market_watchlist_and_strategy(monkeypatch):
+    calls = []
+    prompts = []
+
+    async def fake_run_mcp_tool(params, tool_name, arguments):
+        calls.append((params, tool_name, arguments))
+        if tool_name == "get_market_news":
+            return f"{arguments['stock_name']} 뉴스"
+        if tool_name == "get_balance":
+            return "[보유 종목 리스트]\n- 삼성전자 (005930): 10주"
+        if tool_name == "get_investor_trading":
+            return f"{arguments['stock_name']} 외국인 순매수"
+        raise AssertionError(tool_name)
+
+    async def fake_llm_chat(provider, prompt, *, conversation_id=None):
+        prompts.append((provider, prompt, conversation_id))
+        return (
+            '{"market_summary":"전일 미국 증시 상승",'
+            '"watchlist":["삼성전자: 외국인 순매수"],'
+            '"trading_ideas":["삼성전자 눌림목 관찰"],'
+            '"catalysts":["오늘 CPI 발표"]}'
+        )
+
+    monkeypatch.setattr(services, "run_mcp_tool", fake_run_mcp_tool)
+    monkeypatch.setattr(services, "llm_chat", fake_llm_chat)
+
+    briefing = await services.generate_morning_briefing(["삼성전자", "NAVER"])
+
+    assert briefing == {
+        "market_summary": "전일 미국 증시 상승",
+        "watchlist": ["삼성전자: 외국인 순매수"],
+        "trading_ideas": ["삼성전자 눌림목 관찰"],
+        "catalysts": ["오늘 CPI 발표"],
+    }
+    assert [call[1:] for call in calls] == [
+        ("get_market_news", {"stock_name": "미국 증시"}),
+        ("get_balance", {}),
+        ("get_market_news", {"stock_name": "삼성전자"}),
+        ("get_investor_trading", {"stock_name": "삼성전자"}),
+        ("get_market_news", {"stock_name": "NAVER"}),
+        ("get_investor_trading", {"stock_name": "NAVER"}),
+    ]
+    assert prompts[0][0] == "nat"
+    assert prompts[0][2] == "morning-briefing"
+    assert "Strategy Planner" in prompts[0][1]
+    assert "NAVER 뉴스" in prompts[0][1]
+
+
 def test_analysis_from_nat_text_backfills_source_signals():
     data = services.analysis_from_nat_text(
         (

--- a/backend/tests/test_telegram_notifier.py
+++ b/backend/tests/test_telegram_notifier.py
@@ -75,6 +75,27 @@ def test_format_analysis_alert_marks_only_actual_urgent_alerts():
     assert "긴급" not in message
 
 
+def test_format_morning_briefing_uses_expected_sections():
+    notifier = TelegramNotifier("token", "123")
+
+    message = notifier.format_morning_briefing({
+        "market_summary": "미국 증시 상승, 달러 약세",
+        "watchlist": ["삼성전자: 반도체 수급 개선"],
+        "trading_ideas": ["삼성전자 눌림목 매수 시나리오"],
+        "catalysts": ["오늘 CPI 발표"],
+    })
+
+    assert "📰 오늘의 시장 요약" in message
+    assert "미국 증시 상승, 달러 약세" in message
+    assert "📊 관심종목 동향" in message
+    assert "- 삼성전자: 반도체 수급 개선" in message
+    assert "🎯 오늘의 트레이딩 아이디어" in message
+    assert "- 삼성전자 눌림목 매수 시나리오" in message
+    assert "⚡ 주요 촉매 이벤트" in message
+    assert "- 오늘 CPI 발표" in message
+    assert len(message) <= 4000
+
+
 @pytest.mark.asyncio
 async def test_send_analysis_alert_skips_when_gate_is_false(monkeypatch):
     notifier = TelegramNotifier("token", "123")


### PR DESCRIPTION
## 📝 개요

장 시작 전 Telegram으로 시장 요약, 관심종목 동향, 트레이딩 아이디어, 주요 촉매 이벤트를 전달하는 모닝 브리핑 작업을 추가했습니다.

## 🚀 변경 사항
- 평일 08:30 모닝 브리핑 스케줄러 작업 추가
- 시장 뉴스·잔고·관심종목 뉴스/수급 기반 브리핑 생성 로직 추가
- Telegram 모닝 브리핑 전용 포맷 추가 및 관련 테스트 보강
- 스케줄러 테스트가 로컬 SQLite watchlist 상태에 의존하지 않도록 격리

## 🔗 관련 이슈
- Closes #100

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)

<img width="353" height="1019" alt="image" src="https://github.com/user-attachments/assets/615a4af2-3116-4313-bdb8-9b4ed18f2fab" />
