### PR TITLE
docs: README 기술스택 배지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,6 @@
 
 Fin-Us는 **MCP (Model Context Protocol)** 아키텍처와 **멀티 에이전트 워크플로우**를 결합한 차세대 지능형 투자 시스템입니다. 독립적인 인격을 가진 에이전트들이 각자의 도구(MCP)를 활용해 협업하며, 뉴스 분석부터 실제 매매 집행까지의 복잡한 의사결정을 자율적으로 수행합니다.
 
-## 🧰 기술 스택
-
-![Python](https://img.shields.io/badge/Python-3.13-3776AB?logo=python&logoColor=white)
-![FastAPI](https://img.shields.io/badge/FastAPI-0.136-009688?logo=fastapi&logoColor=white)
-![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=20232A)
-![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)
-![Vite](https://img.shields.io/badge/Vite-8-646CFF?logo=vite&logoColor=white)
-![Node.js](https://img.shields.io/badge/Node.js-24-5FA04E?logo=nodedotjs&logoColor=white)
-![MCP](https://img.shields.io/badge/MCP-1.29-000000)
-![Redis](https://img.shields.io/badge/Redis-7-DC382D?logo=redis&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)
-![OpenAI](https://img.shields.io/badge/OpenAI-API-412991?logo=openai&logoColor=white)
-![Anthropic](https://img.shields.io/badge/Anthropic-API-191919)
-![OpenDART](https://img.shields.io/badge/OpenDART-API-005BAC)
-![KIS](https://img.shields.io/badge/KIS-Open%20API-003B71)
-![Naver](https://img.shields.io/badge/Naver-Search%20API-03C75A?logo=naver&logoColor=white)
-
 ## 🤖 Multi-Agent Ecosystem
 
 Fin-Us는 단일 모델이 모든 일을 처리하지 않고, 역할이 분리된 전문 에이전트들이 협력합니다. 각 에이전트의 페르소나와 지침은 `finus_nat/configs/agents/`의 YAML 설정을 통해 관리됩니다.
@@ -236,6 +219,24 @@ python3 mcp-trading/scripts/update_stock_master.py
 
 슬래시 명령이 아닌 일반 텍스트는 NAT 채팅으로 전달됩니다. Telegram 채팅은 `telegram:{chat_id}` conversation id를 사용하므로 스케줄러 분석 리포트와 대화 이력이 섞이지 않습니다.
 
+--- 
+
+## 📚 기술 스택
+
+![Python](https://img.shields.io/badge/Python-3.13-3776AB?logo=python&logoColor=white)
+![FastAPI](https://img.shields.io/badge/FastAPI-0.136-009688?logo=fastapi&logoColor=white)
+![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=20232A)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-8-646CFF?logo=vite&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-24-5FA04E?logo=nodedotjs&logoColor=white)
+![MCP](https://img.shields.io/badge/MCP-1.29-000000)
+![Redis](https://img.shields.io/badge/Redis-7-DC382D?logo=redis&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)
+![OpenAI](https://img.shields.io/badge/OpenAI-API-412991?logo=openai&logoColor=white)
+![Anthropic](https://img.shields.io/badge/Anthropic-API-191919)
+![OpenDART](https://img.shields.io/badge/OpenDART-API-005BAC)
+![KIS](https://img.shields.io/badge/KIS-Open%20API-003B71)
+![Naver](https://img.shields.io/badge/Naver-Search%20API-03C75A?logo=naver&logoColor=white)
 ---
 
 ## ⚖️ 참고

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Fin-Us는 **MCP (Model Context Protocol)** 아키텍처와 **멀티 에이전트 워크플로우**를 결합한 차세대 지능형 투자 시스템입니다. 독립적인 인격을 가진 에이전트들이 각자의 도구(MCP)를 활용해 협업하며, 뉴스 분석부터 실제 매매 집행까지의 복잡한 의사결정을 자율적으로 수행합니다.
 
+## 🧰 기술 스택
+
+![Python](https://img.shields.io/badge/Python-3.13-3776AB?logo=python&logoColor=white)
+![FastAPI](https://img.shields.io/badge/FastAPI-0.136-009688?logo=fastapi&logoColor=white)
+![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=20232A)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-8-646CFF?logo=vite&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-24-5FA04E?logo=nodedotjs&logoColor=white)
+![MCP](https://img.shields.io/badge/MCP-1.29-000000)
+![Redis](https://img.shields.io/badge/Redis-7-DC382D?logo=redis&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)
+![OpenAI](https://img.shields.io/badge/OpenAI-API-412991?logo=openai&logoColor=white)
+![Anthropic](https://img.shields.io/badge/Anthropic-API-191919)
+![OpenDART](https://img.shields.io/badge/OpenDART-API-005BAC)
+![KIS](https://img.shields.io/badge/KIS-Open%20API-003B71)
+![Naver](https://img.shields.io/badge/Naver-Search%20API-03C75A?logo=naver&logoColor=white)
+
 ## 🤖 Multi-Agent Ecosystem
 
 Fin-Us는 단일 모델이 모든 일을 처리하지 않고, 역할이 분리된 전문 에이전트들이 협력합니다. 각 에이전트의 페르소나와 지침은 `finus_nat/configs/agents/`의 YAML 설정을 통해 관리됩니다.
@@ -43,7 +60,7 @@ Fin-Us는 단일 모델이 모든 일을 처리하지 않고, 역할이 분리�
 
 ### 사전 준비 사항
 
-- Python 3.12+
+- Python 3.13
 - Node.js & npm
 - API Keys: OpenAI/Anthropic API, 한국투자증권(KIS) API Key/Secret, Naver Search API, OpenDART API Key
 
@@ -220,10 +237,6 @@ python3 mcp-trading/scripts/update_stock_master.py
 슬래시 명령이 아닌 일반 텍스트는 NAT 채팅으로 전달됩니다. Telegram 채팅은 `telegram:{chat_id}` conversation id를 사용하므로 스케줄러 분석 리포트와 대화 이력이 섞이지 않습니다.
 
 ---
-
-## 🙌 팀원 목록
-
-남기연, 우용재, 김성현, 김진성, 김현민
 
 ## ⚖️ 참고
 - 본 프로젝트는 **학술적 목적**의 캡스톤 디자인 결과물이며, 일체의 상업적 목적이 없습니다. 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ python3 mcp-trading/scripts/update_stock_master.py
 ![OpenDART](https://img.shields.io/badge/OpenDART-API-005BAC)
 ![KIS](https://img.shields.io/badge/KIS-Open%20API-003B71)
 ![Naver](https://img.shields.io/badge/Naver-Search%20API-03C75A?logo=naver&logoColor=white)
+
 ---
 
 ## ⚖️ 참고


### PR DESCRIPTION
## 📝 개요

README 하단에 프로젝트 기술스택 배지를 추가하고, 팀원 목록 섹션을 제거합니다.

## 🚀 변경 사항
- README 하단에 Python, FastAPI, React, TypeScript, Vite, Node.js, MCP, Redis, Docker, 외부 API 기술스택 배지 추가
- README 팀원 목록 섹션 제거
- backend 요구사항에 맞춰 사전 준비 사항의 Python 버전 표기 정정

## 🔗 관련 이슈
- Related to #



## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

## 📸 스크린샷 (선택 사항)
