### PR TITLE
feat: News Analyst 실적 분석 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Backend 스케줄러는 매 거래일 오전 8시 30분에 Telegram 모닝 브�
 | `/trend <종목명>` | 외국인·기관·개인 수급 조회 | 💵 현재가 보기 |
 | `/earnings <종목명> [기간]` | DART 실적과 최신 뉴스 기반 구조화 리포트 생성. 기간 예: `2025Q1`, `2025FY` | - |
 
-`/earnings`는 OpenDART 실적 데이터와 Naver 뉴스를 NAT News Analyst에 전달합니다. OpenDART가 제공하지 않는 컨센서스/시장 기대치 데이터는 추정하지 않고 데이터 없음으로 표시합니다.
+`/earnings`는 OpenDART 실적 데이터와 Naver 뉴스를 NAT News Analyst에 전달합니다. OpenDART가 제공하지 않는 컨센서스/시장 기대치 데이터는 추정하지 않고 데이터 없음으로 표시합니다. Telegram 응답은 Markdown이 아닌 일반 텍스트이며 첫 줄에 `🟢 호재`, `🔴 악재`, `⚪ 중립` 판정을 표시합니다.
 
 **매매**
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Fin-Us는 단일 모델이 모든 일을 처리하지 않고, 역할이 분리�
 3.  **Tooling Layer (MCP Servers)**:
     - **News Provider (`mcp-news/`)**: 네이버 뉴스 검색 API 기반 최신 뉴스 공급.
     - **Trading Provider (`mcp-trading/`)**: 한국투자증권 Open API 기반 정형 금융 데이터 공급 및 명령 집행.
-    - **Disclosure Provider (`mcp-dart/`)**: OpenDART 공식 API 기반 5% 룰 및 임원·주요주주 지분공시 signal 공급.
+    - **Disclosure Provider (`mcp-dart/`)**: OpenDART 공식 API 기반 5% 룰·임원/주요주주 지분공시 signal 및 실적 리포트 공급.
 4.  **Presentation Layer (`frontend-react/`)**: React (TypeScript)
     - 실시간 투자 신호 및 분석 리포트를 시각화하여 사용자에게 제공합니다.
 
@@ -98,6 +98,7 @@ cd frontend-react && npm ci && npm run dev
 | **News Analyst**     | `get_market_news`      | 네이버 뉴스 검색 API 기반 최신 동향 수집      |
 |                      | `get_investor_trading` | KIS API 기반 기관/외국인 수급 데이터 분석     |
 |                      | `get_disclosure_signal` | OpenDART 공식 API 기반 지분공시 signal 조회   |
+|                      | `get_earnings_report`  | OpenDART 공식 API 기반 매출·영업이익·순이익 YoY 실적 리포트 |
 |                      | `get_research_reports` | deprecated: 공식 대체 API 미선정으로 비활성화 |
 | **Trading Executor** | `get_balance`          | 실시간 계좌 잔고 및 수익률 확인              |
 |                      | `execute_trade`        | 매수/매도 주문 실행 (KIS API)                |
@@ -180,6 +181,9 @@ Backend 스케줄러는 매 거래일 오전 8시 30분에 Telegram 모닝 브�
 | `/watch remove <종목명>` | 관심 종목 삭제 | 📋 목록 새로고침 |
 | `/quote <종목명>` | 현재가 조회 | 📊 수급 보기 |
 | `/trend <종목명>` | 외국인·기관·개인 수급 조회 | 💵 현재가 보기 |
+| `/earnings <종목명> [기간]` | DART 실적과 최신 뉴스 기반 구조화 리포트 생성. 기간 예: `2025Q1`, `2025FY` | - |
+
+`/earnings`는 OpenDART 실적 데이터와 Naver 뉴스를 NAT News Analyst에 전달합니다. OpenDART가 제공하지 않는 컨센서스/시장 기대치 데이터는 추정하지 않고 데이터 없음으로 표시합니다.
 
 **매매**
 

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -1033,7 +1033,7 @@ class TelegramCommandHandler:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
             return
 
-        await self._send_text_or_raise(_telegram_text(str(result)))
+        await self._send_text_or_raise(_telegram_text(self._format_earnings_response(str(result))))
 
     def _parse_earnings_argument(self, argument: str) -> tuple[str, str | None] | None:
         parts = argument.split()
@@ -1071,8 +1071,49 @@ class TelegramCommandHandler:
             "- 컨센서스 대비 서프라이즈/미스 판단. 컨센서스 데이터가 없으면 추정하지 말고 데이터 없음으로 표시\n"
             "- 주요 뉴스 기반 정성적 코멘트\n"
             "- 다음 분기 전망\n"
+            "첫 줄은 반드시 `호재`, `악재`, `중립` 중 하나의 판정과 한 줄 근거로 시작하라.\n"
+            "Markdown 문법(`#`, `**`, 표, 코드블록)을 쓰지 말고 Telegram에서 읽기 쉬운 일반 텍스트로 답하라.\n"
             "투자 조언은 단정하지 말고, 확인된 DART·뉴스 근거와 한계를 구분해 한국어로 답하라."
         )
