### PR TITLE
fix: 주문 멱등 원장 영속 경로 지정 및 자식 프로세스 전달

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 **/dist
 **/build
 **/.env
+**/.state
 **/npm-debug.log*
 **/__pycache__
 **/.pytest_cache

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,18 @@ KIS_REAL_ORDER_ENABLED=false
 # KIS_URL·API 키 해시별 JSON 파일을 만듭니다. 고정 경로가 필요할 때만 설정하세요.
 # KIS_TOKEN_CACHE_PATH=/path/to/kis-token-cache.json
 
+# 주문 멱등 원장(선택). 미설정 시 mcp-trading이 os.tmpdir()/finus-kis-order-dedup.json에
+# 저장하므로 컨테이너 재생성 시 중복 주문 방어선이 사라집니다. Docker Compose는 backend
+# 서비스에서 /app/.state/kis-order-dedup.json을 기본값으로 지정하며, 여기서 설정하면 그
+# 기본값을 덮어씁니다.
+# 주의: Docker Compose에서 이 값은 호스트가 아니라 컨테이너 내부 경로로 해석됩니다.
+# 바인드 마운트된 /app 아래를 벗어나면 컨테이너 재생성 시 원장이 그대로 사라집니다.
+# KIS_ORDER_DEDUP_PATH=/app/.state/kis-order-dedup.json
+
+# 동일 주문 중복 차단 시간(ms, 선택). 기본 120000(2분). 재빌드를 동반한 재배포는 보통
+# 2분을 넘겨 TTL이 이미 만료되므로, 배포 창을 실제로 덮으려면 상향이 필요합니다.
+# KIS_ORDER_DEDUP_TTL_MS=120000
+
 #실전투자계좌일 경우
 #KIS_URL=https://openapi.koreainvestment.com:9443
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,13 @@ Docker Compose에서는 `KIS_ORDER_DEDUP_PATH` 기본값에 따라 원장이 호
 
 `.env`나 셸 환경변수로 `KIS_ORDER_DEDUP_PATH`를 직접 지정하면 위 기본값을 덮어씁니다. 이때 지정하는 값은 **호스트 경로가 아니라 컨테이너 내부 경로**입니다. 바인드 마운트된 `/app` 아래를 벗어난 경로를 넣으면 오류 없이 컨테이너 쓰기 계층에 원장이 만들어지고, 재생성과 함께 사라집니다.
 
-> **주의**: `scripts/reset_clean.sh`나 `docker compose down -v`는 이 파일을 지우지 않습니다(바인드 마운트라 호스트에 그대로 남습니다). 다만 사용자가 `./.state/`를 직접 삭제하면 TTL이 만료될 때까지 중복 주문 방어선이 사라집니다.
+> **주의**: `scripts/reset_clean.sh`나 `docker compose down -v`는 이 파일을 지우지 않습니다(바인드 마운트라 호스트에 그대로 남습니다). 다만 사용자가 `./.state/`를 직접 삭제하면 TTL이 만료될 때까지 중복 주문 방어선이 사라집니다. `backend/Dockerfile`에 `USER` 지정이 없어 Linux 호스트에서는 컨테이너가 root로 실행되므로, `./.state/`도 root 소유로 생성됩니다. 이 경우 일반 사용자 권한의 `rm -rf`가 실패할 수 있어 `sudo rm -rf ./.state/`가 필요할 수 있습니다.
 
-기본 TTL은 120초(`mcp-trading/order-dedup.js:6`)로 사용자의 연타 클릭을 막기 위한 값입니다. 재빌드를 동반한 재배포는 보통 2분을 넘기므로 TTL이 이미 만료된 뒤라, 원장을 영속화해도 재배포 사이의 중복 주문까지는 막지 못합니다. 배포 창 전체를 덮으려면 `KIS_ORDER_DEDUP_TTL_MS`를 상향 조정하세요.
+기본 TTL은 120초(`DEFAULT_ORDER_DEDUP_TTL_MS`, `mcp-trading/order-dedup.js`)로 사용자의 연타 클릭을 막기 위한 값입니다. 재빌드를 동반한 재배포는 보통 2분을 넘기므로 TTL이 이미 만료된 뒤라, 원장을 영속화해도 재배포 사이의 중복 주문까지는 막지 못합니다. 배포 창 전체를 덮으려면 `KIS_ORDER_DEDUP_TTL_MS`를 상향 조정하세요.
 
