### PR TITLE
feat: Telegram /visualize 시연 링크 제공

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ REDIS_URL=redis://localhost:6379/0
 # Telegram Bot
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 TELEGRAM_CHAT_ID=your_telegram_chat_id_here
+VISUALIZATION_URL=http://100.x.y.z:8080/
 
 # Security
 ALLOW_ORIGINS=http://localhost:5173,http://127.0.0.1:5173

--- a/README.md
+++ b/README.md
@@ -182,8 +182,11 @@ Backend 스케줄러는 매 거래일 오전 8시 30분에 Telegram 모닝 브�
 | `/quote <종목명>` | 현재가 조회 | 📊 수급 보기 |
 | `/trend <종목명>` | 외국인·기관·개인 수급 조회 | 💵 현재가 보기 |
 | `/earnings <종목명> [기간]` | DART 실적과 최신 뉴스 기반 구조화 리포트 생성. 기간 예: `2025Q1`, `2025FY` | - |
+| `/visualize` | `VISUALIZATION_URL`에 설정된 Unity 포트폴리오 시각화 링크 제공 | - |
 
 `/earnings`는 OpenDART 실적 데이터와 Naver 뉴스를 NAT News Analyst에 전달합니다. OpenDART가 제공하지 않는 컨센서스/시장 기대치 데이터는 추정하지 않고 데이터 없음으로 표시합니다. Telegram 응답은 Markdown이 아닌 일반 텍스트이며 첫 줄에 `🟢 호재`, `🔴 악재`, `⚪ 중립` 판정을 표시합니다.