+
+    def _format_earnings_response(self, text: str) -> str:
+        plain = self._telegram_plain_text(text)
+        verdict = self._earnings_verdict(plain)
+        if plain.startswith(("🟢 호재", "🔴 악재", "⚪ 중립")):
+            return plain
+        lines = plain.splitlines()
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        if lines:
+            first = lines[0].strip()
+            for label in ("호재", "악재", "중립"):
+                if first == label:
+                    lines = lines[1:]
+                    while lines and not lines[0].strip():
+                        lines.pop(0)
+                    body = "\n".join(lines).strip()
+                    return f"{verdict}\n{body}".strip()
+                if first.startswith(f"{label}:") or first.startswith(f"{label} -"):
+                    lines[0] = first.replace(label, verdict, 1)
+                    return "\n".join(lines).strip()
+        return f"{verdict}\n{plain}".strip()
+
+    def _earnings_verdict(self, text: str) -> str:
+        if "악재" in text:
+            return "🔴 악재"
+        if "호재" in text:
+            return "🟢 호재"
+        return "⚪ 중립"
+
+    def _telegram_plain_text(self, text: str) -> str:
+        lines = []
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            line = re.sub(r"^#{1,6}\s*", "", line)
+            line = re.sub(r"^[-*]\s+", "• ", line)
+            line = line.replace("**", "").replace("__", "").replace("`", "")
+            lines.append(line)
+        return "\n".join(lines).strip()
 
     async def _handle_chat_fallback(self, text: str, chat_id: str) -> None:
         await self.notifier.send_chat_action("typing")

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -11,8 +11,10 @@ from fastapi import HTTPException
 from sqlmodel import Session
 
 from .config import (
+    DART_MCP_PARAMS,
     KIS_ORDER_ENV,
     KIS_REAL_ORDER_ENABLED,
+    NEWS_MCP_PARAMS,
     TRADING_MCP_PARAMS,
 )
 from .database import engine
@@ -35,6 +37,7 @@ ALERT_COMMAND_HELP = "사용법: /alerts urgent | all | off | status"
 BUY_COMMAND_HELP = "사용법: /buy <종목명> <수량> [지정가]"
 SELL_COMMAND_HELP = "사용법: /sell <종목명> <수량> [지정가]"
 WATCH_COMMAND_HELP = "사용법: /watch add <종목명> | remove <종목명> | list"
+EARNINGS_COMMAND_HELP = "사용법: /earnings <종목명> [기간]  예: /earnings 삼성전자 2025Q1"
 NATURAL_ORDER_HELP = "자연어 주문을 해석할 수 없습니다. /buy 또는 /sell 형식으로 입력하세요."
 ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 ORDER_CONFIRM_CALLBACK = "order:confirm"
