### PR TITLE
fix: 영숫자 종목코드 거절 사유 정확화

### DIFF
--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -47,8 +47,8 @@ NATURAL_ORDER_HELP = "자연어 주문을 해석할 수 없습니다. /buy 또�
 # 종목명에 괄호가 들어가고 닫히지 않는 종목이 있어(예: "KIWOOM 엔비디아미국30년국채혼합액티브(H")
 # 단순 괄호 매칭 대신 코드+쉼표 조합에 앵커한다. 종목명에 쉼표가 들어가는 종목은 없다.
 # 코드 길이는 6자(3,889종목)·7자 ETN(389종목)·9자 펀드(75종목)가 섞여 있어 상한을 두지 않는다.
-# backend/services.py에도 같은 정규식이 별도로 정의되어 있다(#125). 공용 헬퍼 추출은
-# 두 PR이 동시에 열려 있어 미뤘고, 둘 다 머지된 뒤 정리한다.
+# PR #133(이슈 #125)이 services.py에 같은 정규식을 추가 중이다. 두 PR이 동시에 열려 있어
+# 머지 컨플릭트를 피하려고 공용 헬퍼 추출은 미뤘고, 둘 다 머지된 뒤 정리한다(#140).
 _STOCK_CODE_EXTRACT_RE = re.compile(r"\(([0-9A-Z]{6,}),")
 # 추출 가능한 코드 전부가 주문 가능한 건 아니다. mcp-trading/order.js의
 # buildCashOrderBody()가 적용하는 허용 범위(`/^\d{6,7}$/`)와 일치시킨다.
@@ -693,8 +693,9 @@ class TelegramCommandHandler:
             if not _ORDERABLE_STOCK_CODE_RE.fullmatch(stock_code):
                 # 사용자가 입력한 건 종목명인데 거절 사유는 종목코드 형태다.
                 # 코드를 함께 보여주지 않으면 인과가 보이지 않는다.
+                # 조사(은/는)는 코드 끝자리 받침에 따라 갈리므로 아예 쓰지 않는다.
                 await self._send_text_or_raise(
-                    f"주문 불가: {stock_name}({stock_code})은 현재 주문을 지원하지 않습니다. "
+                    f"주문 불가: {stock_name}({stock_code}) — 현재 주문을 지원하지 않습니다. "
                     "ETN·펀드 등 영숫자 종목코드는 아직 주문 대상이 아닙니다."
                 )
                 return

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -47,11 +47,13 @@ NATURAL_ORDER_HELP = "자연어 주문을 해석할 수 없습니다. /buy 또�
 # 종목명에 괄호가 들어가고 닫히지 않는 종목이 있어(예: "KIWOOM 엔비디아미국30년국채혼합액티브(H")
 # 단순 괄호 매칭 대신 코드+쉼표 조합에 앵커한다. 종목명에 쉼표가 들어가는 종목은 없다.
 # 코드 길이는 6자(3,889종목)·7자 ETN(389종목)·9자 펀드(75종목)가 섞여 있어 상한을 두지 않는다.
-# PR #133이 services.py에 같은 상수를 추가 중이나, 머지 컨플릭트를 피해 이번 범위에서는
-# 공용 헬퍼로 추출하지 않고 의도적으로 중복 구현한다. (#133 머지 후 정리 예정)
+# backend/services.py에도 같은 정규식이 별도로 정의되어 있다(#125). 공용 헬퍼 추출은
+# 두 PR이 동시에 열려 있어 미뤘고, 둘 다 머지된 뒤 정리한다.
 _STOCK_CODE_EXTRACT_RE = re.compile(r"\(([0-9A-Z]{6,}),")