-원장 파일에는 주문 요청 body와 KIS 응답이 그대로 저장되며, 여기에는 계좌번호(`CANO`, `mcp-trading/order.js:81-82`)가 평문으로 포함됩니다. 생성 시 파일 권한이 `0600`(`mcp-trading/order-dedup.js:121`)으로 지정되지만 이는 Linux 호스트에서만 의미가 있고, 어느 경우든 호스트 파일시스템에 그대로 남는다는 점을 유의하세요.
+원장 파일에는 주문 요청 body와 KIS 응답이 그대로 저장되며, 여기에는 계좌번호(`CANO`, `buildCashOrderBody`, `mcp-trading/order.js`)가 평문으로 포함됩니다. 생성 시 파일 권한이 `0600`(`#writeLedger`의 `0600` 지정, `mcp-trading/order-dedup.js`)으로 지정되지만 이는 Linux 호스트에서만 의미가 있고, 어느 경우든 호스트 파일시스템에 그대로 남는다는 점을 유의하세요.
+
+> **문제 해결**: `/buy`·`/sell` 실행 시 Telegram에 `EACCES`·`EROFS`·`ENOSPC`류 에러가 그대로 노출되며 모든 주문이 차단된다면, 원장 경로(`KIS_ORDER_DEDUP_PATH`, 기본값 `./.state/kis-order-dedup.json`)에 쓰기 권한이 없는 상태입니다. `mcp-trading/index.js`는 `orderDedupStore.reserve(...)`를 KIS 호출용 `try` 블록 바깥에서 실행하고, `order-dedup.js`의 `#writeLedger`는 `fs.mkdirSync`·`fs.writeFileSync` 실패를 감싸지 않으므로 원장에 쓸 수 없으면 즉시 실패합니다. 이는 버그가 아니라 방어선이 깨진 상태에서 주문을 조용히 허용하지 않기 위한 fail-closed 설계입니다. `ls -la ./.state/`와 `docker compose logs backend`로 원인을 확인하고, 임시로는 `KIS_ORDER_DEDUP_PATH`를 바인드 마운트된 `/app` 아래의 쓰기 가능한 경로로 지정해 우회할 수 있습니다.
 
 ### Telegram 긴급 알림 수동 테스트
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Docker Compose에서는 `KIS_ORDER_DEDUP_PATH` 기본값에 따라 원장이 호
 
 원장 파일에는 주문 요청 body와 KIS 응답이 그대로 저장되며, 여기에는 계좌번호(`CANO`, `buildCashOrderBody`, `mcp-trading/order.js`)가 평문으로 포함됩니다. 생성 시 파일 권한이 `0600`(`#writeLedger`의 `0600` 지정, `mcp-trading/order-dedup.js`)으로 지정되지만 이는 Linux 호스트에서만 의미가 있고, 어느 경우든 호스트 파일시스템에 그대로 남는다는 점을 유의하세요.
 
