### PR TITLE
fix: get_balance 연속조회 구현으로 보유 종목 누락 해소

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -81,7 +81,12 @@ def _default_catalyst_repo() -> SqliteCatalystEventRepo:
     return SqliteCatalystEventRepo(lambda: Session(engine))
 
 def extract_stocks_from_balance(balance_text: str) -> list[str]:
-    """mcp-trading의 get_balance 결과에서 종목명 리스트를 추출합니다."""
+    """mcp-trading의 get_balance 결과에서 종목명 리스트를 추출합니다.
+
+    [보유 종목 리스트] 섹션 이후 "- "로 시작하는 모든 줄을 종목으로 해석하므로,
+    mcp-trading/balance.js의 formatTruncationNote가 그 섹션 뒤에 덧붙이는 잘림
+    안내 문구는 "- "로 시작해서는 안 된다.
+    """
     stocks = []
     if "[보유 종목 리스트]" in balance_text:
         lines = balance_text.split("[보유 종목 리스트]")[1].strip().split("\n")

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -58,6 +58,10 @@ export async function fetchAllBalance(fetchPage, {
   let pages = 0;
   let truncated = null;
   const startedAt = now();
+  // 지금까지 받아본 연속조회 커서 전체를 기억해 둔다. 직전 값하고만 비교하면
+  // A,B,A,B처럼 주기 2 이상으로 순환하는 커서를 놓치고 상한(20회)까지 같은
+  // 종목을 계속 중복 조회하게 된다.
+  const seenCursors = new Set();
 
   while (true) {
     if (pages >= maxPages) {
@@ -69,9 +73,10 @@ export async function fetchAllBalance(fetchPage, {
       break;
     }
 
-    // fetchPage에 이번에 넘긴 커서를 기억해 둔다. 응답이 이 값을 그대로 되돌려주면
-    // (repeated_cursor 가드) 같은 페이지가 반복 조회되고 있다는 뜻이다.
-    const sentNk = ctxNk;
+    // 이번 페이지의 행을 rows에 추가하기 전 길이를 기억해 둔다. 반복 커서가
+    // 감지되면 이번에 받은 페이지는 재조회(같은 페이지 재수신)이므로, 방금
+    // 추가한 행을 되돌려 rows에 중복이 남지 않게 한다.
+    const rowsBeforePage = rows.length;
 
     let body;
     let respTrCont;
@@ -122,14 +127,17 @@ export async function fetchAllBalance(fetchPage, {
       truncated = "no_cursor";
       break;
     }
-    if (sentNk && ctxNk === sentNk) {
-      // 같은 커서를 되돌려받았다. 그대로 재요청하면 동일 페이지를 상한까지 반복 조회하고
-      // 리포트에 같은 종목이 여러 번 실릴 수 있다. pdno 기준 중복 제거는 하지 않는다 —
-      // KIS가 페이지마다 동일한 pdno를 돌려주는 경우(예: 시간 예산 테스트 픽스처)가 있어
-      // 서로 다른 실제 보유 종목을 하나로 합쳐버릴 위험이 있다. 대신 중단하고 알린다.
+    if (seenCursors.has(ctxNk)) {
+      // 이전에 이미 받았던 커서가 다시 왔다 = 이번 페이지는 예전에 받은 페이지의
+      // 재조회다. 그대로 두면 리포트에 같은 종목이 여러 번 실리므로, 방금 추가한
+      // 이번 페이지 행을 되돌려 중복을 남기지 않는다. pdno 기준 중복 제거는 하지
+      // 않는다 — KIS가 페이지마다 동일한 pdno를 돌려주는 경우(예: 시간 예산 테스트
+      // 픽스처)가 있어 서로 다른 실제 보유 종목을 하나로 합쳐버릴 위험이 있다.
+      rows.length = rowsBeforePage;
       truncated = "repeated_cursor";
       break;
     }
+    seenCursors.add(ctxNk);
     trCont = "N";
   }
 

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -122,7 +122,13 @@ export async function fetchAllBalance(fetchPage, {
       truncated = "no_cursor";
       break;
     }
-    if (seenCursors.has(ctxNk)) {
+    // 다음 요청에 실리는 커서는 FK/NK 쌍이므로(buildBalanceParams가 둘 다 내보낸다)
+    // 쌍 전체를 키로 삼는다. NK만 같고 FK가 다르면 서로 다른 요청이라 반복이 아닌데,
+    // NK만 보면 조기 중단해 이 함수가 없애려는 조용한 누락을 만든다.
+    // 구분자는 커서 값에 나타날 수 없는 NUL을 쓴다. 공백을 쓰면
+    // ("A B","C")와 ("A","B C")가 같은 키가 된다.
+    const cursorKey = `${ctxFk}\u0000${ctxNk}`;
+    if (seenCursors.has(cursorKey)) {
       // 이전에 이미 받았던 커서가 다시 왔다 = 다음 조회에 보낼 커서가 예전에
       // 보냈던 커서와 같다. 즉 반복되는 것은 "다음에 받을 페이지"이지 방금
       // 받은 이 페이지가 아니다 — 방금 받은 페이지는 이번에 처음 그 커서로
@@ -137,7 +143,7 @@ export async function fetchAllBalance(fetchPage, {
       truncated = "repeated_cursor";
       break;
     }
-    seenCursors.add(ctxNk);
+    seenCursors.add(cursorKey);
     trCont = "N";
   }
 

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -84,6 +84,13 @@ export async function fetchAllBalance(fetchPage, {
       // 2페이지 이후 실패는 이미 확보한 페이지를 버리지 않고 부분 결과 + 잘림 표시로 반환한다.
       // (누락 방지가 목적인데 일시적 오류 1회로 잔고 전체가 사라지면 방향이 반대다.)
       if (pages === 0) throw error;
+      // balance.js는 MCP 서버에 import되어 stdout이 JSON-RPC 채널로 쓰인다. 여기서
+      // console.log를 쓰면 프로토콜이 깨지므로 반드시 console.error(stderr)만 사용한다.
+      // error 객체 전체나 error.config/error.response는 절대 남기지 않는다 — axios가
+      // config.params(CANO 계좌번호)와 config.headers(appkey, appsecret,
+      // authorization: Bearer 토큰)를 그대로 들고 있어 그대로 로그를 남기면 인증정보가
+      // 노출된다. message만 남긴다.
+      console.error(`잔고 연속조회 ${pages + 1}페이지 조회 실패: ${error.message}`);
       truncated = "error";
       break;
     }

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -93,8 +93,11 @@ export async function fetchAllBalance(fetchPage, {
       if (candidate) summary = candidate;
     }
 
-    ctxFk = body.ctx_area_fk100 || "";
-    ctxNk = body.ctx_area_nk100 || "";
+    // KIS는 ctx_area_* 필드를 고정폭으로 반환해 값이 없을 때 빈 문자열 대신
+    // 공백으로 채워진 문자열("          ")을 줄 수 있다. 공백 문자열은 truthy라
+    // trim 없이 두면 아래 !ctxNk 가드를 통과해 버려 같은 페이지를 재요청하게 된다.
+    ctxFk = String(body.ctx_area_fk100 ?? "").trim();
+    ctxNk = String(body.ctx_area_nk100 ?? "").trim();
     pages += 1;
 
     if (!isContinuationTrCont(respTrCont)) {

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -67,6 +67,10 @@ export async function fetchAllBalance(fetchPage, {
       break;
     }
 
+    // fetchPage에 이번에 넘긴 커서를 기억해 둔다. 응답이 이 값을 그대로 되돌려주면
+    // (repeated_cursor 가드) 같은 페이지가 반복 조회되고 있다는 뜻이다.
+    const sentNk = ctxNk;
+
     let body;
     let respTrCont;
     try {
@@ -107,6 +111,14 @@ export async function fetchAllBalance(fetchPage, {
       // 연속 신호는 왔는데 이어받을 커서가 없다. 그대로 재요청하면 KIS가 초기 조회로 해석해
       // 같은 페이지를 상한까지 반복 조회한다. 중단하되 누락 가능성은 알린다.
       truncated = "no_cursor";
+      break;
+    }
+    if (sentNk && ctxNk === sentNk) {
+      // 같은 커서를 되돌려받았다. 그대로 재요청하면 동일 페이지를 상한까지 반복 조회하고
+      // 리포트에 같은 종목이 여러 번 실릴 수 있다. pdno 기준 중복 제거는 하지 않는다 —
+      // KIS가 페이지마다 동일한 pdno를 돌려주는 경우(예: 시간 예산 테스트 픽스처)가 있어
+      // 서로 다른 실제 보유 종목을 하나로 합쳐버릴 위험이 있다. 대신 중단하고 알린다.
+      truncated = "repeated_cursor";
       break;
     }
     trCont = "N";
@@ -197,6 +209,7 @@ function formatTruncationNote(truncated, pages) {
     max_pages: `페이지 상한(${pages}회)을 초과하여`,
     time_budget: "조회 시간 예산을 초과하여",
     no_cursor: "연속조회 커서가 오지 않아",
+    repeated_cursor: "동일한 연속조회 커서가 반복되어",
     error: "연속조회 중 오류가 발생하여",
   };
   const reason = reasons[truncated] || "연속조회가 완료되지 않아";

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -3,11 +3,13 @@
 // 이 값은 KIS가 tr_cont를 계속 "F"/"M"으로 응답하는 이상 상황에 대한 2차 안전장치다.
 export const BALANCE_MAX_PAGES = 20;
 
-// get_balance 전체 호출은 backend의 run_mcp_tool이 30초에서 끊는다(backend/services.py:447).
+// get_balance 전체 호출은 backend의 run_mcp_tool(backend/services.py)이 30초에서 끊는다.
 // 여기에 MCP stdio 서브프로세스 기동/핸드셰이크(수백 ms~1초대)와, 예산 초과 판정 이후에도
-// 이미 시작된 요청 1회가 kisAxios의 8초 타임아웃(mcp-trading/index.js:72)만큼 더 걸릴 수 있는
-// 여유를 더해야 한다. 15초 예산 + 최대 8초 초과분 + 기동 오버헤드(~1-2초)로 상위 30초 한도
-// 안에 안전하게 들어오도록 잡았다.
+// 이미 시작된 요청 1회가 kisAxios 인스턴스(mcp-trading/index.js)의 8초 타임아웃만큼 더 걸릴
+// 수 있는 여유를 더해야 한다. getAccessToken()의 토큰 발급 요청은 fetchPage(index.js의
+// kisApiGet) 내부에서 일어나고, startedAt은 아래 루프 진입 전에 기록되므로 토큰 발급 시간도
+// 이미 이 15초 예산 측정 구간 안에 포함된다 — 별도로 더 얹을 필요가 없다. 15초 예산 + 최대
+// 8초 초과분 + 기동 오버헤드(~1-2초)로 상위 30초 한도 안에 안전하게 들어오도록 잡았다.
 export const BALANCE_TIME_BUDGET_MS = 15_000;
 
 function isContinuationTrCont(value) {
@@ -41,7 +43,7 @@ export function buildBalanceParams(accountNo, { ctxAreaFk100 = "", ctxAreaNk100 
  *   - trCont: 응답 tr_cont 헤더 값
  *
  * 반환: { rows, summary, pages, truncated }
- *   - truncated: null | "max_pages" | "time_budget"
+ *   - truncated: null | "max_pages" | "time_budget" | "no_cursor" | "repeated_cursor" | "error"
  */
 export async function fetchAllBalance(fetchPage, {
   maxPages = BALANCE_MAX_PAGES,
@@ -213,7 +215,7 @@ function calculateAccountReturnRate(summary, holdings) {
 function formatTruncationNote(truncated, pages) {
   if (!truncated) return "";
   const reasons = {
-    max_pages: `페이지 상한(${pages}회)을 초과하여`,
+    max_pages: `페이지 상한(${pages}회)에 도달하여`,
     time_budget: "조회 시간 예산을 초과하여",
     no_cursor: "연속조회 커서가 오지 않아",
     repeated_cursor: "동일한 연속조회 커서가 반복되어",

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -73,11 +73,6 @@ export async function fetchAllBalance(fetchPage, {
       break;
     }
 
-    // 이번 페이지의 행을 rows에 추가하기 전 길이를 기억해 둔다. 반복 커서가
-    // 감지되면 이번에 받은 페이지는 재조회(같은 페이지 재수신)이므로, 방금
-    // 추가한 행을 되돌려 rows에 중복이 남지 않게 한다.
-    const rowsBeforePage = rows.length;
-
     let body;
     let respTrCont;
     try {
@@ -128,12 +123,17 @@ export async function fetchAllBalance(fetchPage, {
       break;
     }
     if (seenCursors.has(ctxNk)) {
-      // 이전에 이미 받았던 커서가 다시 왔다 = 이번 페이지는 예전에 받은 페이지의
-      // 재조회다. 그대로 두면 리포트에 같은 종목이 여러 번 실리므로, 방금 추가한
-      // 이번 페이지 행을 되돌려 중복을 남기지 않는다. pdno 기준 중복 제거는 하지
-      // 않는다 — KIS가 페이지마다 동일한 pdno를 돌려주는 경우(예: 시간 예산 테스트
-      // 픽스처)가 있어 서로 다른 실제 보유 종목을 하나로 합쳐버릴 위험이 있다.
-      rows.length = rowsBeforePage;
+      // 이전에 이미 받았던 커서가 다시 왔다 = 다음 조회에 보낼 커서가 예전에
+      // 보냈던 커서와 같다. 즉 반복되는 것은 "다음에 받을 페이지"이지 방금
+      // 받은 이 페이지가 아니다 — 방금 받은 페이지는 이번에 처음 그 커서로
+      // 조회해서 받은 실제 신규 데이터이므로 rows에 남겨야 한다. 다음 조회를
+      // 계속하면 그 페이지가 재조회가 되므로, 그 전에 멈춘다. pdno 기준 중복
+      // 제거는 하지 않는다 — 행별 pdno가 유일하다는 전제는 buildBalanceParams가
+      // INQR_DVSN을 항상 "02"(종목별)로 고정하기 때문에만 성립한다. "01"
+      // (대출일별) 조회라면 같은 pdno가 여러 행에 정당하게 걸쳐 나타날 수 있어,
+      // 행 단위 dedup은 서로 다른 실제 보유 종목을 하나로 합쳐버리게 된다.
+      // 혹시라도 진짜 중복 행이 들어오는 경우가 있더라도, 조용히 종목을
+      // 빠뜨리는 것보다는 [안내] 잘림 표시와 함께 과다 집계되는 쪽이 낫다.
       truncated = "repeated_cursor";
       break;
     }

--- a/mcp-trading/balance.js
+++ b/mcp-trading/balance.js
@@ -1,4 +1,22 @@
-export function buildBalanceParams(accountNo) {
+// 연속조회 페이지 상한. inquire-balance-rlz-pl 등 다른 조회의 BALANCE_RLZ_PL_MAX_PAGES(mcp-trading/index.js)
+// 명명 관례를 따른다. 실제로는 아래 BALANCE_TIME_BUDGET_MS가 먼저 걸리는 경우가 대부분이며,
+// 이 값은 KIS가 tr_cont를 계속 "F"/"M"으로 응답하는 이상 상황에 대한 2차 안전장치다.
+export const BALANCE_MAX_PAGES = 20;
+
+// get_balance 전체 호출은 backend의 run_mcp_tool이 30초에서 끊는다(backend/services.py:447).
+// 여기에 MCP stdio 서브프로세스 기동/핸드셰이크(수백 ms~1초대)와, 예산 초과 판정 이후에도
+// 이미 시작된 요청 1회가 kisAxios의 8초 타임아웃(mcp-trading/index.js:72)만큼 더 걸릴 수 있는
+// 여유를 더해야 한다. 15초 예산 + 최대 8초 초과분 + 기동 오버헤드(~1-2초)로 상위 30초 한도
+// 안에 안전하게 들어오도록 잡았다.
+export const BALANCE_TIME_BUDGET_MS = 15_000;
+
+function isContinuationTrCont(value) {
+  // index.js의 isKisContinueTrCont()와 동일한 KIS tr_cont 연속조회 판정을 balance.js에서도
+  // 그대로 사용하기 위한 로컬 사본이다 (index.js는 부작용을 가진 서버 진입점이라 여기서 import하지 않는다).
+  return value === "F" || value === "M";
+}
+
+export function buildBalanceParams(accountNo, { ctxAreaFk100 = "", ctxAreaNk100 = "" } = {}) {
   return {
     CANO: accountNo.substring(0, 8),
     ACNT_PRDT_CD: accountNo.substring(8, 10),
@@ -9,9 +27,89 @@ export function buildBalanceParams(accountNo) {
     FUND_STTL_ICLD_YN: "N",
     FNCG_AMT_AUTO_RDPT_YN: "N",
     PRCS_DVSN: "00",
-    CTX_AREA_FK100: "",
-    CTX_AREA_NK100: "",
+    CTX_AREA_FK100: ctxAreaFk100,
+    CTX_AREA_NK100: ctxAreaNk100,
   };
+}
+
+/**
+ * inquire-balance 연속조회 루프. KIS 호출 자체는 fetchPage로 주입받아
+ * (index.js의 kisApiGet 등) balance.js 단독으로 유닛 테스트할 수 있게 한다.
+ *
+ * fetchPage({ ctxAreaFk100, ctxAreaNk100, trCont }) => Promise<{ body, trCont }>
+ *   - body: KIS 응답 바디 (output1/output2/ctx_area_fk100/ctx_area_nk100 포함)
+ *   - trCont: 응답 tr_cont 헤더 값
+ *
+ * 반환: { rows, summary, pages, truncated }
+ *   - truncated: null | "max_pages" | "time_budget"
+ */
+export async function fetchAllBalance(fetchPage, {
+  maxPages = BALANCE_MAX_PAGES,
+  timeBudgetMs = BALANCE_TIME_BUDGET_MS,
+  now = () => Date.now(),
+} = {}) {
+  const rows = [];
+  let summary = null;
+  let trCont = "";
+  let ctxFk = "";
+  let ctxNk = "";
+  let pages = 0;
+  let truncated = null;
+  const startedAt = now();
+
+  while (true) {
+    if (pages >= maxPages) {
+      truncated = "max_pages";
+      break;
+    }
+    if (pages > 0 && now() - startedAt >= timeBudgetMs) {
+      truncated = "time_budget";
+      break;
+    }
+
+    let body;
+    let respTrCont;
+    try {
+      ({ body, trCont: respTrCont } = await fetchPage({
+        ctxAreaFk100: ctxFk,
+        ctxAreaNk100: ctxNk,
+        trCont,
+      }));
+    } catch (error) {
+      // 첫 페이지 실패는 인증·계좌 설정 오류일 수 있어 원인을 숨기지 않고 그대로 전파한다.
+      // 2페이지 이후 실패는 이미 확보한 페이지를 버리지 않고 부분 결과 + 잘림 표시로 반환한다.
+      // (누락 방지가 목적인데 일시적 오류 1회로 잔고 전체가 사라지면 방향이 반대다.)
+      if (pages === 0) throw error;
+      truncated = "error";
+      break;
+    }
+
+    const pageRows = Array.isArray(body.output1) ? body.output1 : [];
+    rows.push(...pageRows);
+    if (!summary) {
+      // index.js의 fetchAllBalanceRlzPl과 동일하게 단일 객체로 정규화한다.
+      // 빈 배열/undefined면 summary를 확정하지 않아, 요약이 뒤 페이지에 오는 경우를 놓치지 않는다.
+      const candidate = Array.isArray(body.output2) ? body.output2[0] : body.output2;
+      if (candidate) summary = candidate;
+    }
+
+    ctxFk = body.ctx_area_fk100 || "";
+    ctxNk = body.ctx_area_nk100 || "";
+    pages += 1;
+
+    if (!isContinuationTrCont(respTrCont)) {
+      break;
+    }
+    if (!ctxNk) {
+      // 연속 신호는 왔는데 이어받을 커서가 없다. 그대로 재요청하면 KIS가 초기 조회로 해석해
+      // 같은 페이지를 상한까지 반복 조회한다. 중단하되 누락 가능성은 알린다.
+      truncated = "no_cursor";
+      break;
+    }
+    trCont = "N";
+  }
+
+  return { rows, summary, pages, truncated };
 }
 
 export function formatPercent(value) {
@@ -87,7 +185,22 @@ function calculateAccountReturnRate(summary, holdings) {
   return summary.evlu_pfls_rt || summary.asst_icdc_erng_rt;
 }
 
-export function formatBalanceReport(data) {
+// 잘림 안내 문구. 주의: "- "로 시작하면 backend/scheduler.py의 extract_stocks_from_balance()가
+// [보유 종목 리스트] 섹션의 "- "로 시작하는 줄을 종목명으로 오인식한다. 이 문구는 반드시
+// "- " 없이, [보유 종목 리스트] 섹션이 끝난 뒤 별도 문단으로만 붙여야 한다.
+function formatTruncationNote(truncated, pages) {
+  if (!truncated) return "";
+  const reasons = {
+    max_pages: `페이지 상한(${pages}회)을 초과하여`,
+    time_budget: "조회 시간 예산을 초과하여",
+    no_cursor: "연속조회 커서가 오지 않아",
+    error: "연속조회 중 오류가 발생하여",
+  };
+  const reason = reasons[truncated] || "연속조회가 완료되지 않아";
+  return `\n\n[안내] ${reason} 조회가 중단되어 일부 보유 종목이 위 목록에서 누락되었을 수 있습니다. 실제 잔고는 별도로 확인하세요.`;
+}
+
+export function formatBalanceReport(data, { pages, truncated } = {}) {
   const summary = data.output2?.[0] || {};
   const holdings = data.output1 || [];
 
@@ -115,6 +228,6 @@ export function formatBalanceReport(data) {
 - 금일 매수/매도: ${formatAmount(summary.thdt_buy_amt)} / ${formatAmount(summary.thdt_sll_amt)}
 
 [보유 종목 리스트]
-${stockList || "보유 종목이 없습니다."}
+${stockList || "보유 종목이 없습니다."}${formatTruncationNote(truncated, pages)}
   `.trim();
 }

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -9,7 +9,7 @@ import axios from "axios";
 import dotenv from "dotenv";
 import { z } from "zod";
 import { formatBalanceRlzPlReport } from "./balance-rlz-pl-report.js";
-import { buildBalanceParams, formatBalanceReport } from "./balance.js";
+import { buildBalanceParams, fetchAllBalance, formatBalanceReport } from "./balance.js";
 import {
   formatPercent,
   formatQuantity,
@@ -307,13 +307,19 @@ ${lines.join("\n")}
 async function getBalance() {
   requireKisCredentials({ accountRequired: true });
 
-  const data = await kisGet(
-    "/uapi/domestic-stock/v1/trading/inquire-balance",
-    KIS_BALANCE_TR_ID,
-    buildBalanceParams(KIS_ACCOUNT_NO),
+  const { rows, summary, pages, truncated } = await fetchAllBalance(
+    ({ ctxAreaFk100, ctxAreaNk100, trCont }) => kisApiGet(
+      "/uapi/domestic-stock/v1/trading/inquire-balance",
+      KIS_BALANCE_TR_ID,
+      buildBalanceParams(KIS_ACCOUNT_NO, { ctxAreaFk100, ctxAreaNk100 }),
+      { trCont },
+    ),
   );
 
-  return formatBalanceReport(data);
+  return formatBalanceReport(
+    { output1: rows, output2: summary ? [summary] : [] },
+    { pages, truncated },
+  );
 }
 
 async function placeOrder(args) {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -329,16 +329,16 @@ test('fetchAllBalance stops after two calls and reports truncated="no_cursor" wh
   assert.deepEqual(calls[1], { ctxAreaFk100: "FK1", ctxAreaNk100: "NK1", trCont: "N" });
 });
 
-test('fetchAllBalance stops after two calls and reports truncated="repeated_cursor" when KIS echoes back the same continuation cursor instead of advancing, discarding the duplicated page\'s rows', async () => {
+test('fetchAllBalance stops after two calls and reports truncated="repeated_cursor" when KIS echoes back the same continuation cursor instead of advancing, keeping both pages\' rows', async () => {
   let calls = 0;
   const fetchPage = async () => {
     calls += 1;
     return {
       body: {
-        // Both "pages" are in fact the same page re-sent by KIS (same cursor echoed back),
-        // so they carry the same holding. If the duplicate page's rows were kept, this
-        // holding would appear twice in the report and double-count the purchase amount.
-        output1: [{ prdt_name: "종목1", pdno: "000000" }],
+        // Both calls echo back the same cursor ("NK1"), so the third call would repeat
+        // page 2. Page 2 itself was fetched with a cursor never sent before, so it is a
+        // genuinely new page — its distinct holding must survive the truncation.
+        output1: [{ prdt_name: `종목${calls}`, pdno: calls === 1 ? "000000" : "000001" }],
         output2: calls === 1 ? [{ tot_evlu_amt: "1" }] : [],
         ctx_area_fk100: "FK1",
         ctx_area_nk100: "NK1",
@@ -352,7 +352,7 @@ test('fetchAllBalance stops after two calls and reports truncated="repeated_curs
   assert.equal(calls, 2);
   assert.equal(result.pages, 2);
   assert.equal(result.truncated, "repeated_cursor");
-  assert.deepEqual(result.rows.map((row) => row.pdno), ["000000"]);
+  assert.deepEqual(result.rows.map((row) => row.pdno), ["000000", "000001"]);
 });
 
 test('fetchAllBalance detects a period-2 repeated-cursor cycle (A,B,A) that a previous-value-only comparison would miss', async () => {
@@ -376,7 +376,7 @@ test('fetchAllBalance detects a period-2 repeated-cursor cycle (A,B,A) that a pr
 
   assert.equal(calls, 3);
   assert.equal(result.truncated, "repeated_cursor");
-  assert.deepEqual(result.rows.map((row) => row.pdno), ["000001", "000002"]);
+  assert.deepEqual(result.rows.map((row) => row.pdno), ["000001", "000002", "000003"]);
 });
 
 test("fetchAllBalance rethrows when the first page fetch fails, so auth/account errors are not swallowed", async () => {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -328,6 +328,32 @@ test('fetchAllBalance stops after two calls and reports truncated="no_cursor" wh
   assert.deepEqual(calls[1], { ctxAreaFk100: "FK1", ctxAreaNk100: "NK1", trCont: "N" });
 });
 
+test('fetchAllBalance stops after two calls and reports truncated="repeated_cursor" when KIS echoes back the same continuation cursor instead of advancing, without dropping either page\'s rows', async () => {
+  let calls = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    return {
+      body: {
+        // Both pages return the same pdno, mirroring the time-budget fixture below. A
+        // pdno-keyed dedup would silently collapse these two distinct holdings into one;
+        // this test asserts nothing is dropped.
+        output1: [{ prdt_name: `종목${calls}`, pdno: "000000" }],
+        output2: calls === 1 ? [{ tot_evlu_amt: "1" }] : [],
+        ctx_area_fk100: "FK1",
+        ctx_area_nk100: "NK1",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllBalance(fetchPage, { maxPages: 20, timeBudgetMs: 60_000 });
+
+  assert.equal(calls, 2);
+  assert.equal(result.pages, 2);
+  assert.equal(result.truncated, "repeated_cursor");
+  assert.equal(result.rows.length, 2);
+});
+
 test("fetchAllBalance rethrows when the first page fetch fails, so auth/account errors are not swallowed", async () => {
   const authError = new Error("EGW00123 인증 오류");
   const fetchPage = async () => {
@@ -401,8 +427,8 @@ test("formatBalanceReport's truncation note stays outside the holdings section s
   assert.ok(stockLines.every((line) => !line.includes("안내") && !line.includes("상한")));
 });
 
-test("formatBalanceReport's no_cursor and error truncation notes also stay outside the holdings section", () => {
-  for (const truncated of ["no_cursor", "error"]) {
+test("formatBalanceReport's no_cursor, error, and repeated_cursor truncation notes also stay outside the holdings section", () => {
+  for (const truncated of ["no_cursor", "error", "repeated_cursor"]) {
     const text = formatBalanceReport(
       {
         output1: [

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import util from "node:util";
 import { buildBalanceParams, fetchAllBalance, formatBalanceReport, formatPercent } from "../balance.js";
 import {
   buildCashOrderBody,
@@ -425,10 +426,10 @@ test("fetchAllBalance logs only the error message and failing page number to std
 
   await fetchAllBalance(fetchPage);
 
-  const logged = errorMock.mock.calls.map((call) => call.arguments.join(" ")).join("\n");
+  const logged = errorMock.mock.calls.map((call) => util.format(...call.arguments)).join("\n");
 
   assert.match(logged, /초당 거래건수를 초과하였습니다\./);
-  assert.match(logged, /2/); // the failing page number (pages=1 completed, so page 2 failed)
+  assert.match(logged, /2페이지/); // the failing page number (pages=1 completed, so page 2 failed)
   assert.doesNotMatch(logged, /87654321/);
   assert.doesNotMatch(logged, /test-app-key-secret/);
   assert.doesNotMatch(logged, /test-app-secret-value/);

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildBalanceParams, formatBalanceReport, formatPercent } from "../balance.js";
+import { buildBalanceParams, fetchAllBalance, formatBalanceReport, formatPercent } from "../balance.js";
 import {
   buildCashOrderBody,
   createCashOrderRequest,
@@ -78,6 +78,319 @@ test("buildBalanceParams includes required KIS inquire-balance fields", () => {
     CTX_AREA_FK100: "",
     CTX_AREA_NK100: "",
   });
+});
+
+test("buildBalanceParams threads continuation context for pagination", () => {
+  assert.deepEqual(
+    buildBalanceParams("1234567801", { ctxAreaFk100: "FK1", ctxAreaNk100: "NK1" }),
+    {
+      CANO: "12345678",
+      ACNT_PRDT_CD: "01",
+      AFHR_FLPR_YN: "N",
+      OFL_YN: "",
+      INQR_DVSN: "02",
+      UNPR_DVSN: "01",
+      FUND_STTL_ICLD_YN: "N",
+      FNCG_AMT_AUTO_RDPT_YN: "N",
+      PRCS_DVSN: "00",
+      CTX_AREA_FK100: "FK1",
+      CTX_AREA_NK100: "NK1",
+    },
+  );
+});
+
+test("fetchAllBalance concatenates holdings across multiple continuation pages", async () => {
+  const pages = [
+    {
+      body: {
+        output1: [{ prdt_name: "삼성전자", pdno: "005930" }],
+        output2: [{ tot_evlu_amt: "1000000" }],
+        ctx_area_fk100: "FK1",
+        ctx_area_nk100: "NK1",
+      },
+      trCont: "F",
+    },
+    {
+      body: {
+        output1: [{ prdt_name: "NAVER", pdno: "035420" }],
+        output2: [],
+        ctx_area_fk100: "",
+        ctx_area_nk100: "",
+      },
+      trCont: "D",
+    },
+  ];
+
+  const calls = [];
+  let callIndex = 0;
+  const fetchPage = async ({ ctxAreaFk100, ctxAreaNk100, trCont }) => {
+    calls.push({ ctxAreaFk100, ctxAreaNk100, trCont });
+    const page = pages[callIndex];
+    callIndex += 1;
+    return { body: page.body, trCont: page.trCont };
+  };
+
+  const result = await fetchAllBalance(fetchPage);
+
+  assert.deepEqual(result.rows.map((row) => row.pdno), ["005930", "035420"]);
+  assert.equal(result.pages, 2);
+  assert.equal(result.truncated, null);
+  // first call has no continuation context yet; second call must carry the
+  // ctx_area values and tr_cont="N" returned from the first page.
+  assert.deepEqual(calls[0], { ctxAreaFk100: "", ctxAreaNk100: "", trCont: "" });
+  assert.deepEqual(calls[1], { ctxAreaFk100: "FK1", ctxAreaNk100: "NK1", trCont: "N" });
+});
+
+test("fetchAllBalance stops and reports truncation when the page cap is hit", async () => {
+  let calls = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    return {
+      body: {
+        output1: [{ prdt_name: `종목${calls}`, pdno: String(calls).padStart(6, "0") }],
+        output2: calls === 1 ? [{ tot_evlu_amt: "1" }] : [],
+        ctx_area_fk100: `FK${calls}`,
+        ctx_area_nk100: `NK${calls}`,
+      },
+      trCont: "F", // KIS keeps signaling "more pages available"
+    };
+  };
+
+  const result = await fetchAllBalance(fetchPage, { maxPages: 3, timeBudgetMs: 60_000 });
+
+  assert.equal(calls, 3);
+  assert.equal(result.pages, 3);
+  assert.equal(result.rows.length, 3);
+  assert.equal(result.truncated, "max_pages");
+});
+
+test("fetchAllBalance stops and reports truncation when the time budget is exceeded", async () => {
+  let calls = 0;
+  let clock = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    clock += 10_000; // simulate a slow 10s KIS response per page
+    return {
+      body: {
+        output1: [{ prdt_name: `종목${calls}`, pdno: "000000" }],
+        output2: [],
+        // 실제 연속조회처럼 매 페이지 커서를 돌려준다. 커서가 비면 no_cursor 가드가
+        // 먼저 걸려 시간 예산 경로를 타지 못한다.
+        ctx_area_fk100: `FK${calls}`,
+        ctx_area_nk100: `NK${calls}`,
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllBalance(fetchPage, {
+    maxPages: 50,
+    timeBudgetMs: 15_000,
+    now: () => clock,
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.pages, 2);
+  assert.equal(result.truncated, "time_budget");
+});
+
+test("fetchAllBalance does not latch summary onto an empty first-page output2, and picks up the real summary from a later page", async () => {
+  const pages = [
+    {
+      body: {
+        output1: [{ prdt_name: "삼성전자", pdno: "005930" }],
+        output2: [], // empty array is truthy in JS; a naive `!summary` check must not latch onto it
+        ctx_area_fk100: "FK1",
+        ctx_area_nk100: "NK1",
+      },
+      trCont: "F",
+    },
+    {
+      body: {
+        output1: [{ prdt_name: "NAVER", pdno: "035420" }],
+        output2: [{ tot_evlu_amt: "1000000" }],
+        ctx_area_fk100: "",
+        ctx_area_nk100: "",
+      },
+      trCont: "D",
+    },
+  ];
+
+  let callIndex = 0;
+  const fetchPage = async () => {
+    const page = pages[callIndex];
+    callIndex += 1;
+    return { body: page.body, trCont: page.trCont };
+  };
+
+  const result = await fetchAllBalance(fetchPage);
+
+  assert.deepEqual(result.summary, { tot_evlu_amt: "1000000" });
+});
+
+test("fetchAllBalance normalizes a non-array output2 object into summary, and formatBalanceReport renders it", async () => {
+  const fetchPage = async () => ({
+    body: {
+      output1: [],
+      output2: { tot_evlu_amt: "5000000" }, // KIS sometimes sends a bare object instead of a one-element array
+      ctx_area_fk100: "",
+      ctx_area_nk100: "",
+    },
+    trCont: "D",
+  });
+
+  const result = await fetchAllBalance(fetchPage);
+
+  assert.deepEqual(result.summary, { tot_evlu_amt: "5000000" });
+
+  // Reproduce index.js:319-321's wrapping of the raw summary before handing it to formatBalanceReport.
+  const text = formatBalanceReport(
+    { output1: result.rows, output2: result.summary ? [result.summary] : [] },
+    { pages: result.pages, truncated: result.truncated },
+  );
+
+  assert.match(text, /총 평가금액: 5,000,000원/);
+  assert.doesNotMatch(text, /총 평가금액: -\n/);
+});
+
+test('fetchAllBalance stops after two calls and reports truncated="no_cursor" when tr_cont keeps signaling more pages but sends no cursor', async () => {
+  let calls = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    if (calls === 1) {
+      return {
+        body: {
+          output1: [{ prdt_name: "삼성전자", pdno: "005930" }],
+          output2: [{ tot_evlu_amt: "1000000" }],
+          ctx_area_fk100: "FK1",
+          ctx_area_nk100: "NK1",
+        },
+        trCont: "F",
+      };
+    }
+    // Pathological case: KIS keeps signaling "more pages available" (tr_cont="F") but never
+    // sends a cursor to resume from. Blindly retrying would re-request the same page forever.
+    return {
+      body: {
+        output1: [{ prdt_name: `종목${calls}`, pdno: String(calls).padStart(6, "0") }],
+        output2: [],
+        ctx_area_fk100: "",
+        ctx_area_nk100: "",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllBalance(fetchPage, { maxPages: 20, timeBudgetMs: 60_000 });
+
+  assert.equal(calls, 2);
+  assert.equal(result.pages, 2);
+  assert.equal(result.truncated, "no_cursor");
+});
+
+test("fetchAllBalance rethrows when the first page fetch fails, so auth/account errors are not swallowed", async () => {
+  const authError = new Error("EGW00123 인증 오류");
+  const fetchPage = async () => {
+    throw authError;
+  };
+
+  await assert.rejects(() => fetchAllBalance(fetchPage), (err) => err === authError);
+});
+
+test('fetchAllBalance preserves already-fetched pages and reports truncated="error" when a later page fetch fails', async () => {
+  let calls = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    if (calls === 1) {
+      return {
+        body: {
+          output1: [{ prdt_name: "삼성전자", pdno: "005930" }],
+          output2: [{ tot_evlu_amt: "1000000" }],
+          ctx_area_fk100: "FK1",
+          ctx_area_nk100: "NK1",
+        },
+        trCont: "F",
+      };
+    }
+    throw new Error("일시적 네트워크 오류");
+  };
+
+  const result = await fetchAllBalance(fetchPage);
+
+  assert.equal(calls, 2);
+  assert.deepEqual(result.rows.map((row) => row.pdno), ["005930"]);
+  assert.equal(result.pages, 1);
+  assert.equal(result.truncated, "error");
+});
+
+test("formatBalanceReport omits the truncation note when the fetch was not truncated", () => {
+  const text = formatBalanceReport(
+    { output1: [], output2: [] },
+    { pages: 1, truncated: null },
+  );
+  assert.doesNotMatch(text, /\[안내\]/);
+});
+
+test("formatBalanceReport's truncation note stays outside the holdings section so scheduler parsing is not polluted", () => {
+  const text = formatBalanceReport(
+    {
+      output1: [
+        {
+          prdt_name: "삼성전자",
+          pdno: "005930",
+          hldg_qty: "3",
+          pchs_avg_pric: "67000",
+          evlu_amt: "210000",
+          evlu_pfls_amt: "9000",
+          evlu_pfls_rt: "4.48",
+        },
+      ],
+      output2: [{ tot_evlu_amt: "210000" }],
+    },
+    { pages: 20, truncated: "max_pages" },
+  );
+
+  assert.match(text, /\[안내\] 페이지 상한\(20회\)을 초과하여/);
+
+  // Mirror backend/scheduler.py's extract_stocks_from_balance(): everything after
+  // "[보유 종목 리스트]", split into lines, keep only lines starting with "- ".
+  const section = text.split("[보유 종목 리스트]")[1].trim();
+  const stockLines = section.split("\n").filter((line) => line.startsWith("- "));
+
+  assert.deepEqual(stockLines, ["- 삼성전자 (005930) · 3주"]);
+  assert.ok(stockLines.every((line) => !line.includes("안내") && !line.includes("상한")));
+});
+
+test("formatBalanceReport's no_cursor and error truncation notes also stay outside the holdings section", () => {
+  for (const truncated of ["no_cursor", "error"]) {
+    const text = formatBalanceReport(
+      {
+        output1: [
+          {
+            prdt_name: "삼성전자",
+            pdno: "005930",
+            hldg_qty: "3",
+            pchs_avg_pric: "67000",
+            evlu_amt: "210000",
+            evlu_pfls_amt: "9000",
+            evlu_pfls_rt: "4.48",
+          },
+        ],
+        output2: [{ tot_evlu_amt: "210000" }],
+      },
+      { pages: 2, truncated },
+    );
+
+    assert.match(text, /\[안내\]/);
+
+    // Mirror backend/scheduler.py's extract_stocks_from_balance(): everything after
+    // "[보유 종목 리스트]", split into lines, keep only lines starting with "- ".
+    const section = text.split("[보유 종목 리스트]")[1].trim();
+    const stockLines = section.split("\n").filter((line) => line.startsWith("- "));
+
+    assert.deepEqual(stockLines, ["- 삼성전자 (005930) · 3주"]);
+    assert.ok(stockLines.every((line) => !line.includes("안내")));
+  }
 });
 
 test("formatPercent avoids undefined balance rates", () => {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -329,16 +329,16 @@ test('fetchAllBalance stops after two calls and reports truncated="no_cursor" wh
   assert.deepEqual(calls[1], { ctxAreaFk100: "FK1", ctxAreaNk100: "NK1", trCont: "N" });
 });
 
-test('fetchAllBalance stops after two calls and reports truncated="repeated_cursor" when KIS echoes back the same continuation cursor instead of advancing, without dropping either page\'s rows', async () => {
+test('fetchAllBalance stops after two calls and reports truncated="repeated_cursor" when KIS echoes back the same continuation cursor instead of advancing, discarding the duplicated page\'s rows', async () => {
   let calls = 0;
   const fetchPage = async () => {
     calls += 1;
     return {
       body: {
-        // Both pages return the same pdno, mirroring the time-budget fixture below. A
-        // pdno-keyed dedup would silently collapse these two distinct holdings into one;
-        // this test asserts nothing is dropped.
-        output1: [{ prdt_name: `종목${calls}`, pdno: "000000" }],
+        // Both "pages" are in fact the same page re-sent by KIS (same cursor echoed back),
+        // so they carry the same holding. If the duplicate page's rows were kept, this
+        // holding would appear twice in the report and double-count the purchase amount.
+        output1: [{ prdt_name: "종목1", pdno: "000000" }],
         output2: calls === 1 ? [{ tot_evlu_amt: "1" }] : [],
         ctx_area_fk100: "FK1",
         ctx_area_nk100: "NK1",
@@ -352,7 +352,31 @@ test('fetchAllBalance stops after two calls and reports truncated="repeated_curs
   assert.equal(calls, 2);
   assert.equal(result.pages, 2);
   assert.equal(result.truncated, "repeated_cursor");
-  assert.equal(result.rows.length, 2);
+  assert.deepEqual(result.rows.map((row) => row.pdno), ["000000"]);
+});
+
+test('fetchAllBalance detects a period-2 repeated-cursor cycle (A,B,A) that a previous-value-only comparison would miss', async () => {
+  const cursors = ["A", "B", "A"];
+  let calls = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    const cursor = cursors[calls - 1];
+    return {
+      body: {
+        output1: [{ prdt_name: `종목${calls}`, pdno: String(calls).padStart(6, "0") }],
+        output2: calls === 1 ? [{ tot_evlu_amt: "1" }] : [],
+        ctx_area_fk100: `FK-${cursor}`,
+        ctx_area_nk100: cursor,
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllBalance(fetchPage, { maxPages: 20, timeBudgetMs: 60_000 });
+
+  assert.equal(calls, 3);
+  assert.equal(result.truncated, "repeated_cursor");
+  assert.deepEqual(result.rows.map((row) => row.pdno), ["000001", "000002"]);
 });
 
 test("fetchAllBalance rethrows when the first page fetch fails, so auth/account errors are not swallowed", async () => {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -389,6 +389,53 @@ test('fetchAllBalance preserves already-fetched pages and reports truncated="err
   assert.equal(result.truncated, "error");
 });
 
+test("fetchAllBalance logs only the error message and failing page number to stderr on a swallowed continuation error, never the account number, app key, secret, or bearer token", async (t) => {
+  const errorMock = t.mock.method(console, "error", () => {});
+
+  const secretMessage = "초당 거래건수를 초과하였습니다.";
+  const secretError = new Error(secretMessage);
+  // Mirror an axios error: config.params carries CANO, config.headers carries appkey/
+  // appsecret/Authorization. Logging the error object (rather than error.message) would
+  // leak all of these to stderr.
+  secretError.config = {
+    params: { CANO: "87654321" },
+    headers: {
+      appkey: "test-app-key-secret",
+      appsecret: "test-app-secret-value",
+      authorization: "Bearer test-bearer-token-value",
+    },
+  };
+
+  let calls = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    if (calls === 1) {
+      return {
+        body: {
+          output1: [{ prdt_name: "삼성전자", pdno: "005930" }],
+          output2: [{ tot_evlu_amt: "1000000" }],
+          ctx_area_fk100: "FK1",
+          ctx_area_nk100: "NK1",
+        },
+        trCont: "F",
+      };
+    }
+    throw secretError;
+  };
+
+  await fetchAllBalance(fetchPage);
+
+  const logged = errorMock.mock.calls.map((call) => call.arguments.join(" ")).join("\n");
+
+  assert.match(logged, /초당 거래건수를 초과하였습니다\./);
+  assert.match(logged, /2/); // the failing page number (pages=1 completed, so page 2 failed)
+  assert.doesNotMatch(logged, /87654321/);
+  assert.doesNotMatch(logged, /test-app-key-secret/);
+  assert.doesNotMatch(logged, /test-app-secret-value/);
+  assert.doesNotMatch(logged, /Bearer/);
+  assert.doesNotMatch(logged, /test-bearer-token-value/);
+});
+
 test("formatBalanceReport omits the truncation note when the fetch was not truncated", () => {
   const text = formatBalanceReport(
     { output1: [], output2: [] },

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -379,6 +379,38 @@ test('fetchAllBalance detects a period-2 repeated-cursor cycle (A,B,A) that a pr
   assert.deepEqual(result.rows.map((row) => row.pdno), ["000001", "000002", "000003"]);
 });
 
+test("fetchAllBalance keeps paging when ctx_area_nk100 repeats but ctx_area_fk100 differs, since the outgoing cursor is the FK/NK pair", async () => {
+  // 다음 요청에 실리는 커서는 CTX_AREA_FK100/CTX_AREA_NK100 쌍이다(buildBalanceParams).
+  // NK만 같고 FK가 다르면 서로 다른 요청이므로 반복이 아니다. 반복 판정을 NK 하나로만
+  // 하면 여기서 조기 중단해, 이 함수가 없애려는 조용한 누락을 스스로 만든다.
+  const pages = [
+    { fk: "FK-1", nk: "NK" },
+    { fk: "FK-2", nk: "NK" },
+    { fk: "FK-3", nk: "NK" },
+  ];
+  let calls = 0;
+  const fetchPage = async () => {
+    calls += 1;
+    const page = pages[calls - 1];
+    return {
+      body: {
+        output1: [{ prdt_name: `종목${calls}`, pdno: String(calls).padStart(6, "0") }],
+        output2: calls === 1 ? [{ tot_evlu_amt: "1" }] : [],
+        ctx_area_fk100: page.fk,
+        ctx_area_nk100: page.nk,
+      },
+      // 4번째 호출은 fixture가 없으므로, 여기까지 왔다면 상한이 아니라 페이지 소진으로 끝난다.
+      trCont: calls < pages.length ? "F" : "D",
+    };
+  };
+
+  const result = await fetchAllBalance(fetchPage, { maxPages: 20, timeBudgetMs: 60_000 });
+
+  assert.equal(calls, 3);
+  assert.equal(result.truncated, null);
+  assert.deepEqual(result.rows.map((row) => row.pdno), ["000001", "000002", "000003"]);
+});
+
 test("fetchAllBalance rethrows when the first page fetch fails, so auth/account errors are not swallowed", async () => {
   const authError = new Error("EGW00123 인증 오류");
   const fetchPage = async () => {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -288,6 +288,46 @@ test('fetchAllBalance stops after two calls and reports truncated="no_cursor" wh
   assert.equal(result.truncated, "no_cursor");
 });
 
+test('fetchAllBalance stops after two calls and reports truncated="no_cursor" when KIS pads the continuation cursor with spaces instead of leaving it empty', async () => {
+  const calls = [];
+  let callCount = 0;
+  const fetchPage = async ({ ctxAreaFk100, ctxAreaNk100, trCont }) => {
+    calls.push({ ctxAreaFk100, ctxAreaNk100, trCont });
+    callCount += 1;
+    if (callCount === 1) {
+      return {
+        body: {
+          output1: [{ prdt_name: "삼성전자", pdno: "005930" }],
+          output2: [{ tot_evlu_amt: "1000000" }],
+          // fixed-width KIS response: padded rather than actually empty
+          ctx_area_fk100: " FK1 ",
+          ctx_area_nk100: "NK1",
+        },
+        trCont: "F",
+      };
+    }
+    // Pathological case: the cursor KIS hands back is space-padded, not empty.
+    // A naive `!ctxNk` check treats padded whitespace as truthy and keeps looping.
+    return {
+      body: {
+        output1: [{ prdt_name: `종목${callCount}`, pdno: String(callCount).padStart(6, "0") }],
+        output2: [],
+        ctx_area_fk100: "",
+        ctx_area_nk100: "   ",
+      },
+      trCont: "F",
+    };
+  };
+
+  const result = await fetchAllBalance(fetchPage, { maxPages: 20, timeBudgetMs: 60_000 });
+
+  assert.equal(callCount, 2);
+  assert.equal(result.pages, 2);
+  assert.equal(result.truncated, "no_cursor");
+  // the outgoing cursor to the second call must be trimmed, not just checked by the guard
+  assert.deepEqual(calls[1], { ctxAreaFk100: "FK1", ctxAreaNk100: "NK1", trCont: "N" });
+});
+
 test("fetchAllBalance rethrows when the first page fetch fails, so auth/account errors are not swallowed", async () => {
   const authError = new Error("EGW00123 인증 오류");
   const fetchPage = async () => {

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -463,7 +463,7 @@ test("formatBalanceReport's truncation note stays outside the holdings section s
     { pages: 20, truncated: "max_pages" },
   );
 
-  assert.match(text, /\[안내\] 페이지 상한\(20회\)을 초과하여/);
+  assert.match(text, /\[안내\] 페이지 상한\(20회\)에 도달하여/);
 
   // Mirror backend/scheduler.py's extract_stocks_from_balance(): everything after
   // "[보유 종목 리스트]", split into lines, keep only lines starting with "- ".


### PR DESCRIPTION
## 📝 개요

`get_balance`가 KIS `inquire-balance`를 1회만 호출하고 연속조회를 하지 않아, 보유 종목이 첫 페이지를 넘으면 이후 종목이 응답에서 빠지던 문제를 수정합니다. 누락된 종목은 `backend/scheduler.py`의 10분 주기 뉴스·공시 감시에서 조용히 제외됩니다.

같은 서버의 `fetchAllBalanceRlzPl()`(`mcp-trading/index.js`)이 이미 검증된 `tr_cont` + `ctx_area_*` 페이징 패턴을 갖고 있어 그것을 따랐습니다. 다만 그대로 베끼지 않고 `fetchPage`·`now`를 의존성으로 주입받게 해서, 네트워크·타이머 없이 단위 테스트가 가능하도록 했습니다(선례는 `kisApiGet`을 직접 호출해 테스트가 불가능합니다).

## 🚀 변경 사항

- `mcp-trading/balance.js`: `fetchAllBalance()` 연속조회 루프 추가. `buildBalanceParams()`가 `CTX_AREA_FK100`/`CTX_AREA_NK100`을 인자로 받아 커서를 이어받도록 변경(기존에는 빈 문자열 고정).
- `mcp-trading/index.js`: `getBalance()`가 단일 `kisGet()` 대신 `fetchAllBalance()`로 페이지를 모아 포맷하도록 교체.
- **상한 2종**: `BALANCE_MAX_PAGES = 20`, `BALANCE_TIME_BUDGET_MS = 15_000`. 페이지 수만으로 상한을 두면 안 되는 이유가 있습니다 — 상위 `run_mcp_tool`이 MCP 호출 전체를 30초에서 끊고(`backend/services.py`) 요청당 `kisAxios`가 8초(`mcp-trading/index.js`)라, 페이지 상한만 크게 잡으면 상위 타임아웃에 걸려 **부분 결과조차 받지 못합니다**. 시간 예산을 함께 둬서 잘리더라도 확보한 페이지는 반환합니다.
- **잘림 안내 문구**: 상한에 걸리면 그 사실을 반환 텍스트에 명시합니다. 단 `- `로 시작하지 않게 했습니다 — `backend/scheduler.py`의 `extract_stocks_from_balance()`가 `[보유 종목 리스트]` 이후 `- ` 시작 줄을 종목명으로 파싱하므로, 안내 문구가 감시 대상 종목으로 등록되는 것을 막아야 합니다. 이 제약은 소스 주석·JS 테스트·`scheduler.py` 상호 참조 주석 3중으로 고정했습니다.

### 코드 리뷰에서 발견해 함께 수정한 결함 4건

1. **`output2` 정규화 누락** — 선례(`fetchAllBalanceRlzPl`)는 `Array.isArray(body.output2) ? body.output2[0] : body.output2`로 정규화하는데 초기 구현이 그 방어를 빠뜨렸습니다. `output2`가 객체로 오면 소비자 `formatBalanceReport`의 `data.output2?.[0]`이 `undefined`가 되어 **계좌 요약이 통째로 `-`로 표시**됩니다.
2. **빈 배열 래치** — 첫 페이지 `output2: []`는 truthy라 `summary = []`로 확정되어, 뒤 페이지에 오는 진짜 요약이 영구 차단됩니다. 단일 페이지 시절엔 존재할 수 없었던, **연속조회 도입으로 새로 열린 경로**입니다.
3. **`no_cursor` 가드** — `tr_cont`는 연속을 신호하는데 `ctx_area_nk100`이 비어 오면, 다음 요청이 초기 조회로 해석되어 같은 페이지를 상한까지 반복 조회합니다. 중단하되 누락 가능성은 안내합니다.
4. **부분 실패 시 전량 폐기** — N페이지에서 실패하면 이미 받아둔 1..N-1이 통째로 버려졌습니다. 누락 방지가 목적인데 일시적 오류 1회로 잔고 전체가 사라지면 방향이 반대입니다. 2페이지 이후 실패는 부분 결과 + `truncated: "error"`로 반환하고, 1페이지 실패는 인증·계좌 오류를 숨기지 않도록 그대로 전파합니다.


### 리뷰 반영으로 추가된 변경 (커밋 9개)

리뷰 이후 커서 처리에서 결함 두 건이 더 나와 함께 고쳤습니다.

**커서 공백 패딩** — KIS는 `ctx_area_*`를 고정폭으로 반환해 값이 없을 때 빈 문자열이 아니라 공백으로 채워 보낼 수 있습니다. `"          "`는 truthy라 위 `no_cursor` 가드를 그대로 통과했고, 공백 커서로 재요청하면 KIS가 초기 조회로 해석해 같은 페이지를 상한까지 반복 조회합니다. 가드가 막으려던 시나리오가 그대로 재현되던 상태였습니다. `String(...).trim()`으로 정규화했고, 나가는 커서까지 트림되는지 `deepEqual`로 고정했습니다.

**커서 반복 감지 (`truncated: "repeated_cursor"` 신규)** — 리뷰에서 `pdno` 기준 행 중복 제거를 제안받았으나 채택하지 않았습니다. 이 PR의 시간 예산 테스트 픽스처가 두 페이지 모두 `pdno: "000000"`을 반환하면서 `prdt_name`은 다르게 주는데, `pdno` 집합을 넣으면 **서로 다른 두 보유 종목이 하나로 합쳐지면서 모든 단언이 그대로 통과**합니다. 그 행들은 `calculatePurchaseAmount`(계좌 수익률)와 `extract_stocks_from_balance`(스케줄러 감시 대상)로 흘러가므로, 잔고 누락을 막으려는 PR이 새 누락 경로를 여는 셈이었습니다.

증상을 지우는 대신 원인을 막았습니다. 보낸 커서를 `Set`에 모아 두고 이미 본 커서가 다시 오면 중단합니다. 직전 값 비교가 아니라 집합인 이유는 `A,B,A,B` 같은 주기 2 이상 순환 때문입니다 — 직전 값만 보면 상한 20회까지 그대로 돕니다.

판정 키는 `ctx_area_fk100`/`ctx_area_nk100` **쌍**입니다. 다음 요청에 실리는 것이 쌍이므로, NK만 같고 FK가 다르면 서로 다른 요청이고 반복이 아닙니다.

반복을 감지해도 **방금 받은 페이지의 행은 버리지 않습니다.** 반복되는 것은 다음에 받을 페이지이지 방금 받은 페이지가 아닙니다 — 방금 받은 것은 그 커서로 처음 조회해 받은 신규 데이터입니다.

**연속조회 실패 원인 로깅** — `truncated = "error"`가 예외를 통째로 버려, 운영자가 토큰 만료인지 유량 초과인지 네트워크 단절인지 구분할 수 없었습니다. stderr에 `error.message`만 남깁니다. 객체를 통째로 남기면 axios가 들고 있는 `config.params`의 `CANO`와 `config.headers`의 `appkey`·`appsecret`·`authorization: Bearer`가 로그에 찍힙니다. 가짜 axios 에러를 주입해 그 값들이 로그에 없음을 단언하는 테스트를 함께 넣었습니다.

**시간 예산 주석** — 리뷰에서 `getAccessToken()`의 토큰 발급 8초가 산술에서 빠졌다는 지적이 있었는데, 확인 결과 이미 측정 구간 안입니다. `startedAt`이 루프 진입 전에 기록되고 토큰 발급은 `fetchPage`(=`kisApiGet`) 내부에서 일어납니다. 최악은 예산이 `15초 - ε`에 만료된 뒤 진행 중인 요청 하나가 8초 더 걸리는 ≈23초로 30초 한도 안입니다. `BALANCE_TIME_BUDGET_MS`는 그대로 두고 주석에 그 사실만 명시했습니다.

**`truncated` 값이 늘었습니다.** 소비자는 확인이 필요합니다.

```
null | "max_pages" | "time_budget" | "no_cursor" | "error" | "repeated_cursor"
```

`max_pages` 문구도 `초과하여` → `도달하여`로 고쳤습니다. 루프 가드가 `pages >= maxPages`라 상한을 넘기는 게 아니라 상한에서 멈춥니다.

**후속으로 분리한 것**

- `isContinuationTrCont` 중복 제거 → **#147**. 4줄짜리 술어만 옮기는 것은 실익이 적어, 그 술어를 쓰는 연속조회 루프 자체를 공용 `fetchAllPaged()`로 통합하는 범위로 넓혔습니다. `index.js`의 `fetchAllDailyOrderCcld`·`fetchAllBalanceRlzPl`이 커서 트림도 `no_cursor` 가드도 **시간 예산도** 없이 50페이지 상한으로 돌고 있어, 주문 이력이 3페이지를 넘는 계좌는 조회가 매번 타임아웃으로 실패합니다.
- 잔고 테스트를 `balance.test.js`로 분리 → **#149**. 이 PR에 파일 이동까지 넣으면 실제 수정이 묻힙니다.

## 🔗 관련 이슈

- Closes #121

## ✅ 체크리스트

- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요? — 도구 동작 변경이 사용자 문서에 드러나지 않아 해당 없음

### 테스트

`mcp-trading` 테스트 33건 → **45건 통과** (12건 추가, 기존 실패 0).

추가 테스트는 다중 페이지 이어붙이기, 페이지 상한/시간 예산 잘림, 위 결함 4건 각각의 회귀, 그리고 잘림 안내 문구가 `backend/scheduler.py` 파서를 오염시키지 않는지를 다룹니다. 마지막 항목은 파서 로직을 JS로 미러링해 검증하며, 별도로 실제 `extract_stocks_from_balance()`에 출력을 투입해 종목 목록이 `['삼성전자', 'NAVER']`로 깨끗하게 나오는 것도 확인했습니다.

결함 4건의 회귀 테스트는 mutation 검증을 거쳤습니다 — 각 수정을 되돌리면 해당 테스트가 실패합니다.

### 미검증

실제 KIS 다중 페이지 계좌 응답으로는 검증하지 못했습니다. 스텁 기반 단위 테스트만 수행했으며, 첫 페이지 정원 등 KIS 스펙 수치는 리포지터리에 근거가 없어 확인하지 못했습니다.

### 후속

스케줄러(`backend/scheduler.py`)는 잘림 안내 문구를 읽지 않으므로, 20페이지를 넘겨 잘린 계좌는 여전히 감시 대상이 조용히 줄어든 채로 돕니다. `backend/scheduler.py` 수정이 필요해 별도 이슈로 분리했습니다.