-# 추출 가능한 코드 전부가 주문 가능한 건 아니다. mcp-trading/order.js:73-78의
-# 허용 범위(`/^\d{6,7}$/`)와 일치시킨다. 영숫자 코드 주문 미지원은 #73에서 확정된 정책이다.
+# 추출 가능한 코드 전부가 주문 가능한 건 아니다. mcp-trading/order.js의
+# buildCashOrderBody()가 적용하는 허용 범위(`/^\d{6,7}$/`)와 일치시킨다.
+# 이 상수와 order.js의 가드는 쌍을 이루므로 한쪽만 바꾸면 안 된다(#138 참조).
+# 영숫자 코드 주문 미지원은 #73에서 확정된 정책이다.
 # 앵커를 호출부가 아니라 패턴에 넣어 order.js와 형태를 맞춘다. 나중에 누가 fullmatch를
 # match/search로 바꿔도 방어가 무너지지 않는다. `\d`는 파이썬에서 전각 숫자까지 매치하므로
 # JS의 ASCII 전용 `\d`와 어긋나지 않도록 `[0-9]`로 명시한다.
@@ -684,12 +686,16 @@ class TelegramCommandHandler:
             if stock_code is None:
                 await self._send_text_or_raise("주문 준비 실패: 종목코드를 확인할 수 없습니다.")
                 return
-            # 추출 성공 != 주문 가능. mcp-trading/order.js:73-78이 숫자 코드만 주문을
-            # 받으므로(#73에서 확정된 정책), 시세·잔고 조회와 60초 대기 슬롯을 쓰기 전에
-            # 여기서 끊는다. 이 검사가 없으면 /confirm 이후에야 같은 사유로 실패한다.
+            # 추출 성공 != 주문 가능. mcp-trading/order.js의 buildCashOrderBody()가
+            # 숫자 코드만 주문을 받으므로(#73에서 확정된 정책), 시세·잔고 조회와 60초
+            # 대기 슬롯을 쓰기 전에 여기서 끊는다. 이 검사가 없으면 /confirm 이후에야
+            # 같은 사유로 실패한다.
             if not _ORDERABLE_STOCK_CODE_RE.fullmatch(stock_code):