-> **문제 해결**: `/buy`·`/sell` 실행 시 Telegram에 `EACCES`·`EROFS`·`ENOSPC`류 에러가 그대로 노출되며 모든 주문이 차단된다면, 원장 경로(`KIS_ORDER_DEDUP_PATH`, 기본값 `./.state/kis-order-dedup.json`)에 쓰기 권한이 없는 상태입니다. `mcp-trading/index.js`는 `orderDedupStore.reserve(...)`를 KIS 호출용 `try` 블록 바깥에서 실행하고, `order-dedup.js`의 `#writeLedger`는 `fs.mkdirSync`·`fs.writeFileSync` 실패를 감싸지 않으므로 원장에 쓸 수 없으면 즉시 실패합니다. 이는 버그가 아니라 방어선이 깨진 상태에서 주문을 조용히 허용하지 않기 위한 fail-closed 설계입니다. `ls -la ./.state/`와 `docker compose logs backend`로 원인을 확인하고, 임시로는 `KIS_ORDER_DEDUP_PATH`를 바인드 마운트된 `/app` 아래의 쓰기 가능한 경로로 지정해 우회할 수 있습니다.
+> **문제 해결**: `/buy`·`/sell` 실행 시 Telegram에 `EACCES`·`EROFS`·`ENOSPC`류 에러가 그대로 노출되며 모든 주문이 차단된다면, 원장 경로(`KIS_ORDER_DEDUP_PATH`, 코드 기본값은 `os.tmpdir()`의 `finus-kis-order-dedup.json`, Docker Compose 기본값은 컨테이너 내부 경로 `/app/.state/kis-order-dedup.json`)에 쓰기 권한이 없는 상태입니다. `mcp-trading/index.js`는 `orderDedupStore.reserve(...)`를 KIS 호출용 `try` 블록 바깥에서 실행하고, `order-dedup.js`의 `#writeLedger`는 `fs.mkdirSync`·`fs.writeFileSync` 실패를 감싸지 않으므로 원장에 쓸 수 없으면 즉시 실패합니다. 이는 버그가 아니라 방어선이 깨진 상태에서 주문을 조용히 허용하지 않기 위한 fail-closed 설계입니다. `ls -la ./.state/`와 `docker compose logs backend`로 원인을 확인하고, 임시로는 `KIS_ORDER_DEDUP_PATH`를 바인드 마운트된 `/app` 아래의 쓰기 가능한 경로로 지정해 우회할 수 있습니다.
 
 ### Telegram 긴급 알림 수동 테스트
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ bash scripts/run_stack.sh
 
 - 로컬에서 `uvicorn --reload`만 쓰고 싶다면 볼륨 마운트된 소스로 호스트에서 실행하면 됩니다.
 
+### 주문 멱등 원장 영속화
+
+`/buy`·`/sell` 확정 주문이 중복 제출되는 것을 막는 마지막 방어선은 `mcp-trading/order-dedup.js`의 파일 기반 원장입니다. 백엔드 측 방어(`backend/telegram_commands.py`의 `pending_orders`)는 프로세스 메모리에만 존재하므로 재시작하면 사라지지만, 이 원장은 파일에 남아 컨테이너가 재생성되어도 최근 주문 이력을 유지합니다.
+
+Docker Compose에서는 `KIS_ORDER_DEDUP_PATH` 기본값에 따라 원장이 호스트의 `./.state/kis-order-dedup.json`에 저장됩니다(`.:/app` 바인드 마운트 덕분). 이 경로는 `.gitignore`·`.dockerignore`에 등록되어 있어 커밋되지도, 이미지에 구워지지도 않습니다.
+
+`.env`나 셸 환경변수로 `KIS_ORDER_DEDUP_PATH`를 직접 지정하면 위 기본값을 덮어씁니다. 이때 지정하는 값은 **호스트 경로가 아니라 컨테이너 내부 경로**입니다. 바인드 마운트된 `/app` 아래를 벗어난 경로를 넣으면 오류 없이 컨테이너 쓰기 계층에 원장이 만들어지고, 재생성과 함께 사라집니다.
+
+> **주의**: `scripts/reset_clean.sh`나 `docker compose down -v`는 이 파일을 지우지 않습니다(바인드 마운트라 호스트에 그대로 남습니다). 다만 사용자가 `./.state/`를 직접 삭제하면 TTL이 만료될 때까지 중복 주문 방어선이 사라집니다.
+
+기본 TTL은 120초(`mcp-trading/order-dedup.js:6`)로 사용자의 연타 클릭을 막기 위한 값입니다. 재빌드를 동반한 재배포는 보통 2분을 넘기므로 TTL이 이미 만료된 뒤라, 원장을 영속화해도 재배포 사이의 중복 주문까지는 막지 못합니다. 배포 창 전체를 덮으려면 `KIS_ORDER_DEDUP_TTL_MS`를 상향 조정하세요.
+
+원장 파일에는 주문 요청 body와 KIS 응답이 그대로 저장되며, 여기에는 계좌번호(`CANO`, `mcp-trading/order.js:81-82`)가 평문으로 포함됩니다. 생성 시 파일 권한이 `0600`(`mcp-trading/order-dedup.js:121`)으로 지정되지만 이는 Linux 호스트에서만 의미가 있고, 어느 경우든 호스트 파일시스템에 그대로 남는다는 점을 유의하세요.
+
 ### Telegram 긴급 알림 수동 테스트
 
 Docker Compose가 실행 중이고 `.env`에 `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`가 설정되어 있으면 backend 컨테이너에서 테스트 알림을 보낼 수 있습니다.