+
+`/visualize`는 홈서버나 Tailscale 시연 환경에서 접근 가능한 Unity WebGL URL을 그대로 안내합니다. 예: `VISUALIZATION_URL=http://100.x.y.z:8080/`
 
 **매매**
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -72,6 +72,7 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 # Telegram urgent alert settings.
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
+VISUALIZATION_URL = os.getenv("VISUALIZATION_URL", "").strip()
 KIS_ORDER_ENV = os.environ.get("KIS_ORDER_ENV", "demo").strip().lower()
 KIS_REAL_ORDER_ENABLED = os.environ.get("KIS_REAL_ORDER_ENABLED", "").strip().lower() in {
     "1",

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -17,6 +17,7 @@ from .config import (
     KIS_REAL_ORDER_ENABLED,
     NEWS_MCP_PARAMS,
     TRADING_MCP_PARAMS,
+    VISUALIZATION_URL,
 )
 from .database import engine
 from .redis_state import RedisSchedulerState, redis_state
@@ -67,6 +68,7 @@ TELEGRAM_INTERACTIVE_HELP = "\n".join(
         "/watch add <종목명>|remove <종목명>|list - 관심 종목 관리",
         "/trade - 매수·매도 주문 입력 안내",
         "/lookup - 현재가·수급 조회 입력 안내",
+        "/visualize - Unity 포트폴리오 시각화 링크",
         "/quote <종목명> - 현재가 조회",
         "/trend <종목명> - 외국인·기관·개인 수급 조회",
         "/earnings <종목명> [기간] - DART 실적·뉴스 분석",
@@ -85,6 +87,7 @@ TELEGRAM_BOT_COMMANDS = [
     {"command": "trend", "description": "종목 외국인·기관·개인 수급 조회"},
     {"command": "earnings", "description": "DART 실적·뉴스 분석"},
     {"command": "alerts", "description": "Telegram 알림 모드 변경"},
+    {"command": "visualize", "description": "Unity 포트폴리오 시각화 링크"},
     {"command": "trade", "description": "매수·매도 주문 입력 안내"},
     {"command": "lookup", "description": "현재가·수급 조회 입력 안내"},
     {"command": "buy", "description": "매수 주문 준비 (예: /buy 삼성전자 1)"},
@@ -166,6 +169,7 @@ class TelegramCommandHandler:
         order_gateway: Any | None = None,
         trade_recorder: Any | None = None,
         now_factory: Callable[[], datetime] | None = None,
+        visualization_url: str = VISUALIZATION_URL,
     ):
         self.notifier = notifier
         self.state_factory = state_factory
@@ -175,6 +179,7 @@ class TelegramCommandHandler:
         self.order_gateway = order_gateway
         self.trade_recorder = trade_recorder
         self.now_factory = now_factory or (lambda: datetime.now(KST))
+        self.visualization_url = visualization_url.strip()
         self.pending_orders: dict[str, PendingOrder] = {}
         self.market_callbacks: dict[str, tuple[str, str]] = {}
 
@@ -220,6 +225,9 @@ class TelegramCommandHandler:
                 LOOKUP_COMMAND_HELP,
                 reply_markup=self._lookup_reply_markup(),
             )
+            return
+        if self._matches_command(command, bot_username, "/visualize"):
+            await self._handle_visualize()
             return
         if self._matches_command(command, bot_username, "/quote"):
             await self._handle_quote(argument, str(chat.get("id", "")).strip())
@@ -377,6 +385,15 @@ class TelegramCommandHandler:
 
         await self._answer_callback_query(callback_query_id)
         await self._handle_alerts(action)
+
+    async def _handle_visualize(self) -> None:
+        if not self.visualization_url:
+            await self._send_text_or_raise(
+                "시각화 URL이 설정되지 않았습니다. VISUALIZATION_URL 환경변수를 설정하세요."
+            )
+            return
+
+        await self._send_text_or_raise(f"Unity 포트폴리오 시각화:\n{self.visualization_url}")
 
     async def _handle_trade_callback(
         self,

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,5 +1,7 @@
+import importlib
 from pathlib import Path
 
+import backend.config as config
 from backend.config import DART_MCP_PARAMS, NEWS_MCP_PARAMS, TRADING_MCP_PARAMS, _stdio_server_params
 
 
@@ -25,3 +27,11 @@ def test_mcp_stdio_params_do_not_pass_parent_only_secrets(monkeypatch):
     assert params.env["FIN_US_TRACE_ID"] == "trace-id"
     assert "DATABASE_URL" not in params.env
     assert "OPENAI_API_KEY" not in params.env
+
+
+def test_visualization_url_is_trimmed_and_trailing_slash_preserved(monkeypatch):
+    monkeypatch.setenv("VISUALIZATION_URL", " https://finus-visual.example/portfolio/ ")
+
+    reloaded = importlib.reload(config)
+
+    assert reloaded.VISUALIZATION_URL == "https://finus-visual.example/portfolio/"

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -165,6 +165,7 @@ async def test_help_command_replies_with_supported_commands():
     assert "/balance - 예수금·총자산·보유 종목 조회" in notifier.messages[-1]
     assert "/trade - 매수·매도 주문 입력 안내" in notifier.messages[-1]
     assert "/lookup - 현재가·수급 조회 입력 안내" in notifier.messages[-1]
+    assert "/visualize - Unity 포트폴리오 시각화 링크" in notifier.messages[-1]
     assert "/earnings <종목명> [기간] - DART 실적·뉴스 분석" in notifier.messages[-1]
     assert "/quote <종목명> - 현재가 조회" in notifier.messages[-1]
     assert "/trend <종목명> - 외국인·기관·개인 수급 조회" in notifier.messages[-1]
@@ -262,6 +263,48 @@ async def test_lookup_command_replies_with_entrypoint_buttons():
 
 
 @pytest.mark.asyncio
+async def test_visualize_command_replies_with_configured_url():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        visualization_url="http://100.64.0.10:8080/portfolio",
+    )
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/visualize"}})
+
+    assert notifier.messages == [
+        "Unity 포트폴리오 시각화:\nhttp://100.64.0.10:8080/portfolio"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_visualize_command_reports_missing_url():
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(notifier=notifier, visualization_url="")
+
+    await handler.handle_update({"message": {"chat": {"id": 123}, "text": "/visualize"}})
+
+    assert notifier.messages == [
+        "시각화 URL이 설정되지 않았습니다. VISUALIZATION_URL 환경변수를 설정하세요."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_visualize_command_accepts_matching_telegram_bot_suffix():
+    notifier = FakeNotifier(bot_username="finus_bot")
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        visualization_url="http://100.64.0.10:8080/",
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": "/visualize@finus_bot"}}
+    )
+
+    assert notifier.messages[-1] == "Unity 포트폴리오 시각화:\nhttp://100.64.0.10:8080/"
+
+
+@pytest.mark.asyncio
 async def test_trade_menu_button_replies_with_buy_and_sell_guidance():
     notifier = FakeNotifier()
     handler = TelegramCommandHandler(notifier=notifier)
@@ -304,7 +347,7 @@ def test_bot_command_menu_includes_all_user_commands():
 
     assert commands == [
         "help", "balance", "watch", "quote", "trend", "earnings",
-        "alerts", "trade", "lookup", "buy", "sell", "confirm", "cancel",
+        "alerts", "visualize", "trade", "lookup", "buy", "sell", "confirm", "cancel",
     ]
 
 


### PR DESCRIPTION
## 📝 개요

Telegram 봇에서 /visualize 명령으로 Unity WebGL 포트폴리오 시각화 URL을 안내합니다.

## 🚀 변경 사항
- VISUALIZATION_URL 설정값 추가
- Telegram /visualize 명령과 봇 명령 메뉴 등록
- URL 미설정 시 설정 안내 메시지 응답
- README와 .env.example 설정 안내 추가

## 🔗 관련 이슈
- Closes #109

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 테스트
- UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_config.py backend/tests/test_telegram_commands.py -q
- UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests/test_telegram_commands.py backend/tests/test_telegram_notifier.py backend/tests/test_scheduler.py -q
- UV_CACHE_DIR=.uv-cache uv run --project backend pytest backend/tests -q