### PR TITLE
fix: Telegram 주문 체결 상태 알림 추가

### DIFF
--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -671,6 +671,23 @@ class TelegramCommandHandler:
             return
 
         self.pending_orders.pop(chat_id, None)
+        order_status_message = ""
+        try:
+            order_status = await self.mcp_runner(
+                TRADING_MCP_PARAMS,
+                "get_today_daily_orders",
+                {
+                    "stock_name": order.stock_code,
+                    "ccld_dvsn": "00",
+                    "sll_buy_dvsn": "02" if order.side == "BUY" else "01",
+                },
+            )
+            if str(order_status).strip():
+                order_status_message = f"\n현재 주문·체결 조회:\n{order_status}"
+        except Exception as exc:
+            logger.warning("Today order status lookup failed: %s", exc)
+            order_status_message = f"\n주문·체결 조회 실패: {_short_error(exc)}"
+
         record_warning = ""
         if self.trade_recorder is not None:
             try:
@@ -678,7 +695,9 @@ class TelegramCommandHandler:
             except Exception as exc:
                 logger.warning("Trade history recording failed: %s", exc)
                 record_warning = f"\n거래 이력 기록 실패: {_short_error(exc)}"
-        await self._send_text_or_raise(f"주문 완료: {result.message}{record_warning}")
+        await self._send_text_or_raise(
+            f"주문 완료: {result.message}{order_status_message}{record_warning}"
+        )
 
     def _parse_order_argument(self, argument: str) -> tuple[str, int, int, OrderType] | None:
         parts = argument.split()

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -985,6 +985,8 @@ async def test_confirm_executes_gateway_and_records_trade():
             return "현재가: 74,500원"
         if tool_name == "get_balance":
             return "주문가능금액: 1,000,000원"
+        if tool_name == "get_today_daily_orders":
+            return "[당일 주문·체결 내역]\n주문번호 123456 | 매수 | 체결"
         raise AssertionError(f"unexpected tool: {tool_name}")
 
     gateway = FakeOrderGateway()
@@ -1013,6 +1015,93 @@ async def test_confirm_executes_gateway_and_records_trade():
 
 
 @pytest.mark.asyncio
+async def test_confirm_sends_today_order_status_after_successful_order():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        if tool_name == "get_today_daily_orders":
+            return (
+                "[당일 주문·체결 내역] 20260520 / 005930\n"
+                "1. 삼성전자 (005930)\n"
+                "   주문번호 123456 | 매수 | 체결\n"
+                "   체결 1주 / 잔량 0주"
+            )
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    recorder = FakeTradeRecorder()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        trade_recorder=recorder,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert calls[-1] == (
+        TRADING_MCP_PARAMS,
+        "get_today_daily_orders",
+        {"stock_name": "005930", "ccld_dvsn": "00", "sll_buy_dvsn": "02"},
+    )
+    assert "주문 완료: 주문 접수" in notifier.messages[-1]
+    assert "현재 주문·체결 조회:" in notifier.messages[-1]
+    assert "주문번호 123456" in notifier.messages[-1]
+    assert "체결 1주 / 잔량 0주" in notifier.messages[-1]
+    assert len(gateway.orders) == 1
+    assert len(recorder.results) == 1
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
+async def test_confirm_keeps_order_success_when_today_order_status_lookup_fails():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        if tool_name == "get_today_daily_orders":
+            raise RuntimeError("daily orders down")
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    recorder = FakeTradeRecorder()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        trade_recorder=recorder,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert "주문 완료: 주문 접수" in notifier.messages[-1]
+    assert "주문·체결 조회 실패: daily orders down" in notifier.messages[-1]
+    assert len(gateway.orders) == 1
+    assert len(recorder.results) == 1
+    assert handler.pending_orders == {}
+
+
+@pytest.mark.asyncio
 async def test_confirm_button_executes_gateway_and_records_trade():
     async def mcp_runner(server_params, tool_name, arguments):
         if tool_name == "resolve_stock_code":
@@ -1021,6 +1110,8 @@ async def test_confirm_button_executes_gateway_and_records_trade():
             return "현재가: 74,500원"
         if tool_name == "get_balance":
             return "주문가능금액: 1,000,000원"