--- a/backend/config.py
+++ b/backend/config.py
@@ -56,6 +56,15 @@ _MCP_ENV_ALLOWED_KEYS = {
     "KIS_API_SECRET",
     "KIS_ACCOUNT_NO",
     "KIS_URL",
+    # 주문 멱등 원장(mcp-trading/order-dedup.js:50-51) 설정.
+    # Docker 이미지의 mcp-trading은 /opt/mcp-trading에 있고 .dockerignore가 .env를 배제하므로
+    # mcp-trading/index.js:34의 dotenv가 루트 .env를 읽지 못한다. 이 두 키를 자식 프로세스로
+    # 전달해야 원장 경로 재정의가 실제로 적용된다.
+    # KIS_REAL_ORDER_ENABLED는 의도적으로 제외한다 — 추가하면 Docker에서 실계좌 주문
+    # 가드(mcp-trading/order.js:56-61)에 사용자 .env 값이 반영되기 시작하므로,
+    # 전용 이슈·리뷰를 거쳐야 한다.
+    "KIS_ORDER_DEDUP_PATH",
+    "KIS_ORDER_DEDUP_TTL_MS",
     "NAVER_CLIENT_ID",
     "NAVER_CLIENT_SECRET",
     "DART_API_KEY",

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -29,6 +29,16 @@ def test_mcp_stdio_params_do_not_pass_parent_only_secrets(monkeypatch):
     assert "OPENAI_API_KEY" not in params.env
 
 
+def test_mcp_stdio_params_pass_order_dedup_ledger_settings(monkeypatch):
+    monkeypatch.setenv("KIS_ORDER_DEDUP_PATH", "/var/lib/finus/kis-order-dedup.json")
+    monkeypatch.setenv("KIS_ORDER_DEDUP_TTL_MS", "120000")
+
+    params = _stdio_server_params(Path("/opt/mcp-trading"))
+
+    assert params.env["KIS_ORDER_DEDUP_PATH"] == "/var/lib/finus/kis-order-dedup.json"
+    assert params.env["KIS_ORDER_DEDUP_TTL_MS"] == "120000"
+
+
 def test_visualization_url_is_trimmed_and_trailing_slash_preserved(monkeypatch):
     monkeypatch.setenv("VISUALIZATION_URL", " https://finus-visual.example/portfolio/ ")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       TRADING_MCP_DIR: /opt/mcp-trading
       DART_MCP_DIR: /opt/mcp-dart
       REDIS_URL: redis://redis:6379/0
+      # 주문 멱등 원장(#124). `.:/app` bind mount 덕분에 호스트 ./.state/ 에 영속된다.
+      # 소스를 bind mount하지 않는 배포용 compose를 도입하면 named volume으로 전환할 것.
+      KIS_ORDER_DEDUP_PATH: ${KIS_ORDER_DEDUP_PATH:-/app/.state/kis-order-dedup.json}
     depends_on:
       finus-nat:
         condition: service_healthy

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -138,3 +138,35 @@ test("OrderDedupStore blocks duplicate reservations across separate instances sh
     DuplicateOrderError,
   );
 });
