### PR TITLE
fix: /watch list 현재가 조회 간격 추가

### DIFF
--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -45,6 +45,7 @@ BALANCE_REFRESH_CALLBACK = "balance:refresh"
 TRADE_CALLBACK_PREFIX = "trade:"
 LOOKUP_CALLBACK_PREFIX = "lookup:"
 WATCH_LIST_CALLBACK = "watch:list"
+WATCH_LIST_QUOTE_DELAY_SECONDS = 1.1
 MARKET_QUOTE_CALLBACK = "market:quote"
 MARKET_TREND_CALLBACK = "market:trend"
 MARKET_STALE_CALLBACK_TEXT = "이전 조회 버튼입니다. 최신 조회 메시지에서 다시 선택하세요."
@@ -486,7 +487,9 @@ class TelegramCommandHandler:
                 text = "관심 종목이 없습니다.\n/watch add <종목명> 으로 추가하세요."
             else:
                 lines = []
-                for stock in watchlist:
+                for index, stock in enumerate(watchlist):
+                    if index > 0:
+                        await asyncio.sleep(WATCH_LIST_QUOTE_DELAY_SECONDS)
                     try:
                         raw = await self.mcp_runner(
                             TRADING_MCP_PARAMS, "get_stock_quote", {"stock_name": stock}

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1789,6 +1789,38 @@ async def test_watch_list_calls_quote_for_each_stock_sequentially():
 
 
 @pytest.mark.asyncio
+async def test_watch_list_waits_between_quote_calls(monkeypatch):
+    notifier = FakeNotifier()
+    events: list[tuple[str, str | float]] = []
+    expected_delay_seconds = 1.1
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        events.append(("quote", arguments.get("stock_name")))
+        return f"[{arguments.get('stock_name')}] 현재가 시세\n- 현재가: 75,400원\n- 전일 대비: +930 (1.23%)"
+
+    async def fake_sleep(seconds):
+        events.append(("sleep", seconds))
+
+    monkeypatch.setattr("backend.telegram_commands.asyncio.sleep", fake_sleep)
+
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        watchlist_repo=FakeWatchlistRepo(["CCC", "AAA", "BBB"]),
+        mcp_runner=mcp_runner,
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/watch list"}})
+
+    assert events == [
+        ("quote", "AAA"),
+        ("sleep", expected_delay_seconds),
+        ("quote", "BBB"),
+        ("sleep", expected_delay_seconds),
+        ("quote", "CCC"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_help_command_includes_watch_description():
     notifier = FakeNotifier()
     handler = TelegramCommandHandler(notifier=notifier)


### PR DESCRIPTION
## 📝 개요

`/watch list`가 관심종목 현재가를 연속 조회하면서 일부 KIS/MCP 호출이 500으로 실패하던 문제를 줄이기 위해, 다건 조회 시 각 현재가 호출 사이에 1.1초 간격을 추가했습니다.

## 🚀 변경 사항
- `/watch list` 현재가 조회 루프에서 첫 종목 이후 호출 전 1.1초 지연 추가
- 3개 관심종목 기준으로 `quote -> sleep -> quote -> sleep -> quote` 순서를 검증하는 회귀 테스트 추가

## 🔗 관련 이슈
- Closes #104



## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요? (해당 없음: 문서 변경이 필요 없는 버그 수정)

## 📸 스크린샷 (선택 사항)

없음