@@ -65,6 +68,7 @@ TELEGRAM_INTERACTIVE_HELP = "\n".join(
         "/lookup - 현재가·수급 조회 입력 안내",
         "/quote <종목명> - 현재가 조회",
         "/trend <종목명> - 외국인·기관·개인 수급 조회",
+        "/earnings <종목명> [기간] - DART 실적·뉴스 분석",
         "/buy <종목명> <수량> [지정가] - 매수 주문 준비",
         "/sell <종목명> <수량> [지정가] - 매도 주문 준비",
         "/confirm - 대기 주문 확정",
@@ -78,6 +82,7 @@ TELEGRAM_BOT_COMMANDS = [
     {"command": "watch", "description": "관심 종목 추가·삭제·조회 (add/remove/list)"},
     {"command": "quote", "description": "종목 현재가 조회"},
     {"command": "trend", "description": "종목 외국인·기관·개인 수급 조회"},
+    {"command": "earnings", "description": "DART 실적·뉴스 분석"},
     {"command": "alerts", "description": "Telegram 알림 모드 변경"},
     {"command": "trade", "description": "매수·매도 주문 입력 안내"},
     {"command": "lookup", "description": "현재가·수급 조회 입력 안내"},
@@ -220,6 +225,9 @@ class TelegramCommandHandler:
             return
         if self._matches_command(command, bot_username, "/trend"):
             await self._handle_trend(argument, str(chat.get("id", "")).strip())
+            return
+        if self._matches_command(command, bot_username, "/earnings"):
+            await self._handle_earnings(argument, str(chat.get("id", "")).strip())
             return
         if self._matches_command(command, bot_username, "/buy"):
             await self._handle_order_command("BUY", argument, str(chat.get("id", "")).strip())
@@ -996,6 +1004,73 @@ class TelegramCommandHandler:
         await self._send_text_or_raise(
             _telegram_text(str(result)),
             reply_markup=self._market_reply_markup("quote", chat_id, stock),
+        )
+
+    async def _handle_earnings(self, argument: str, chat_id: str) -> None:
+        parsed = self._parse_earnings_argument(argument)
+        if parsed is None:
+            await self._send_text_or_raise(EARNINGS_COMMAND_HELP)
+            return
+
+        stock, period = parsed
+        dart_arguments: dict[str, Any] = {"stock_name": stock}
+        if period:
+            dart_arguments["period"] = period
+
+        await self.notifier.send_chat_action("typing")
+        try:
+            dart_result, news_result = await asyncio.gather(
+                self.mcp_runner(DART_MCP_PARAMS, "get_earnings_report", dart_arguments),
+                self.mcp_runner(NEWS_MCP_PARAMS, "get_market_news", {"stock_name": stock}),
+            )
+            result = await self.llm_runner(
+                "nat",
+                self._earnings_analysis_prompt(stock, period, str(dart_result), str(news_result)),
+                conversation_id=f"telegram:{chat_id}:earnings:{stock}",
+            )
+        except Exception as exc:
+            await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")
+            return
+
+        await self._send_text_or_raise(_telegram_text(str(result)))
+
+    def _parse_earnings_argument(self, argument: str) -> tuple[str, str | None] | None:
+        parts = argument.split()
+        if not parts:
+            return None
+
+        period = None
+        if re.match(r"^\d{4}(?:[-_\s]?Q[1-4]|[-_\s]?FY)$", parts[-1], flags=re.IGNORECASE):
+            period = parts[-1].upper().replace("-", "").replace("_", "")
+            parts = parts[:-1]
+
+        stock = " ".join(parts).strip()
+        if not stock:
+            return None
+        return stock, period
+
+    def _earnings_analysis_prompt(
+        self,
+        stock: str,
+        period: str | None,
+        dart_result: str,
+        news_result: str,
+    ) -> str:
+        period_line = f"조회 기간: {period}" if period else "조회 기간: DART MCP 기본값"
+        return (
+            "News Analyst 실적 분석 모드로 다음 종목의 구조화된 실적 리포트를 작성하라.\n"
+            f"종목: {stock}\n"
+            f"{period_line}\n\n"
+            "[DART 실적 데이터]\n"
+            f"{dart_result}\n\n"
+            "[최신 뉴스]\n"
+            f"{news_result}\n\n"
+            "반드시 다음 항목을 포함하라:\n"
+            "- 매출/영업이익/순이익 전년 동기 대비 증감\n"
+            "- 컨센서스 대비 서프라이즈/미스 판단. 컨센서스 데이터가 없으면 추정하지 말고 데이터 없음으로 표시\n"
+            "- 주요 뉴스 기반 정성적 코멘트\n"
+            "- 다음 분기 전망\n"
+            "투자 조언은 단정하지 말고, 확인된 DART·뉴스 근거와 한계를 구분해 한국어로 답하라."
         )
 
     async def _handle_chat_fallback(self, text: str, chat_id: str) -> None:

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -5,6 +5,7 @@ import secrets
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Any, Callable
+from urllib.parse import quote as _url_quote
 
 import httpx
 from fastapi import HTTPException
@@ -1026,7 +1027,7 @@ class TelegramCommandHandler:
             result = await self.llm_runner(
                 "nat",
                 self._earnings_analysis_prompt(stock, period, str(dart_result), str(news_result)),
-                conversation_id=f"telegram:{chat_id}:earnings:{stock}",
+                conversation_id=f"telegram:{chat_id}:earnings:{_url_quote(stock, safe='')}",
             )
         except Exception as exc:
             await self._send_text_or_raise(f"조회 실패: {_short_error(exc)}")

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -5,9 +5,10 @@ import pytest
 from fastapi import HTTPException
 
 import backend.telegram_commands as telegram_commands
-from backend.config import TRADING_MCP_PARAMS
+from backend.config import DART_MCP_PARAMS, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS
 from backend.telegram_commands import (
     BUY_COMMAND_HELP,
+    EARNINGS_COMMAND_HELP,
     QUOTE_COMMAND_HELP,
     TELEGRAM_INTERACTIVE_HELP,
     TRADE_COMMAND_HELP,
@@ -164,6 +165,7 @@ async def test_help_command_replies_with_supported_commands():
     assert "/balance - 예수금·총자산·보유 종목 조회" in notifier.messages[-1]
     assert "/trade - 매수·매도 주문 입력 안내" in notifier.messages[-1]
     assert "/lookup - 현재가·수급 조회 입력 안내" in notifier.messages[-1]
+    assert "/earnings <종목명> [기간] - DART 실적·뉴스 분석" in notifier.messages[-1]
     assert "/quote <종목명> - 현재가 조회" in notifier.messages[-1]
     assert "/trend <종목명> - 외국인·기관·개인 수급 조회" in notifier.messages[-1]
     assert "/buy <종목명> <수량> [지정가] - 매수 주문 준비" in notifier.messages[-1]
@@ -301,7 +303,7 @@ def test_bot_command_menu_includes_all_user_commands():
     commands = [command["command"] for command in telegram_commands.TELEGRAM_BOT_COMMANDS]
 
     assert commands == [
-        "help", "balance", "watch", "quote", "trend",
+        "help", "balance", "watch", "quote", "trend", "earnings",
         "alerts", "trade", "lookup", "buy", "sell", "confirm", "cancel",
     ]
 
@@ -555,6 +557,111 @@ async def test_trend_result_quote_button_uses_same_stock_name():
     ]
     assert notifier.callback_answers == [("quote-callback", None)]
     assert notifier.messages[-1] == "현재가 응답"
+
+
+@pytest.mark.asyncio
+async def test_earnings_command_combines_dart_news_and_nat_analysis():
+    mcp_calls = []
+    llm_calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        mcp_calls.append((server_params, tool_name, arguments))
+        if server_params is DART_MCP_PARAMS:
+            return "DART 실적: 매출 +12%, 영업이익 +5%"
+        if server_params is NEWS_MCP_PARAMS:
+            return "뉴스: 반도체 수요 회복"
+        raise AssertionError(f"unexpected server params: {server_params}")
+
+    async def llm_runner(provider, text, *, conversation_id=None):
+        llm_calls.append((provider, text, conversation_id))
+        return "실적 분석 응답"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        llm_runner=llm_runner,
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/earnings 삼성전자"}})
+
+    assert mcp_calls == [
+        (DART_MCP_PARAMS, "get_earnings_report", {"stock_name": "삼성전자"}),
+        (NEWS_MCP_PARAMS, "get_market_news", {"stock_name": "삼성전자"}),
+    ]
+    assert len(llm_calls) == 1
+    provider, prompt, conversation_id = llm_calls[0]
+    assert provider == "nat"
+    assert conversation_id == "telegram:123:earnings:삼성전자"
+    assert "DART 실적: 매출 +12%, 영업이익 +5%" in prompt
+    assert "뉴스: 반도체 수요 회복" in prompt
+    assert "컨센서스 대비 서프라이즈/미스" in prompt
+    assert "다음 분기 전망" in prompt
+    assert notifier.actions == ["typing"]
+    assert notifier.messages == ["실적 분석 응답"]
+
+
+@pytest.mark.asyncio
+async def test_earnings_command_passes_optional_period_to_dart():
+    mcp_calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        mcp_calls.append((server_params, tool_name, arguments))
+        if server_params is DART_MCP_PARAMS:
+            return "DART 실적"
+        if server_params is NEWS_MCP_PARAMS:
+            return "뉴스"
+        raise AssertionError(f"unexpected server params: {server_params}")
+
+    async def llm_runner(provider, text, *, conversation_id=None):
+        return "실적 분석 응답"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        llm_runner=llm_runner,
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/earnings 삼성전자 2025Q1"}}
+    )
+
+    assert mcp_calls[0] == (
+        DART_MCP_PARAMS,
+        "get_earnings_report",
+        {"stock_name": "삼성전자", "period": "2025Q1"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_earnings_command_requires_stock_name():
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        return "unexpected"
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/earnings"}})
+
+    assert calls == []
+    assert notifier.messages == [EARNINGS_COMMAND_HELP]
+
+
+@pytest.mark.asyncio
+async def test_earnings_command_reports_collection_failure():
+    async def mcp_runner(server_params, tool_name, arguments):
+        raise RuntimeError("dart down")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, mcp_runner=mcp_runner)
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/earnings 삼성전자"}})
+
+    assert notifier.messages == ["조회 실패: dart down"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -598,8 +598,49 @@ async def test_earnings_command_combines_dart_news_and_nat_analysis():
     assert "뉴스: 반도체 수요 회복" in prompt
     assert "컨센서스 대비 서프라이즈/미스" in prompt
     assert "다음 분기 전망" in prompt
+    assert "Markdown 문법" in prompt
+    assert "호재`, `악재`, `중립" in prompt
     assert notifier.actions == ["typing"]
-    assert notifier.messages == ["실적 분석 응답"]
+    assert notifier.messages == ["⚪ 중립\n실적 분석 응답"]
+
+
+@pytest.mark.asyncio
+async def test_earnings_command_sends_plain_text_with_verdict_emoji():
+    async def mcp_runner(server_params, tool_name, arguments):
+        if server_params is DART_MCP_PARAMS:
+            return "DART 실적"
+        if server_params is NEWS_MCP_PARAMS:
+            return "뉴스"
+        raise AssertionError(f"unexpected server params: {server_params}")
+
+    async def llm_runner(provider, text, *, conversation_id=None):
+        return "\n".join(
+            [
+                "## **호재**",
+                "",
+                "### **실적 요약**",
+                "- **매출**: 전년 대비 증가",
+                "- **영업이익**: 개선",
+            ]
+        )
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        llm_runner=llm_runner,
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/earnings 삼성전자"}})
+
+    message = notifier.messages[-1]
+    assert message.startswith("🟢 호재\n")
+    assert "호재\n호재" not in message
+    assert "#" not in message
+    assert "*" not in message
+    assert "- " not in message
+    assert "실적 요약" in message
+    assert "• 매출: 전년 대비 증가" in message
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -592,7 +592,8 @@ async def test_earnings_command_combines_dart_news_and_nat_analysis():
     assert len(llm_calls) == 1
     provider, prompt, conversation_id = llm_calls[0]
     assert provider == "nat"
-    assert conversation_id == "telegram:123:earnings:삼성전자"
+    assert conversation_id == "telegram:123:earnings:%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90"
+    conversation_id.encode("ascii")
     assert "DART 실적: 매출 +12%, 영업이익 +5%" in prompt
     assert "뉴스: 반도체 수요 회복" in prompt
     assert "컨센서스 대비 서프라이즈/미스" in prompt

--- a/finus_nat/configs/agents/news_agent.yml
+++ b/finus_nat/configs/agents/news_agent.yml
@@ -16,6 +16,7 @@ functions:
       # news agent가 실수로 주식거래를 해버리는 위험을 막기 위해 향후에 다른 것으로 변경
       - mcp-news-get-market-news
       - mcp-dart-get-disclosure-signal
+      - mcp-dart-get-earnings-report
       - add_user_memory
       - get_user_memory
     verbose: false
@@ -31,6 +32,9 @@ functions:
 
       - 최신 뉴스·헤드라인: `mcp-news-get-market-news` (stock_name = 종목명 또는 6자리 코드).
       - DART 지분공시 signal(5% 룰·임원/주요주주): `mcp-dart-get-disclosure-signal` (stock_name). 매매 지시가 아닌 리스크·맥락 참고용.
+      - DART 실적 리포트: `mcp-dart-get-earnings-report` (stock_name, period 선택). 실적·분기보고서·사업보고서·earnings 질문에는 이 도구와 최신 뉴스를 함께 사용합니다.
+      - 실적 분석 모드에서는 매출/영업이익/순이익 YoY, 실적 서프라이즈/미스 여부, 주요 뉴스 기반 정성 코멘트, 다음 분기 전망을 구조화해 답하십시오.
+        컨센서스 또는 시장 기대치 데이터가 도구 Observation에 없으면 추정하지 말고 "컨센서스 데이터 없음"으로 명시하십시오.
       - `kis-trading-mcp-tool`: 보유종목/포트폴리오 확인이 필요할 때 사용합니다.
         기본 잔고 조회는 `api_type:"inquire_balance"`, `params:{{"env_dv":"real","inqr_dvsn":"01"}}`로 시작하십시오.
       - 최근 대화에 종목명이 이미 있으면 그 종목명을 그대로 사용해도 됩니다. 그렇지 않다면 kis-trading-mcp-tool을 사용하여 직접 조회하고 종목명을 가져옵니다.

--- a/finus_nat/configs/common.yml
+++ b/finus_nat/configs/common.yml
@@ -18,6 +18,10 @@ functions:
   mcp-dart-get-disclosure-signal:
     _type: finus_disclosure_signal
 
+  # fin-us/mcp-dart stdio: get_earnings_report
+  mcp-dart-get-earnings-report:
+    _type: finus_earnings_report
+
 llms:
   openai_cloud_llm:
     _type: openai

--- a/finus_nat/configs/router.yml
+++ b/finus_nat/configs/router.yml
@@ -44,7 +44,7 @@ functions:
         description: "보유·관심 포트폴리오 상태 점검, 리스크/하락/알림/건전성 모니터링."
       - name: news_agent
         function_name: news_branch_agent
-        description: "종목·시황 뉴스 헤드라인·요약(mcp-news: get_market_news). 투자자 수급은 Kis Trading MCP 경로로 조회."
+        description: "종목·시황 뉴스 헤드라인·요약, 실적·earnings·분기보고서·사업보고서 분석. 투자자 수급은 Kis Trading MCP 경로로 조회."
       - name: recommend_agent
         function_name: recommend_branch_agent
         description: "조건에 맞는 종목 후보 탐색, 대안 종목, 관심종목 아이디어 추천."

--- a/finus_nat/configs/router_nomemory.yml
+++ b/finus_nat/configs/router_nomemory.yml
@@ -25,7 +25,7 @@ functions:
         description: "보유·관심 포트폴리오 상태 점검, 리스크/하락/알림/건전성 모니터링."
       - name: news_agent
         function_name: news_branch_agent
-        description: "종목·시황 뉴스 헤드라인·요약(mcp-news: get_market_news). 투자자 수급은 Kis Trading MCP 경로로 조회."
+        description: "종목·시황 뉴스 헤드라인·요약, 실적·earnings·분기보고서·사업보고서 분석. 투자자 수급은 Kis Trading MCP 경로로 조회."
       - name: recommend_agent
         function_name: recommend_branch_agent
         description: "조건에 맞는 종목 후보 탐색, 대안 종목, 관심종목 아이디어 추천."

--- a/finus_nat/src/nat_finus_nat/agents.py
+++ b/finus_nat/src/nat_finus_nat/agents.py
@@ -93,6 +93,8 @@ def chat_response_plain_text(result: ChatResponse | str) -> str:
 
 def _is_holdings_news_request(chat_request: ChatRequest) -> bool:
     latest = latest_user_plain_text(chat_request.messages)
+    if any(word in latest for word in ("실적", "earnings", "분기보고서", "사업보고서")):
+        return False
     wants_news = "뉴스" in latest or "뉴" in latest
     refers_holdings = any(word in latest for word in ("보유", "포트폴리오", "종목", "보유종목"))
     return wants_news and refers_holdings

--- a/finus_nat/src/nat_finus_nat/finus_api.py
+++ b/finus_nat/src/nat_finus_nat/finus_api.py
@@ -254,6 +254,25 @@ async def _mcp_dart_stock(
     )
 
 
+async def _mcp_dart_earnings_stock(
+    *,
+    vendor_root: str | None,
+    timeout_sec: float,
+    stock_name: str,
+    period: str | None = None,
+) -> str:
+    arguments = {"stock_name": stock_name}
+    if period:
+        arguments["period"] = period
+    return await _mcp_call_tool(
+        vendor_root=_resolve_vendor_root(vendor_root),
+        subdir="mcp-dart",
+        tool_name="get_earnings_report",
+        arguments=arguments,
+        timeout_sec=timeout_sec,
+    )
+
+
 async def _mcp_trading_call(
     *,
     vendor_root: str | None,
@@ -283,6 +302,10 @@ class FinusMarketNewsConfig(_FinusMcpStdioConfig, name="finus_market_news"):
 
 class FinusDisclosureSignalConfig(FinusMarketNewsConfig, name="finus_disclosure_signal"):
     """mcp-dart stdio MCP — OpenDART 지분공시 signal."""
+
+
+class FinusEarningsReportConfig(FinusMarketNewsConfig, name="finus_earnings_report"):
+    """mcp-dart stdio MCP — OpenDART 실적 리포트."""
 
 
 class FinusMcpTradingConfig(_FinusMcpStdioConfig, name="finus_mcp_trading_base"):
@@ -608,6 +631,26 @@ async def finus_disclosure_signal(config: FinusDisclosureSignalConfig, _builder:
 
     get_disclosure_signal.__doc__ = doc
     yield FunctionInfo.from_fn(get_disclosure_signal, description=doc)
+
+
+@register_function(config_type=FinusEarningsReportConfig)
+async def finus_earnings_report(config: FinusEarningsReportConfig, _builder: Builder):
+    doc = (
+        "Fin-Us mcp-dart stdio MCP: OpenDART 공식 API 실적 리포트 "
+        "(매출·영업이익·순이익 YoY). stock_name 예: 삼성전자, 005930. "
+        "period 선택 예: 2025Q1, 2025Q2, 2025Q3, 2025FY. DART_API_KEY 필요."
+    )
+
+    async def get_earnings_report(stock_name: str, period: str | None = None) -> str:
+        return await _mcp_dart_earnings_stock(
+            vendor_root=config.vendor_root,
+            timeout_sec=config.timeout_sec,
+            stock_name=stock_name,
+            period=period,
+        )
+
+    get_earnings_report.__doc__ = doc
+    yield FunctionInfo.from_fn(get_earnings_report, description=doc)
 
 
 @register_function(config_type=FinusMcpTradingTodayOrdersConfig)

--- a/finus_nat/src/nat_finus_nat/register.py
+++ b/finus_nat/src/nat_finus_nat/register.py
@@ -71,6 +71,7 @@ Action Input (아래 Fin-Us 래퍼 도구 — ``tool_name``·``api_type``·``dom
 - ``finus-save-diary``: {{"title":"매매일지 YYYY-MM-DD","content":"본문"}}
 - ``finus-list-diaries``: {{}}
 - ``finus_market_news`` / ``finus_investor_trading`` / ``finus_disclosure``: {{"stock_name":"삼성전자"}}
+- ``mcp-dart-get-earnings-report``: {{"stock_name":"삼성전자","period":"2025Q1"}}
 """
 
 _FINUS_REACT_ACTION_INPUT_MIXED = """
@@ -97,6 +98,7 @@ def _react_system_prompt_for_tools(tools) -> str:
             "finus_market_news",
             "finus_investor_trading",
             "finus_disclosure",
+            "mcp-dart-get-earnings-report",
         )
     )
     if has_finus_wrapped and not has_kis:

--- a/finus_nat/tests/test_agents.py
+++ b/finus_nat/tests/test_agents.py
@@ -1,0 +1,33 @@
+from nat.data_models.api_server import ChatRequest
+from nat.data_models.api_server import Message
+from nat.data_models.api_server import UserMessageContentRoleType
+
+from nat_finus_nat import agents
+
+
+def _user_request(text: str) -> ChatRequest:
+    return ChatRequest(
+        messages=[
+            Message(
+                role=UserMessageContentRoleType.USER,
+                content=text,
+            )
+        ]
+    )
+
+
+def test_earnings_analysis_request_does_not_use_holdings_news_shortcut():
+    request = _user_request(
+        "News Analyst 실적 분석 모드로 다음 종목의 구조화된 실적 리포트를 작성하라.\n"
+        "종목: 삼성전자\n\n"
+        "[최신 뉴스]\n"
+        "삼성전자 최신 뉴스"
+    )
+
+    assert agents._is_holdings_news_request(request) is False
+
+
+def test_holdings_news_request_still_uses_holdings_news_shortcut():
+    request = _user_request("내 보유종목 삼성전자 최신 뉴스 알려줘")
+
+    assert agents._is_holdings_news_request(request) is True

--- a/finus_nat/tests/test_finus_api.py
+++ b/finus_nat/tests/test_finus_api.py
@@ -222,3 +222,31 @@ def test_mcp_dart_stock_routes_to_disclosure_signal_tool(monkeypatch, tmp_path):
         "arguments": {"stock_name": "삼성전자"},
         "timeout_sec": 7,
     }
+
+
+def test_mcp_dart_earnings_stock_routes_to_earnings_report_tool(monkeypatch, tmp_path):
+    captured = {}
+
+    async def fake_mcp_call_tool(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(finus_api, "_mcp_call_tool", fake_mcp_call_tool)
+
+    result = asyncio.run(
+        finus_api._mcp_dart_earnings_stock(
+            vendor_root=str(tmp_path),
+            timeout_sec=7,
+            stock_name="삼성전자",
+            period="2025Q1",
+        )
+    )
+
+    assert result == "ok"
+    assert captured == {
+        "vendor_root": Path(str(tmp_path)).expanduser().resolve(),
+        "subdir": "mcp-dart",
+        "tool_name": "get_earnings_report",
+        "arguments": {"stock_name": "삼성전자", "period": "2025Q1"},
+        "timeout_sec": 7,
+    }

--- a/mcp-dart/index.js
+++ b/mcp-dart/index.js
@@ -20,9 +20,37 @@ const CORP_CODE_ENDPOINT = "https://opendart.fss.or.kr/api/corpCode.xml";
 const DISCLOSURE_LIST_ENDPOINT = "https://opendart.fss.or.kr/api/list.json";
 const MAJOR_STOCK_ENDPOINT = "https://opendart.fss.or.kr/api/majorstock.json";
 const ELE_STOCK_ENDPOINT = "https://opendart.fss.or.kr/api/elestock.json";
+const FINANCIAL_STATEMENT_ENDPOINT = "https://opendart.fss.or.kr/api/fnlttSinglAcntAll.json";
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10000;
 const DISCLOSURE_DETAIL_TYPES = ["D001", "D002", "D005"];
+const EARNINGS_REPORT_CODES = {
+  Q1: "11013",
+  Q2: "11012",
+  Q3: "11014",
+  Q4: "11011",
+  FY: "11011",
+};
+const EARNINGS_ACCOUNT_MATCHERS = {
+  revenue: {
+    label: "매출",
+    accountIds: [
+      "ifrs-full_Revenue",
+      "ifrs-full_RevenueFromContractsWithCustomersExcludingAssessedTax",
+    ],
+    accountNames: ["매출액", "수익(매출액)", "영업수익"],
+  },
+  op_profit: {
+    label: "영업이익",
+    accountIds: ["dart_OperatingIncomeLoss", "ifrs-full_ProfitLossFromOperatingActivities"],
+    accountNames: ["영업이익", "영업이익(손실)"],
+  },
+  net_profit: {
+    label: "순이익",
+    accountIds: ["ifrs-full_ProfitLoss"],
+    accountNames: ["당기순이익", "분기순이익", "반기순이익", "연결당기순이익"],
+  },
+};
 
 function loadRootEnv() {
   if (!fs.existsSync(rootEnvPath)) return;
@@ -297,6 +325,164 @@ function disclosureViewerUrl(rceptNo) {
   return rceptNo ? `https://dart.fss.or.kr/dsaf001/main.do?rcpNo=${rceptNo}` : "";
 }
 
+function defaultEarningsPeriod() {
+  const now = new Date();
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  const year = kst.getUTCFullYear();
+  const month = kst.getUTCMonth() + 1;
+  const day = kst.getUTCDate();
+  const mmdd = month * 100 + day;
+
+  if (mmdd >= 1115) return `${year}Q3`;
+  if (mmdd >= 815) return `${year}Q2`;
+  if (mmdd >= 515) return `${year}Q1`;
+  return `${year - 1}FY`;
+}
+
+function parseEarningsPeriod(period) {
+  const normalized = cleanText(period || defaultEarningsPeriod()).toUpperCase().replace(/[-_\s]/g, "");
+  const match = normalized.match(/^(\d{4})(Q[1-4]|FY)$/);
+  if (!match) {
+    throw new Error("period는 YYYYQ1, YYYYQ2, YYYYQ3, YYYYQ4 또는 YYYYFY 형식이어야 합니다.");
+  }
+
+  const [, bsnsYear, quarter] = match;
+  return {
+    period: `${bsnsYear}${quarter}`,
+    bsns_year: bsnsYear,
+    reprt_code: EARNINGS_REPORT_CODES[quarter],
+    is_annual: quarter === "Q4" || quarter === "FY",
+  };
+}
+
+async function fetchFinancialStatements(apiKey, corp, periodInfo, fsDiv) {
+  const payload = await fetchJson(FINANCIAL_STATEMENT_ENDPOINT, {
+    crtfc_key: apiKey,
+    corp_code: corp.corp_code,
+    bsns_year: periodInfo.bsns_year,
+    reprt_code: periodInfo.reprt_code,
+    fs_div: fsDiv,
+  });
+  return asArray(payload.list);
+}
+
+async function fetchBestFinancialStatements(apiKey, corp, periodInfo) {
+  const cfs = await fetchFinancialStatements(apiKey, corp, periodInfo, "CFS");
+  if (cfs.length > 0) return { fs_div: "CFS", rows: cfs };
+  return { fs_div: "OFS", rows: await fetchFinancialStatements(apiKey, corp, periodInfo, "OFS") };
+}
+
+function parseAmount(value) {
+  const normalized = cleanText(value).replaceAll(",", "");
+  if (!normalized || normalized === "-") return null;
+  const negative = normalized.startsWith("(") && normalized.endsWith(")");
+  const numeric = Number(normalized.replace(/[()]/g, ""));
+  if (!Number.isFinite(numeric)) return null;
+  return negative ? -numeric : numeric;
+}
+
+function yoyPercent(current, previous) {
+  if (current === null || previous === null || previous === 0) return null;
+  return Number((((current - previous) / Math.abs(previous)) * 100).toFixed(2));
+}
+
+function isIncomeStatementRow(row) {
+  return ["IS", "CIS"].includes(cleanText(row.sj_div));
+}
+
+function accountScore(row, matcher) {
+  if (!isIncomeStatementRow(row)) return -1;
+  const accountId = cleanText(row.account_id);
+  const accountName = cleanText(row.account_nm);
+  if (matcher.accountIds.includes(accountId)) return 100;
+  if (matcher.accountNames.includes(accountName)) return 90;
+  if (matcher.accountNames.some((name) => accountName.includes(name))) return 70;
+  return -1;
+}
+
+function pickAccountRow(rows, matcher) {
+  return rows
+    .map((row) => ({ row, score: accountScore(row, matcher) }))
+    .filter((item) => item.score >= 0)
+    .sort((a, b) => b.score - a.score || Number(cleanText(a.row.ord) || 9999) - Number(cleanText(b.row.ord) || 9999))[0]
+    ?.row ?? null;
+}
+
+function extractEarningsAccount(rows, key, periodInfo) {
+  const matcher = EARNINGS_ACCOUNT_MATCHERS[key];
+  const row = pickAccountRow(rows, matcher);
+  if (!row) {
+    return {
+      label: matcher.label,
+      account_name: "",
+      current: null,
+      previous: null,
+      yoy_change: null,
+    };
+  }
+
+  const current = parseAmount(row.thstrm_amount);
+  const previous = parseAmount(periodInfo.is_annual ? row.frmtrm_amount : row.frmtrm_q_amount);
+  return {
+    label: matcher.label,
+    account_name: cleanText(row.account_nm),
+    current,
+    previous,
+    yoy_change: yoyPercent(current, previous),
+  };
+}
+
+function formatMoney(value, currency) {
+  if (value === null) return "N/A";
+  return `${value.toLocaleString("ko-KR")} ${currency || "KRW"}`;
+}
+
+function formatYoy(value) {
+  if (value === null) return "N/A";
+  return `${value > 0 ? "+" : ""}${value}%`;
+}
+
+function formatEarningsReport(corp, periodInfo, fsDiv, rows) {
+  if (rows.length === 0) {
+    return [
+      `[${corp.corp_name}] DART 실적 리포트`,
+      `- 종목코드: ${corp.stock_code}`,
+      `- 고유번호: ${corp.corp_code}`,
+      `- 조회기간: ${periodInfo.period}`,
+      "- 조회 결과: OpenDART 재무제표 데이터가 없습니다.",
+    ].join("\n");
+  }
+
+  const currency = cleanText(rows.find((row) => cleanText(row.currency))?.currency) || "KRW";
+  const accounts = {
+    revenue: extractEarningsAccount(rows, "revenue", periodInfo),
+    op_profit: extractEarningsAccount(rows, "op_profit", periodInfo),
+    net_profit: extractEarningsAccount(rows, "net_profit", periodInfo),
+  };
+  const firstReceipt = cleanText(rows.find((row) => cleanText(row.rcept_no))?.rcept_no);
+
+  return [
+    `[${corp.corp_name}] DART 실적 리포트`,
+    `- 종목코드: ${corp.stock_code}`,
+    `- 고유번호: ${corp.corp_code}`,
+    `- 조회기간: ${periodInfo.period}`,
+    `- 사업연도/보고서: ${periodInfo.bsns_year}/${periodInfo.reprt_code}`,
+    `- 재무제표: ${fsDiv}`,
+    `- 원문: ${disclosureViewerUrl(firstReceipt) || "N/A"}`,
+    "",
+    "[주요 실적]",
+    `- 매출: ${formatMoney(accounts.revenue.current, currency)} | YoY ${formatYoy(accounts.revenue.yoy_change)}`,
+    `- 영업이익: ${formatMoney(accounts.op_profit.current, currency)} | YoY ${formatYoy(accounts.op_profit.yoy_change)}`,
+    `- 순이익: ${formatMoney(accounts.net_profit.current, currency)} | YoY ${formatYoy(accounts.net_profit.yoy_change)}`,
+    "",
+    "[비교 기준]",
+    periodInfo.is_annual
+      ? "- YoY는 전기 사업보고서 금액 기준입니다."
+      : "- YoY는 전기 동분기 금액 기준입니다.",
+    "- 컨센서스 데이터는 OpenDART에서 제공되지 않으므로 별도 시장 기대치 소스가 필요합니다.",
+  ].join("\n");
+}
+
 function formatDisclosureItem(item) {
   const parts = [
     cleanText(item.rcept_dt),
@@ -374,6 +560,15 @@ async function getDisclosureSignal(stockName) {
   return formatDisclosureSignal(corp, window, disclosures, majorStocks, eleStocks);
 }
 
+async function getEarningsReport(stockName, period) {
+  const apiKey = requireDartApiKey();
+  const corp = resolveCorp(await getCorpCodes(apiKey), stockName);
+  const periodInfo = parseEarningsPeriod(period);
+  const { fs_div: fsDiv, rows } = await fetchBestFinancialStatements(apiKey, corp, periodInfo);
+
+  return formatEarningsReport(corp, periodInfo, fsDiv, rows);
+}
+
 server.registerTool(
   "get_disclosure_signal",
   {
@@ -394,6 +589,36 @@ server.registerTool(
     try {
       const signal = await getDisclosureSignal(stockName);
       return { content: [{ type: "text", text: signal }] };
+    } catch (error) {
+      return { content: [{ type: "text", text: `에러 발생: ${error.message}` }], isError: true };
+    }
+  },
+);
+
+server.registerTool(
+  "get_earnings_report",
+  {
+    description: "OpenDART 공식 API로 분기/연간 실적 주요 계정과 YoY 변화를 조회합니다.",
+    inputSchema: z.object({
+      stock_name: z.string().describe("주식 종목명 또는 6자리 종목코드"),
+      period: z
+        .string()
+        .optional()
+        .describe("조회 기간. 예: 2025Q1, 2025Q2, 2025Q3, 2025FY. 생략 시 최근 공시 가능 기간을 추정합니다."),
+    }),
+  },
+  async (args) => {
+    const stockName = args?.stock_name;
+    if (!stockName) {
+      return {
+        content: [{ type: "text", text: "에러: stock_name 파라미터가 누락되었습니다." }],
+        isError: true,
+      };
+    }
+
+    try {
+      const report = await getEarningsReport(stockName, args?.period);
+      return { content: [{ type: "text", text: report }] };
     } catch (error) {
       return { content: [{ type: "text", text: `에러 발생: ${error.message}` }], isError: true };
     }

--- a/mcp-dart/tests/mcp-server.test.js
+++ b/mcp-dart/tests/mcp-server.test.js
@@ -23,8 +23,19 @@ test("registers disclosure signal tool with required stock_name schema", async (
   await withClient(async (client) => {
     const { tools } = await client.listTools();
 
-    assert.equal(tools.length, 1);
-    assert.equal(tools[0].name, "get_disclosure_signal");
-    assert.deepEqual(tools[0].inputSchema.required, ["stock_name"]);
+    const disclosureTool = tools.find((tool) => tool.name === "get_disclosure_signal");
+    assert.ok(disclosureTool);
+    assert.deepEqual(disclosureTool.inputSchema.required, ["stock_name"]);
+  });
+});
+
+test("registers earnings report tool with stock_name and optional period schema", async () => {
+  await withClient(async (client) => {
+    const { tools } = await client.listTools();
+
+    const earningsTool = tools.find((tool) => tool.name === "get_earnings_report");
+    assert.ok(earningsTool);
+    assert.deepEqual(earningsTool.inputSchema.required, ["stock_name"]);
+    assert.ok(earningsTool.inputSchema.properties.period);
   });
 });


### PR DESCRIPTION
## 📝 개요

News Analyst에 OpenDART 실적 리포트와 Naver 뉴스 기반 실적 분석 흐름을 추가했습니다. Telegram `/earnings <종목명> [기간]` 명령으로 매출·영업이익·순이익 YoY, 컨센서스 판단 한계, 주요 뉴스 코멘트, 다음 분기 전망을 구조화해 요청할 수 있습니다.

## 🚀 변경 사항
- `mcp-dart`에 `get_earnings_report` 도구 추가
- NAT News Analyst에 실적 리포트 도구 및 실적 분석 모드 연결
- Telegram `/earnings <종목명> [기간]` 명령 추가
- README에 DART 실적 도구와 `/earnings` 사용법 문서화

## 🔗 관련 이슈
- Related to #99

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)
### 삼성전자 입력시(기간 생략 시 최신 일자로 반영됨)
<img width="910" height="890" alt="image" src="https://github.com/user-attachments/assets/722e16f9-e808-4a43-96bc-a448a1e90422" />

- 차세대 HBM, 젠슨 황 방문 등 긍정적 뉴스를 분석에 잘 반영하고 있는 것을 확인할 수 있음. 
<br/>

### 한화에어로스페이스 입력시
<img width="901" height="856" alt="image" src="https://github.com/user-attachments/assets/df00451a-4840-41db-a15c-266543d7e636" />

- 실적 외에 대전사업장 사고 관련한 뉴스도 분석에 잘 포함하고 있는 것을 확인 할 수 있음. 