+
+// 이 테스트는 parsePositiveInteger()의 현재 동작(잘못된 값을 조용히 기본값으로
+// 대체)을 있는 그대로 문서화한다. 이 침묵하는 폴백은 바람직한 설계로 보증하는
+// 것이 아니라 별도 이슈로 추적 중이며, 이번 PR에서는 손대지 않는다.
+test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, silently falling back on invalid values", (t) => {
+  const originalEnvValue = process.env.KIS_ORDER_DEDUP_TTL_MS;
+  t.after(() => {
+    if (originalEnvValue === undefined) {
+      delete process.env.KIS_ORDER_DEDUP_TTL_MS;
+    } else {
+      process.env.KIS_ORDER_DEDUP_TTL_MS = originalEnvValue;
+    }
+  });
+
+  const DEFAULT_TTL_MS = 120_000;
+  const cases = [
+    ["600000", 600_000], // 유효한 값은 그대로 사용된다
+    ["600_000", DEFAULT_TTL_MS], // JS 숫자 구분자(_) 습관 - Number()는 이를 파싱하지 못함
+    ["10m", DEFAULT_TTL_MS], // 단위 접미사 오타
+    ["0", DEFAULT_TTL_MS], // <= 0 분기
+    ["-1", DEFAULT_TTL_MS], // <= 0 분기, 음수
+    ["60.5", DEFAULT_TTL_MS], // !Number.isInteger 분기
+  ];
+
+  for (const [envValue, expectedTtlMs] of cases) {
+    process.env.KIS_ORDER_DEDUP_TTL_MS = envValue;
+    assert.equal(new OrderDedupStore().ttlMs, expectedTtlMs, `env=${envValue}`);
+  }
+
+  delete process.env.KIS_ORDER_DEDUP_TTL_MS;
+  assert.equal(new OrderDedupStore().ttlMs, DEFAULT_TTL_MS, "env=unset");
+});

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -2,16 +2,27 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import {
   DuplicateOrderError,
   OrderDedupStore,
   createOrderDedupKey,
 } from "../order-dedup.js";
 
-function tempLedgerPath() {
-  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "finus-order-dedup-test-")), "ledger.json");
+const createdDirs = [];
+
+function tempLedgerPath(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "finus-order-dedup-test-"));
+  createdDirs.push(dir);
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return path.join(dir, "ledger.json");
 }