+                # 사용자가 입력한 건 종목명인데 거절 사유는 종목코드 형태다.
+                # 코드를 함께 보여주지 않으면 인과가 보이지 않는다.
                 await self._send_text_or_raise(
-                    "주문 불가: 이 종목은 현재 주문을 지원하지 않습니다."
+                    f"주문 불가: {stock_name}({stock_code})은 현재 주문을 지원하지 않습니다. "
+                    "ETN·펀드 등 영숫자 종목코드는 아직 주문 대상이 아닙니다."
                 )
                 return
             quote_result, balance_result = await asyncio.gather(

--- a/backend/telegram_commands.py
+++ b/backend/telegram_commands.py
@@ -43,6 +43,19 @@ WATCH_COMMAND_HELP = "사용법: /watch add <종목명> | remove <종목명> | l
 CATALYST_COMMAND_HELP = "사용법: /catalysts <종목명>"
 EARNINGS_COMMAND_HELP = "사용법: /earnings <종목명> [기간]  예: /earnings 삼성전자 2025Q1"
 NATURAL_ORDER_HELP = "자연어 주문을 해석할 수 없습니다. /buy 또는 /sell 형식으로 입력하세요."
+# resolve_stock_code 응답 형식: "종목명 (코드, 시장)" — mcp-trading/index.js
+# 종목명에 괄호가 들어가고 닫히지 않는 종목이 있어(예: "KIWOOM 엔비디아미국30년국채혼합액티브(H")
+# 단순 괄호 매칭 대신 코드+쉼표 조합에 앵커한다. 종목명에 쉼표가 들어가는 종목은 없다.
+# 코드 길이는 6자(3,889종목)·7자 ETN(389종목)·9자 펀드(75종목)가 섞여 있어 상한을 두지 않는다.
+# PR #133이 services.py에 같은 상수를 추가 중이나, 머지 컨플릭트를 피해 이번 범위에서는
+# 공용 헬퍼로 추출하지 않고 의도적으로 중복 구현한다. (#133 머지 후 정리 예정)
+_STOCK_CODE_EXTRACT_RE = re.compile(r"\(([0-9A-Z]{6,}),")
+# 추출 가능한 코드 전부가 주문 가능한 건 아니다. mcp-trading/order.js:73-78의
+# 허용 범위(`/^\d{6,7}$/`)와 일치시킨다. 영숫자 코드 주문 미지원은 #73에서 확정된 정책이다.
+# 앵커를 호출부가 아니라 패턴에 넣어 order.js와 형태를 맞춘다. 나중에 누가 fullmatch를
+# match/search로 바꿔도 방어가 무너지지 않는다. `\d`는 파이썬에서 전각 숫자까지 매치하므로
+# JS의 ASCII 전용 `\d`와 어긋나지 않도록 `[0-9]`로 명시한다.
+_ORDERABLE_STOCK_CODE_RE = re.compile(r"\A[0-9]{6,7}\Z")
 ORDER_EXPIRES_AFTER = timedelta(seconds=60)
 ORDER_CONFIRM_CALLBACK = "order:confirm"
 ORDER_CANCEL_CALLBACK = "order:cancel"
@@ -671,6 +684,14 @@ class TelegramCommandHandler:
             if stock_code is None:
                 await self._send_text_or_raise("주문 준비 실패: 종목코드를 확인할 수 없습니다.")
                 return
+            # 추출 성공 != 주문 가능. mcp-trading/order.js:73-78이 숫자 코드만 주문을
+            # 받으므로(#73에서 확정된 정책), 시세·잔고 조회와 60초 대기 슬롯을 쓰기 전에
+            # 여기서 끊는다. 이 검사가 없으면 /confirm 이후에야 같은 사유로 실패한다.
+            if not _ORDERABLE_STOCK_CODE_RE.fullmatch(stock_code):
+                await self._send_text_or_raise(
+                    "주문 불가: 이 종목은 현재 주문을 지원하지 않습니다."
+                )
+                return
             quote_result, balance_result = await asyncio.gather(
                 self.mcp_runner(
                     TRADING_MCP_PARAMS,
@@ -835,7 +856,7 @@ class TelegramCommandHandler:
             self.pending_orders.pop(chat_id, None)
 
     def _extract_stock_code(self, text: str) -> str | None:
-        match = re.search(r"\b(\d{6})\b", text)
+        match = _STOCK_CODE_EXTRACT_RE.search(text)
         return match.group(1) if match else None
 
     def _extract_order_callback_token(self, data: str) -> str | None:

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1198,7 +1198,14 @@ def test_extract_stock_code_returns_none_when_unmatched():
 )
 @pytest.mark.parametrize(
     "text_template",
-    ["/buy {name} 10", "/sell {name} 10", "{name} 10주 시장가로 매수해줘"],
+    [
+        "/buy {name} 10",
+        "/sell {name} 10",
+        # 자연어 경로는 _parse_natural_order_text가 "매수"/"매도" 리터럴을 요구한다.
+        # 매수·매도 양쪽 분기를 모두 거쳐 _handle_order_command로 합류하는지 본다.
+        "{name} 10주 시장가로 매수해줘",
+        "{name} 10주 시장가로 매도해줘",
+    ],
 )
 @pytest.mark.asyncio
 async def test_order_command_rejects_unorderable_stock_code_before_quote_and_balance(
@@ -1237,10 +1244,14 @@ async def test_order_command_rejects_unorderable_stock_code_before_quote_and_bal
     )
 
     assert [call[1] for call in calls] == ["resolve_stock_code"]
-    # 거절 사유는 종목코드 형태인데 사용자가 입력한 건 종목명이므로 둘 다 보여준다.
-    assert stock_name in notifier.messages[-1]
-    assert stock_code in notifier.messages[-1]
-    assert "주문을 지원하지 않습니다" in notifier.messages[-1]
+    message = notifier.messages[-1]
+    # 이름과 코드를 따로 단언하면 resolve_stock_code 응답("덕양에너젠 (0001A0, KOSDAQ)")을
+    # 그대로 흘려보내도 통과한다. 조합된 형태를 단언해야 실제로 우리가 만든 문장이 나갔음이
+    # 고정된다.
+    assert f"{stock_name}({stock_code})" in message
+    assert "주문을 지원하지 않습니다" in message
+    # 왜 안 되는지를 설명하는 문장이 이 수정의 핵심이므로 함께 고정한다.
+    assert "ETN·펀드 등 영숫자 종목코드는 아직 주문 대상이 아닙니다." in message
     assert handler.pending_orders == {}
 
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1186,20 +1186,31 @@ def test_extract_stock_code_returns_none_when_unmatched():
 
 
 @pytest.mark.parametrize(
-    "stock_name, resolved",
+    "stock_name, resolved, stock_code",
     [
-        ("덕양에너젠", "덕양에너젠 (0001A0, KOSDAQ)"),
-        ("한투글로벌넥스트웨이브1(A)", "한투글로벌넥스트웨이브1(A) (F70100026, KOSPI)"),
+        ("덕양에너젠", "덕양에너젠 (0001A0, KOSDAQ)", "0001A0"),
+        (
+            "한투글로벌넥스트웨이브1(A)",
+            "한투글로벌넥스트웨이브1(A) (F70100026, KOSPI)",
+            "F70100026",
+        ),
     ],
 )
+@pytest.mark.parametrize(
+    "text_template",
+    ["/buy {name} 10", "/sell {name} 10", "{name} 10주 시장가로 매수해줘"],
+)
 @pytest.mark.asyncio
-async def test_buy_command_rejects_unorderable_stock_code_before_quote_and_balance(
-    stock_name, resolved
+async def test_order_command_rejects_unorderable_stock_code_before_quote_and_balance(
+    stock_name, resolved, stock_code, text_template
 ):
     """주문 미지원 코드는 시세·잔고 조회 전에 끊고 사유를 정확히 알린다.
 
-    코드 추출은 성공하지만 mcp-trading/order.js:73-78이 숫자 코드만 받는다(#73).
-    가드가 없으면 /confirm 이후에야 실패하면서 60초 대기 슬롯까지 점유한다.
+    코드 추출은 성공하지만 mcp-trading/order.js의 buildCashOrderBody()가 숫자
+    코드만 받는다(#73). 가드가 없으면 /confirm 이후에야 실패하면서 60초 대기
+    슬롯까지 점유한다.
+
+    자연어 주문도 _handle_order_command로 합류하므로 세 경로를 함께 고정한다.
     """
     calls = []
 
@@ -1217,11 +1228,19 @@ async def test_buy_command_rejects_unorderable_stock_code_before_quote_and_balan
     )
 
     await handler.handle_update(
-        {"message": {"chat": {"id": 123}, "text": f"/buy {stock_name} 10"}}
+        {
+            "message": {
+                "chat": {"id": 123},
+                "text": text_template.format(name=stock_name),
+            }
+        }
     )
 
     assert [call[1] for call in calls] == ["resolve_stock_code"]
-    assert notifier.messages[-1] == "주문 불가: 이 종목은 현재 주문을 지원하지 않습니다."
+    # 거절 사유는 종목코드 형태인데 사용자가 입력한 건 종목명이므로 둘 다 보여준다.
+    assert stock_name in notifier.messages[-1]
+    assert stock_code in notifier.messages[-1]
+    assert "주문을 지원하지 않습니다" in notifier.messages[-1]
     assert handler.pending_orders == {}
 
 

--- a/backend/tests/test_telegram_commands.py
+++ b/backend/tests/test_telegram_commands.py
@@ -1133,6 +1133,98 @@ async def test_buy_command_rejects_unresolved_stock_code_before_quote_and_balanc
     assert handler.pending_orders == {}
 
 
+def test_extract_stock_code_numeric():
+    handler = TelegramCommandHandler(notifier=FakeNotifier())
+    assert handler._extract_stock_code("삼성전자 (005930, KOSPI)") == "005930"
+
+
+def test_extract_stock_code_alphanumeric():
+    handler = TelegramCommandHandler(notifier=FakeNotifier())
+    assert handler._extract_stock_code("덕양에너젠 (0001A0, KOSDAQ)") == "0001A0"
+
+
+def test_extract_stock_code_ignores_parentheses_in_stock_name():
+    """종목명에 괄호가 있어도 코드+쉼표 앵커가 코드만 뽑아낸다.
+
+    종목마스터 실제 항목이다. 이름의 괄호가 닫히지 않는 종목(0015E0)까지 있어
+    단순 괄호 매칭으로는 안전하지 않다.
+    """
+    handler = TelegramCommandHandler(notifier=FakeNotifier())
+    assert (
+        handler._extract_stock_code("한투글로벌넥스트웨이브1(A-e) (F70100027, KOSPI)")
+        == "F70100027"
+    )
+    assert (
+        handler._extract_stock_code(
+            "KIWOOM 엔비디아미국30년국채혼합액티브(H (0015E0, KOSPI)"
+        )
+        == "0015E0"
+    )
+
+
+def test_extract_stock_code_accepts_seven_and_nine_char_codes():
+    """코드 길이 상한을 두지 않는 이유를 고정한다.
+
+    종목마스터 코드 길이는 6자 3,889 / 7자 ETN 389 / 9자 펀드 75종목이다.
+    정규식을 {6}으로 좁히면 464종목이, {6,7}로 좁히면 9자 펀드 75종목이
+    조용히 추출 실패로 돌아간다.
+    """
+    handler = TelegramCommandHandler(notifier=FakeNotifier())
+    assert (
+        handler._extract_stock_code("신한 레버리지 다우존스지수 선물 ETN(H) (Q500020, KOSPI)")
+        == "Q500020"
+    )
+    assert (
+        handler._extract_stock_code("한투글로벌넥스트웨이브1(A) (F70100026, KOSPI)")
+        == "F70100026"
+    )
+
+
+def test_extract_stock_code_returns_none_when_unmatched():
+    handler = TelegramCommandHandler(notifier=FakeNotifier())
+    assert handler._extract_stock_code("종목을 찾지 못했습니다") is None
+
+
+@pytest.mark.parametrize(
+    "stock_name, resolved",
+    [
+        ("덕양에너젠", "덕양에너젠 (0001A0, KOSDAQ)"),
+        ("한투글로벌넥스트웨이브1(A)", "한투글로벌넥스트웨이브1(A) (F70100026, KOSPI)"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_buy_command_rejects_unorderable_stock_code_before_quote_and_balance(
+    stock_name, resolved
+):
+    """주문 미지원 코드는 시세·잔고 조회 전에 끊고 사유를 정확히 알린다.
+
+    코드 추출은 성공하지만 mcp-trading/order.js:73-78이 숫자 코드만 받는다(#73).
+    가드가 없으면 /confirm 이후에야 실패하면서 60초 대기 슬롯까지 점유한다.
+    """
+    calls = []
+
+    async def mcp_runner(server_params, tool_name, arguments):
+        calls.append((server_params, tool_name, arguments))
+        if tool_name == "resolve_stock_code":
+            return resolved
+        raise AssertionError(f"주문 불가 종목인데 호출됨: {tool_name}")
+
+    notifier = FakeNotifier()
+    handler = TelegramCommandHandler(
+        notifier=notifier,
+        mcp_runner=mcp_runner,
+        now_factory=lambda: datetime(2026, 5, 20, 10, 0, tzinfo=KST),
+    )
+
+    await handler.handle_update(
+        {"message": {"chat": {"id": 123}, "text": f"/buy {stock_name} 10"}}
+    )
+
+    assert [call[1] for call in calls] == ["resolve_stock_code"]
+    assert notifier.messages[-1] == "주문 불가: 이 종목은 현재 주문을 지원하지 않습니다."
+    assert handler.pending_orders == {}
+
+
 @pytest.mark.asyncio
 async def test_cancel_removes_pending_order():
     async def mcp_runner(server_params, tool_name, arguments):

--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -70,6 +70,9 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price, orde
   if (account.length < 10) {
     throw new Error("KIS_ACCOUNT_NO가 올바르지 않습니다. 계좌번호 앞 8자리와 상품코드 2자리를 붙여 설정하세요.");
   }
+  // 이 허용 범위는 backend/telegram_commands.py의 _ORDERABLE_STOCK_CODE_RE와 쌍을 이룬다.
+  // 백엔드가 같은 정책을 복제해 조기 거절하므로, 여기만 풀면 백엔드가 조용히 계속 막는다.
+  // 영숫자 코드 주문 지원을 검토할 때(#138) 반드시 두 곳을 함께 바꿔야 한다.
   if (/^[0-9A-Z]{6,7}$/i.test(code) && !/^\d{6,7}$/.test(code)) {
     throw new Error("이 종목은 현재 주문을 지원하지 않습니다.");
   }

--- a/mcp-trading/order.js
+++ b/mcp-trading/order.js
@@ -70,12 +70,17 @@ export function buildCashOrderBody({ accountNo, stockCode, quantity, price, orde
   if (account.length < 10) {
     throw new Error("KIS_ACCOUNT_NO가 올바르지 않습니다. 계좌번호 앞 8자리와 상품코드 2자리를 붙여 설정하세요.");
   }
-  // 이 허용 범위는 backend/telegram_commands.py의 _ORDERABLE_STOCK_CODE_RE와 쌍을 이룬다.
-  // 백엔드가 같은 정책을 복제해 조기 거절하므로, 여기만 풀면 백엔드가 조용히 계속 막는다.
-  // 영숫자 코드 주문 지원을 검토할 때(#138) 반드시 두 곳을 함께 바꿔야 한다.
+  // 아래 두 가드가 함께 "숫자 6~7자만 주문 가능"이라는 하나의 정책을 이룬다.
+  // 첫 번째는 영숫자 코드(0001A0 등)에 전용 메시지를 주기 위한 것이고, 실제로 범위를
+  // 확정하는 건 두 번째다. 9자 펀드코드(F70100026)는 첫 번째에 매치조차 되지 않고
+  // 두 번째에서 거절된다.
   if (/^[0-9A-Z]{6,7}$/i.test(code) && !/^\d{6,7}$/.test(code)) {
     throw new Error("이 종목은 현재 주문을 지원하지 않습니다.");
   }
+  // 이 범위가 backend/telegram_commands.py의 _ORDERABLE_STOCK_CODE_RE(`\A[0-9]{6,7}\Z`)와
+  // 쌍을 이룬다. 백엔드가 같은 정책을 복제해 조기 거절하므로, 영숫자 코드 주문 지원을
+  // 검토할 때(#138) 위 두 가드와 백엔드 상수를 **모두** 함께 바꿔야 한다. 하나라도 남기면
+  // 그 계층에서 조용히 계속 막힌다.
   if (!/^\d{6,7}$/.test(code)) {
     throw new Error("stock_code는 6자리 또는 7자리 종목코드여야 합니다.");
   }


### PR DESCRIPTION
## 📝 개요

`_extract_stock_code()`가 `\b(\d{6})\b`로 6자리 숫자만 종목코드로 인정해, 영숫자 코드 종목의 `/buy`·`/sell`이 전부 `주문 준비 실패: 종목코드를 확인할 수 없습니다`로 끝나고 있었습니다. MCP가 코드를 정확히 반환했는데도 백엔드가 스스로 버리는 구조라 원인 파악도 어렵습니다.

**다만 작업 중 이슈의 전제가 일부 사실과 다르다는 점이 드러나, 이슈 본문의 "예상 동작"과 다르게 처리했습니다.** 리뷰에서 판단 부탁드립니다.

`mcp-trading/order.js:73-78`이 영숫자 코드를 **의도적으로** 차단합니다. 이건 실수가 아니라 #73(2026-05-28 CLOSED)에서 확정된 정책이고, `mcp-trading/tests/order.test.js:309`에 `0001A0` 거부를 단언하는 회귀 테스트까지 있습니다. 차단 종목 수를 종목마스터로 전수 계산하면 영숫자 6~7자 701 + 9자 펀드 75 = **776종목**으로 #135가 말한 수치와 정확히 일치합니다.

즉 정규식만 고치면 776종목이 주문 가능해지는 게 아니라, **실패 지점이 `/confirm` 이후로 밀릴 뿐**입니다. 그 사이 시세·잔고 MCP 호출 2회와 60초 대기 슬롯을 낭비하고, 사용자는 확인 프롬프트까지 본 뒤 거부당합니다. 정규식만 적용한 상태는 UX 후퇴입니다.

그래서 **#73 정책은 유지하고, 백엔드를 거기에 맞췄습니다.** 실패를 없애는 대신 **정확한 사유로 즉시** 실패하게 합니다. 776종목의 실제 주문 지원은 KIS Open API가 영숫자 `PDNO`를 수용하는지 확인이 선행되어야 하고 `order.test.js`가 PR #131과 겹치므로 #138로 분리했습니다.

| | 변경 전 | 변경 후 |
|---|---|---|
| 메시지 | `종목코드를 확인할 수 없습니다` (원인 오도) | `이 종목은 현재 주문을 지원하지 않습니다` (정확) |
| 실패 시점 | 시세·잔고 조회 전 | 시세·잔고 조회 전 (유지) |
| 낭비되는 MCP 호출 | 0 | 0 |

## 🚀 변경 사항

- **`backend/telegram_commands.py`: 추출 정규식 교체** — `\b(\d{6})\b` → `_STOCK_CODE_EXTRACT_RE = re.compile(r"\(([0-9A-Z]{6,}),")`. `resolve_stock_code` 응답 형식 `"종목명 (코드, 시장)"`의 코드+쉼표 조합에 앵커합니다. 종목명 자체에 괄호가 들어가고 **닫히지 않는** 종목이 실재해(`KIWOOM 엔비디아미국30년국채혼합액티브(H`, 0015E0) 단순 괄호 매칭은 위험합니다. 종목명에 쉼표가 들어가는 종목은 0건이라 `,` 앵커가 구조적으로 안전합니다.
- **길이 상한을 두지 않음** — 코드 길이는 6자 3,889 / 7자 ETN 389 / 9자 펀드 75종목이 섞여 있습니다. `{6}`으로 좁히면 464종목이, `{6,7}`로 좁히면 9자 펀드 75종목이 조용히 추출 실패로 돌아갑니다. 이 근거를 테스트로 고정했습니다.
- **주문 미지원 코드 조기 거절 (신규)** — 추출 성공이 곧 주문 가능은 아닙니다. `_ORDERABLE_STOCK_CODE_RE = re.compile(r"\A[0-9]{6,7}\Z")`로 `order.js:73-78`의 허용 범위를 백엔드에 복제하고, **시세·잔고 조회와 대기 슬롯을 쓰기 전에** 끊습니다.
  - 앵커를 호출부(`fullmatch`)가 아니라 패턴에 넣었습니다. 나중에 누가 `match`/`search`로 바꿔도 방어가 무너지지 않습니다. `order.js`가 `/^\d{6,7}$/`로 패턴에 앵커를 내장한 것과 형태를 맞췄습니다.
  - `\d` 대신 `[0-9]`를 썼습니다. 파이썬 `\d`는 전각 숫자까지 매치해 JS의 ASCII 전용 `\d`와 어긋납니다.
- **`services.py`와의 중복은 의도적으로 남김** — PR #133이 같은 파일에 같은 상수를 추가 중이라 공용 헬퍼 추출은 컨플릭트를 유발합니다. 사유를 코드 주석에 남기고 #140으로 분리했습니다.

## 🔗 관련 이슈

- Related to #135 — 거절 사유만 정확화합니다. 이슈 본문의 "예상 동작"(776종목 주문 진행)은 #138이 닫습니다.
- Related to #73 — 현재 차단 정책을 확정한 이슈. 본 PR은 그 정책을 유지합니다.
- Related to #138 — 776종목의 실제 주문 지원 검토 (KIS API 확인 선행, PR #131 머지 후)
- Related to #140 — `services.py`와의 중복 정리 (PR #133 머지 후)


## ✅ 체크리스트

- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [ ] 변경 사항에 대한 문서(README 등)를 업데이트했나요? — 내부 파싱·검증 로직 변경이라 해당 없음

### 테스트

`pytest backend/tests/` → 194건 → **201건 통과** (7건 추가, skip 2건은 라이브 Redis 필요한 기존 항목).

- `test_extract_stock_code_numeric` — 일반 6자리 (`005930`)
- `test_extract_stock_code_alphanumeric` — 이슈의 핵심 회귀 케이스 (`0001A0` 덕양에너젠)
- `test_extract_stock_code_ignores_parentheses_in_stock_name` — 종목명에 괄호 포함. 마스터 실제 항목인 `한투글로벌넥스트웨이브1(A-e)`(F70100027)와 괄호가 닫히지 않는 `KIWOOM ...액티브(H`(0015E0) 두 건
- `test_extract_stock_code_accepts_seven_and_nine_char_codes` — 7자 ETN(`Q500020`)·9자 펀드(`F70100026`). 상한을 두지 않는 근거를 고정
- `test_extract_stock_code_returns_none_when_unmatched` — 추출 실패 시 `None`
- `test_buy_command_rejects_unorderable_stock_code_before_quote_and_balance` — `0001A0`·`F70100026` parametrize. `resolve_stock_code` 외 도구가 호출되면 실패하도록 해 **가드 위치**(시세·잔고 이전)까지 고정하고, 거절 메시지와 `pending_orders == {}`를 함께 단언

수정을 되돌리면 새 테스트 3건이 실패하는 것을 확인해 회귀 방어가 실제로 동작함을 검증했습니다.

### 검증 근거

`mcp-trading/data/stocks.json` 4,353종목 전량을 실제 응답 형식으로 렌더링해 대조했습니다.

```
추출:   {6,} (채택) 실패 0종목  |  {6} 실패 464종목  |  {6,7} 실패 75종목
가드:   통과 3,577 / 차단 776 (= 영숫자 701 + 9자 펀드 75)
order.js 순효과와 백엔드 가드의 허용 집합 불일치: 0건
변경 전후 주문 허용 집합 비교: 3,577 동일 / 776 동일 — 신규 허용 0건
```

마지막 줄이 중요합니다. **이 PR은 주문 가능 종목 집합을 넓히지 않습니다.** 새 추출 정규식이 넓힌 수용 범위를 가드가 정확히 원래 크기로 되돌리므로, "엉뚱한 종목에 주문이 나간다"는 위험 표면은 변경 전과 동일합니다.

`pending_orders` 접근점 11곳을 전수 조사해 슬롯 삽입이 `:715` 한 곳뿐이고 가드(`:687-691`)가 그보다 앞에서 `return`하는 것도 확인했습니다. `PendingOrder(` 생성자 호출도 저장소 전체에 1곳뿐이라 우회 경로가 없습니다.