+        if tool_name == "get_today_daily_orders":
+            return "[당일 주문·체결 내역]\n주문번호 123456 | 매수 | 체결"
         raise AssertionError(f"unexpected tool: {tool_name}")
 
     gateway = FakeOrderGateway()
@@ -1104,6 +1195,8 @@ async def test_confirm_gateway_success_recorder_failure_clears_pending_order():
             return "현재가: 74,500원"
         if tool_name == "get_balance":
             return "주문가능금액: 1,000,000원"
+        if tool_name == "get_today_daily_orders":
+            return "[당일 주문·체결 내역]\n주문번호 123456 | 매수 | 체결"
         raise AssertionError(f"unexpected tool: {tool_name}")
 
     gateway = FakeOrderGateway()
@@ -1125,7 +1218,13 @@ async def test_confirm_gateway_success_recorder_failure_clears_pending_order():
 
     assert len(gateway.orders) == 1
     assert len(recorder.results) == 1
-    assert notifier.messages[-2] == "주문 완료: 주문 접수\n거래 이력 기록 실패: db commit failed"
+    assert notifier.messages[-2] == (
+        "주문 완료: 주문 접수\n"
+        "현재 주문·체결 조회:\n"
+        "[당일 주문·체결 내역]\n"
+        "주문번호 123456 | 매수 | 체결\n"
+        "거래 이력 기록 실패: db commit failed"
+    )
     assert notifier.messages[-1] == "확정할 대기 주문이 없습니다."
     assert handler.pending_orders == {}
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1066,6 +1066,45 @@ async def test_confirm_sends_today_order_status_after_successful_order():
 
 
 @pytest.mark.asyncio
+async def test_sell_confirm_queries_today_order_status_with_sell_filter():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        if tool_name == "get_today_daily_orders":
+            return "[당일 주문·체결 내역]\n주문번호 987654 | 매도 | 체결"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    gateway = FakeOrderGateway()
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=gateway,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/sell 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert gateway.orders[0].side == "SELL"
+    assert calls[-1] == (
+        TRADING_MCP_PARAMS,
+        "get_today_daily_orders",
+        {"stock_name": "005930", "ccld_dvsn": "00", "sll_buy_dvsn": "01"},
+    )
+    assert "주문번호 987654" in notifier.messages[-1]
+
+
+@pytest.mark.asyncio
 async def test_confirm_keeps_order_success_when_today_order_status_lookup_fails():
     async def mcp_runner(server_params, tool_name, arguments):
         if tool_name == "resolve_stock_code":