+
+after(() => {
+  for (const dir of createdDirs) {
+    assert.equal(fs.existsSync(dir), false, `임시 디렉터리가 정리되지 않았습니다: ${dir}`);
+  }
+});
 
 test("createOrderDedupKey normalizes equivalent order arguments", () => {
   const first = createOrderDedupKey({
@@ -52,9 +63,9 @@ test("createOrderDedupKey ignores original price for market orders", () => {
   );
 });
 
-test("OrderDedupStore blocks duplicate reservations before TTL expires", () => {
+test("OrderDedupStore blocks duplicate reservations before TTL expires", (t) => {
   const store = new OrderDedupStore({
-    filePath: tempLedgerPath(),
+    filePath: tempLedgerPath(t),
     ttlMs: 60_000,
     now: () => 1_000,
   });
@@ -67,10 +78,10 @@ test("OrderDedupStore blocks duplicate reservations before TTL expires", () => {
   );
 });
 
-test("OrderDedupStore allows reservation after TTL expires", () => {
+test("OrderDedupStore allows reservation after TTL expires", (t) => {
   let now = 1_000;
   const store = new OrderDedupStore({
-    filePath: tempLedgerPath(),
+    filePath: tempLedgerPath(t),
     ttlMs: 60_000,
     now: () => now,
   });
@@ -81,9 +92,9 @@ test("OrderDedupStore allows reservation after TTL expires", () => {
   assert.doesNotThrow(() => store.reserve("same-order", { stockCode: "005930" }));
 });
 
-test("OrderDedupStore releases failed reservations", () => {
+test("OrderDedupStore releases failed reservations", (t) => {
   const store = new OrderDedupStore({
-    filePath: tempLedgerPath(),
+    filePath: tempLedgerPath(t),
     ttlMs: 60_000,
     now: () => 1_000,
   });
@@ -115,8 +126,8 @@ test("OrderDedupStore resolves filePath from KIS_ORDER_DEDUP_PATH env var, falli
   );
 });
 
-test("OrderDedupStore blocks duplicate reservations across separate instances sharing a filePath", () => {
-  const filePath = tempLedgerPath();
+test("OrderDedupStore blocks duplicate reservations across separate instances sharing a filePath", (t) => {
+  const filePath = tempLedgerPath(t);
   const storeA = new OrderDedupStore({ filePath, ttlMs: 60_000, now: () => 1_000 });
   const storeB = new OrderDedupStore({ filePath, ttlMs: 60_000, now: () => 1_000 });
 

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -14,7 +14,7 @@ const createdDirs = [];
 function tempLedgerPath(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "finus-order-dedup-test-"));
   createdDirs.push(dir);
-  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 }));
   return path.join(dir, "ledger.json");
 }
 
@@ -152,6 +152,8 @@ test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, silent
     }
   });
 
+  const consoleError = t.mock.method(console, "error");
+
   const DEFAULT_TTL_MS = 120_000;
   const cases = [
     ["600000", 600_000], // 유효한 값은 그대로 사용된다
@@ -169,4 +171,10 @@ test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, silent
 
   delete process.env.KIS_ORDER_DEDUP_TTL_MS;
   assert.equal(new OrderDedupStore().ttlMs, DEFAULT_TTL_MS, "env=unset");
+
+  assert.equal(
+    consoleError.mock.callCount(),
+    0,
+    "잘못된 값에 대한 폴백은 조용히 처리되어야 합니다(console.error 호출 없음)",
+  );
 });

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -93,3 +93,37 @@ test("OrderDedupStore releases failed reservations", () => {
 
   assert.doesNotThrow(() => store.reserve("same-order", { stockCode: "005930" }));
 });
+
+test("OrderDedupStore resolves filePath from KIS_ORDER_DEDUP_PATH env var, falling back to os.tmpdir()", (t) => {
+  const originalEnvValue = process.env.KIS_ORDER_DEDUP_PATH;
+  t.after(() => {
+    if (originalEnvValue === undefined) {
+      delete process.env.KIS_ORDER_DEDUP_PATH;
+    } else {
+      process.env.KIS_ORDER_DEDUP_PATH = originalEnvValue;
+    }
+  });
+
+  const envPath = path.join(os.tmpdir(), "finus-order-dedup-env-override.json");
+  process.env.KIS_ORDER_DEDUP_PATH = envPath;
+  assert.equal(new OrderDedupStore().filePath, envPath);
+
+  delete process.env.KIS_ORDER_DEDUP_PATH;
+  assert.equal(
+    new OrderDedupStore().filePath,
+    path.join(os.tmpdir(), "finus-kis-order-dedup.json"),
+  );
+});
+
+test("OrderDedupStore blocks duplicate reservations across separate instances sharing a filePath", () => {
+  const filePath = tempLedgerPath();
+  const storeA = new OrderDedupStore({ filePath, ttlMs: 60_000, now: () => 1_000 });
+  const storeB = new OrderDedupStore({ filePath, ttlMs: 60_000, now: () => 1_000 });
+
+  storeA.reserve("same-order", { stockCode: "005930" });
+
+  assert.throws(
+    () => storeB.reserve("same-order", { stockCode: "005930" }),
+    DuplicateOrderError,
+  );
+});


### PR DESCRIPTION
## 📝 개요

`place_order` 중복 방지 원장이 `os.tmpdir()`에 저장되어 컨테이너 재생성 시 소실되던 문제를 수정합니다.

조사 과정에서 이슈 본문의 제안(볼륨 마운트 + `.env.example` 문서화)만으로는 **Docker 환경에서 원장 경로 재정의가 아예 적용되지 않는다**는 점을 확인했습니다.

- `backend/config.py:97-111` `_mcp_child_env()`가 화이트리스트로 stdio 자식 프로세스 env를 필터링하는데 `KIS_ORDER_DEDUP_PATH`·`KIS_ORDER_DEDUP_TTL_MS`가 목록에 없었습니다.
- `mcp-trading/index.js:34`의 dotenv는 `<mcp-trading>/../.env`를 읽는데, `backend/Dockerfile:20-23`이 mcp-trading을 `/opt/mcp-trading`으로 분리하고 `.dockerignore`가 `**/.env`를 배제하므로 컨테이너 안에서 `/opt/.env`는 존재하지 않습니다.

즉 이 화이트리스트가 자식 프로세스로 가는 유일한 통로였고, 이를 함께 열어야 수정이 실제로 동작합니다.

**영속화 방식**: named volume이 아니라 기존 `.:/app` 바인드 마운트 안의 `.state/`를 사용했습니다. `scripts/reset_clean.sh:29`가 `docker compose down -v --rmi local`을 실행하므로 named volume은 프로젝트 표준 리셋에 파괴되는 반면 `backend/finus.db`는 바인드 마운트라 살아남습니다. 가장 안전이 중요한 원장이 거래 이력 DB보다 취약해지는 내구성 역전을 피했습니다. `.state/`는 이미 저장소 관례입니다(`finus_nat/src/nat_finus_nat/agents.py:345`).

**범위 한계**: 이 PR은 원장의 영속화만 다룹니다. 영속화는 멱등성의 필요조건이지 충분조건이 아닙니다. 작업 중 확인한 잔여 결함은 후속 이슈로 분리했습니다(하단 참조).

## 🚀 변경 사항

- `backend/config.py`: `_MCP_ENV_ALLOWED_KEYS`에 `KIS_ORDER_DEDUP_PATH`·`KIS_ORDER_DEDUP_TTL_MS` 추가. 두 키가 stdio 자식 프로세스에 도달하지 않으면 원장 경로 재정의 자체가 불가능합니다. `KIS_REAL_ORDER_ENABLED`는 실계좌 주문 가드에 영향을 주므로 의도적으로 제외했습니다.
- `docker-compose.yml`: backend 서비스에 `KIS_ORDER_DEDUP_PATH: ${KIS_ORDER_DEDUP_PATH:-/app/.state/kis-order-dedup.json}` 추가. compose `environment:`가 `env_file:`을 덮어쓰므로, 하드코딩 대신 `${VAR:-default}` 보간을 써서 사용자의 `.env` 값이 조용히 무시되지 않도록 했습니다.
- `.dockerignore`: `**/.state` 추가. `backend/Dockerfile:39`의 `COPY . .`가 호스트 `./.state/`를 이미지 레이어에 굽는 것을 막습니다. 원장에는 계좌번호(`CANO`)가 평문으로 들어갑니다.
- `mcp-trading/tests/order-dedup.test.js`: 회귀 테스트 2건 추가 — (1) `KIS_ORDER_DEDUP_PATH` env 기반 경로 해석과 `os.tmpdir()` 폴백, (2) 같은 `filePath`를 공유하는 별개 인스턴스 간 중복 차단. (2)가 이 이슈의 수용 기준입니다. `backend/services.py:432`가 도구 호출마다 새 node 프로세스를 띄우므로 파일이 유일한 공유 상태입니다.
- `.env.example`: 두 환경변수를 주석 처리된 형태로 문서화. `backend/scripts/setup_env.py`의 `parse_env_lines`가 `#` 시작 줄을 그대로 통과시키므로, 실값으로 두면 초기 설정 CLI가 생성하는 `.env`에 실키로 들어갑니다. Docker에서는 컨테이너 내부 경로로 해석된다는 경고를 포함했습니다.
- `README.md`: `### 주문 멱등 원장 영속화` 소절 추가. 보장 범위와 함께 **한계**도 명시했습니다 — 기본 TTL 120초는 재빌드를 동반한 재배포(보통 2분 초과)를 덮지 못하므로, 영속화만으로 재배포 중 중복 주문이 막히지는 않습니다.

## 🔗 관련 이슈

- Closes #124
- Related to #72

## ✅ 체크리스트

- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요?

### 테스트

```
uv run --project backend pytest backend/tests/    # 195 passed, 2 skipped
cd mcp-trading && npm test                        # 35 passed, 0 failed
```

추가한 env 해석 테스트는 mutation 검증을 거쳤습니다. `mcp-trading/order-dedup.js:50`을 `filePath = DEFAULT_ORDER_DEDUP_PATH`(env 무시)로 바꾸면 해당 테스트가 실패하고, 원복하면 통과합니다.

**미검증**: 로컬에 docker가 없어 `docker compose config`와 실제 컨테이너 재생성 시나리오는 확인하지 못했습니다. compose YAML은 파서로만 검증했습니다.

### 후속 이슈

이 PR 범위 밖으로 분리한 항목입니다. 특히 두 번째 항목은 이 PR이 먼저 머지되어야 합니다.

- #128 — 원장의 락 없는 read-modify-write(TOCTOU)와 비원자적 쓰기
- #129 — Docker에서 `KIS_REAL_ORDER_ENABLED`가 자식 프로세스에 도달하지 않아 실계좌 주문이 항상 차단되는 문제 (**이 PR이 blocker입니다. #129를 먼저 머지하면 안 됩니다.**)
- #130 — `KIS_TOKEN_CACHE_PATH`·`FINUS_` 접두사가 화이트리스트에 없어 발생하는 동일 계열 결함