--- a/docs/superpowers/plans/2026-06-01-telegram-confirm-fill-alert.md
+++ b/docs/superpowers/plans/2026-06-01-telegram-confirm-fill-alert.md
@@ -1,0 +1,139 @@
+# Telegram Confirm Fill Alert Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Telegram `/confirm` 성공 후 주문 접수 메시지와 함께 현재 당일 주문·체결 상태를 알린다.
+
+**Architecture:** 기존 Telegram 수동 매매 경로를 유지하고, 주문 성공 뒤 local `mcp-trading`의 `get_today_daily_orders`를 한 번 조회한다. 체결 조회 실패는 주문 성공을 실패로 바꾸지 않고 별도 경고로만 표시한다.
+
+**Tech Stack:** Python backend, pytest-asyncio, local MCP runner, `mcp-trading` KIS order/fill tools
+
+---
+
+### Task 1: Telegram Confirm Status Lookup
+
+**Files:**
+- Modify: `backend/tests/test_telegram_commands.py`
+- Modify: `backend/telegram_commands.py`
+
+- [ ] **Step 1: Write failing Telegram handler tests**
+
+Add tests near the existing `/confirm` tests:
+
+```python
+@pytest.mark.asyncio
+async def test_confirm_sends_today_order_status_after_successful_order():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return "삼성전자 (005930, KOSPI)"
+        if tool_name == "get_stock_quote":
+            return "현재가: 74,500원"
+        if tool_name == "get_balance":
+            return "주문가능금액: 1,000,000원"
+        if tool_name == "get_today_daily_orders":
+            return "[당일 주문·체결 내역]\n주문번호 123456 | 매수 | 체결"
+        raise AssertionError(f"unexpected tool: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        order_gateway=FakeOrderGateway(),
+        trade_recorder=FakeTradeRecorder(),
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/buy 삼성전자 1 75000"}}
+    )
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/confirm"}})
+
+    assert calls[-1] == (
+        TRADING_MCP_PARAMS,
+        "get_today_daily_orders",
+        {"stock_name": "005930", "ccld_dvsn": "00", "sll_buy_dvsn": "02"},
+    )
+    assert "주문 완료: 주문 접수" in notifier.messages[-1]
+    assert "현재 주문·체결 조회:" in notifier.messages[-1]
+    assert "주문번호 123456" in notifier.messages[-1]
+```
+
+Also add a failure-path test proving status lookup failure keeps the order success message and trade recording.
+
+- [ ] **Step 2: Verify tests fail**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py -q
+```
+
+Expected: the new status lookup tests fail because `_handle_confirm()` does not call `get_today_daily_orders`.
+
+- [ ] **Step 3: Implement minimal status lookup**
+
+In `TelegramCommandHandler._handle_confirm()`, after `place_order()` succeeds and before the final message is sent, call:
+
+```python
+await self.mcp_runner(
+    TRADING_MCP_PARAMS,
+    "get_today_daily_orders",
+    {
+        "stock_name": order.stock_code,
+        "ccld_dvsn": "00",
+        "sll_buy_dvsn": "02" if order.side == "BUY" else "01",
+    },
+)
+```
+
+Append the returned text under `현재 주문·체결 조회:`. If the lookup raises, append `주문·체결 조회 실패: ...` and keep the order success path intact.
+
+- [ ] **Step 4: Verify focused tests pass**
+
+Run:
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_trading_orders.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/test_telegram_commands.py backend/telegram_commands.py
+git commit -m "fix: Telegram 주문 체결 상태 알림 추가"
+```
+
+Body:
+
+```text
+- /confirm 성공 후 당일 주문·체결 조회 추가
+- 체결 조회 실패 시 주문 성공 메시지 유지
+- Telegram confirm 회귀 테스트 추가
+```
+
+### Task 2: Final Verification and PR
+
+**Files:**
+- Modify: `.github/PULL_REQUEST_TEMPLATE.md` only as a read source, not edited
+
+- [ ] **Step 1: Run Telegram-focused regression suite**
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q
+```
+
+- [ ] **Step 2: Check diff hygiene**
+
+```bash
+git diff --check
+git status --short
+```
+
+- [ ] **Step 3: Create Korean PR with template**
+
+Use `.github/PULL_REQUEST_TEMPLATE.md` unchanged. Link issue `#106` and include the verification command outputs in the test plan.


### PR DESCRIPTION
## 📝 개요

Telegram 수동 매매에서 `/confirm` 성공 후 주문 접수 메시지에 현재 당일 주문·체결 조회 결과를 함께 표시합니다.
`get_today_daily_orders` 조회 실패는 주문 성공 흐름을 깨지 않도록 경고 문구로만 처리합니다.

## 🚀 변경 사항
- `/confirm` 성공 후 `get_today_daily_orders`로 당일 주문·체결 상태 조회 추가
- 매수·매도 방향에 맞는 `sll_buy_dvsn` 필터 적용
- 주문·체결 조회 실패 시 주문 성공 메시지와 거래 기록 유지
- 구현 계획 문서 및 Telegram confirm 회귀 테스트 추가

## 🔗 관련 이슈
- Closes #106

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

검증:
- [x] `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_confirm_sends_today_order_status_after_successful_order backend/tests/test_telegram_commands.py::test_confirm_keeps_order_success_when_today_order_status_lookup_fails -q` (`2 passed`)
- [x] `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py::test_sell_confirm_queries_today_order_status_with_sell_filter -q` (`1 passed`)
- [x] `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_trading_orders.py -q` (`82 passed`)
- [x] `UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q` (`107 passed`)
- [x] `git diff --check origin/main..HEAD`

## 📸 스크린샷 (선택 사항)

N/A
