### PR TITLE
fix: KIS_ORDER_DEDUP_TTL_MS 잘못된 값에 경고 출력

### DIFF
--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const DEFAULT_ORDER_DEDUP_TTL_MS = 120_000;
+export const DEFAULT_ORDER_DEDUP_TTL_MS = 120_000;
 const DEFAULT_ORDER_DEDUP_PATH = path.join(os.tmpdir(), "finus-kis-order-dedup.json");
 
 export class DuplicateOrderError extends Error {

--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -40,9 +40,10 @@ export function createOrderDedupKey({
 function parsePositiveInteger(value, fallback, name) {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed <= 0) {
-    if (value !== undefined && value !== "") {
+    // 공백만 있는 값도 빈 문자열과 마찬가지로 "설정하지 않음"으로 취급한다.
+    if (value !== undefined && String(value).trim() !== "") {
       console.error(
-        `${name}=${value} 는 양의 정수(ms)가 아니어서 기본값 ${fallback}ms를 사용합니다.`,
+        `${name}="${value}"는 양의 정수(ms)가 아니어서 기본값 ${fallback}ms를 사용합니다.`,
       );
     }
     return fallback;

--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -37,7 +37,7 @@ export function createOrderDedupKey({
   return crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 }
 
-function parsePositiveInteger(value, fallback, name) {
+function parsePositiveInteger(value, fallback, name = "값") {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed <= 0) {
     // 공백만 있는 값도 빈 문자열과 마찬가지로 "설정하지 않음"으로 취급한다.

--- a/mcp-trading/order-dedup.js
+++ b/mcp-trading/order-dedup.js
@@ -37,9 +37,14 @@ export function createOrderDedupKey({
   return crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");
 }
 
-function parsePositiveInteger(value, fallback) {
+function parsePositiveInteger(value, fallback, name) {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed <= 0) {
+    if (value !== undefined && value !== "") {
+      console.error(
+        `${name}=${value} 는 양의 정수(ms)가 아니어서 기본값 ${fallback}ms를 사용합니다.`,
+      );
+    }
     return fallback;
   }
   return parsed;
@@ -48,7 +53,11 @@ function parsePositiveInteger(value, fallback) {
 export class OrderDedupStore {
   constructor({
     filePath = process.env.KIS_ORDER_DEDUP_PATH || DEFAULT_ORDER_DEDUP_PATH,
-    ttlMs = parsePositiveInteger(process.env.KIS_ORDER_DEDUP_TTL_MS, DEFAULT_ORDER_DEDUP_TTL_MS),
+    ttlMs = parsePositiveInteger(
+      process.env.KIS_ORDER_DEDUP_TTL_MS,
+      DEFAULT_ORDER_DEDUP_TTL_MS,
+      "KIS_ORDER_DEDUP_TTL_MS",
+    ),
     now = () => Date.now(),
   } = {}) {
     this.filePath = filePath;

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -139,10 +139,10 @@ test("OrderDedupStore blocks duplicate reservations across separate instances sh
   );
 });
 
-// 이 테스트는 parsePositiveInteger()의 현재 동작(잘못된 값을 조용히 기본값으로
-// 대체)을 있는 그대로 문서화한다. 이 침묵하는 폴백은 바람직한 설계로 보증하는
-// 것이 아니라 별도 이슈로 추적 중이며, 이번 PR에서는 손대지 않는다.
-test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, silently falling back on invalid values", (t) => {
+// 잘못된 KIS_ORDER_DEDUP_TTL_MS 값은 기본값으로 폴백하되, 사용자가 실제로
+// 값을 지정했는데 파싱에 실패한 경우 stderr에 경고를 남긴다(#148).
+// 값이 아예 없는 경우(정상적인 기본값 사용)는 조용해야 한다.
+test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, warning on invalid values but staying silent when unset", (t) => {
   const originalEnvValue = process.env.KIS_ORDER_DEDUP_TTL_MS;
   t.after(() => {
     if (originalEnvValue === undefined) {
@@ -152,11 +152,11 @@ test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, silent
     }
   });
 
-  const consoleError = t.mock.method(console, "error");
+  const consoleError = t.mock.method(console, "error", () => {});
 
   const DEFAULT_TTL_MS = 120_000;
-  const cases = [
-    ["600000", 600_000], // 유효한 값은 그대로 사용된다
+  const validCase = ["600000", 600_000]; // 유효한 값은 그대로 사용되고 경고가 없다
+  const invalidCases = [
     ["600_000", DEFAULT_TTL_MS], // JS 숫자 구분자(_) 습관 - Number()는 이를 파싱하지 못함
     ["10m", DEFAULT_TTL_MS], // 단위 접미사 오타
     ["0", DEFAULT_TTL_MS], // <= 0 분기
@@ -164,17 +164,69 @@ test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, silent
     ["60.5", DEFAULT_TTL_MS], // !Number.isInteger 분기
   ];
 
-  for (const [envValue, expectedTtlMs] of cases) {
-    process.env.KIS_ORDER_DEDUP_TTL_MS = envValue;
-    assert.equal(new OrderDedupStore().ttlMs, expectedTtlMs, `env=${envValue}`);
-  }
-
-  delete process.env.KIS_ORDER_DEDUP_TTL_MS;
-  assert.equal(new OrderDedupStore().ttlMs, DEFAULT_TTL_MS, "env=unset");
-
+  // 유효한 값: 파싱된 값을 그대로 쓰고, 경고가 없어야 한다.
+  const [validEnvValue, expectedValidTtlMs] = validCase;
+  process.env.KIS_ORDER_DEDUP_TTL_MS = validEnvValue;
+  assert.equal(new OrderDedupStore().ttlMs, expectedValidTtlMs, `env=${validEnvValue}`);
   assert.equal(
     consoleError.mock.callCount(),
     0,
-    "잘못된 값에 대한 폴백은 조용히 처리되어야 합니다(console.error 호출 없음)",
+    `유효한 값(env=${validEnvValue})에는 경고가 없어야 합니다`,
+  );
+
+  // 잘못된 값: 기본값으로 폴백하되, 값마다 경고가 한 번씩 발생해야 한다.
+  for (const [envValue, expectedTtlMs] of invalidCases) {
+    consoleError.mock.resetCalls();
+    process.env.KIS_ORDER_DEDUP_TTL_MS = envValue;
+    assert.equal(new OrderDedupStore().ttlMs, expectedTtlMs, `env=${envValue}`);
+    assert.equal(
+      consoleError.mock.callCount(),
+      1,
+      `잘못된 값(env=${envValue})에는 경고가 한 번 발생해야 합니다`,
+    );
+    const [message] = consoleError.mock.calls[0].arguments;
+    assert.match(
+      message,
+      /KIS_ORDER_DEDUP_TTL_MS/,
+      `경고 메시지에 변수명이 포함되어야 합니다(env=${envValue})`,
+    );
+    assert.ok(
+      message.includes(envValue),
+      `경고 메시지에 잘못된 값이 포함되어야 합니다: ${message}`,
+    );
+  }
+
+  // 값이 아예 없는 경우(정상적인 기본값 사용)는 조용해야 한다.
+  consoleError.mock.resetCalls();
+  delete process.env.KIS_ORDER_DEDUP_TTL_MS;
+  assert.equal(new OrderDedupStore().ttlMs, DEFAULT_TTL_MS, "env=unset");
+  assert.equal(
+    consoleError.mock.callCount(),
+    0,
+    "env var가 설정되지 않은 정상 폴백 경로는 조용해야 합니다(console.error 호출 없음)",
+  );
+});
+
+test("OrderDedupStore stays silent when KIS_ORDER_DEDUP_TTL_MS is set but blank", (t) => {
+  const originalEnvValue = process.env.KIS_ORDER_DEDUP_TTL_MS;
+  t.after(() => {
+    if (originalEnvValue === undefined) {
+      delete process.env.KIS_ORDER_DEDUP_TTL_MS;
+    } else {
+      process.env.KIS_ORDER_DEDUP_TTL_MS = originalEnvValue;
+    }
+  });
+
+  const consoleError = t.mock.method(console, "error", () => {});
+
+  // 빈 문자열(KIS_ORDER_DEDUP_TTL_MS=)은 .env 파일에서 값을 비워둔 상태와
+  // 동일하게 취급한다 - 오타로 값을 지정한 것이 아니라 사실상 미설정과
+  // 같은 상태이므로 경고하지 않는다.
+  process.env.KIS_ORDER_DEDUP_TTL_MS = "";
+  assert.equal(new OrderDedupStore().ttlMs, 120_000, "env=blank");
+  assert.equal(
+    consoleError.mock.callCount(),
+    0,
+    "빈 문자열은 미설정과 동일하게 조용히 처리되어야 합니다",
   );
 });

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -194,6 +194,10 @@ test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, warnin
       message.includes(envValue),
       `경고 메시지에 잘못된 값이 포함되어야 합니다: ${message}`,
     );
+    assert.ok(
+      message.includes(`="${envValue}"`),
+      `경고 메시지에서 값의 경계가 따옴표로 표시되어야 합니다: ${message}`,
+    );
   }
 
   // 값이 아예 없는 경우(정상적인 기본값 사용)는 조용해야 한다.
@@ -228,5 +232,17 @@ test("OrderDedupStore stays silent when KIS_ORDER_DEDUP_TTL_MS is set but blank"
     consoleError.mock.callCount(),
     0,
     "빈 문자열은 미설정과 동일하게 조용히 처리되어야 합니다",
+  );
+
+  // 공백만 있는 값(docker-compose.yml의 environment: 블록이나 셸 export로
+  // 전달될 수 있다 - dotenv는 트림하지만 이 경로들은 그대로 전달한다)도
+  // 빈 문자열과 같은 의도이므로 조용히 처리되어야 한다.
+  consoleError.mock.resetCalls();
+  process.env.KIS_ORDER_DEDUP_TTL_MS = "   ";
+  assert.equal(new OrderDedupStore().ttlMs, 120_000, "env=whitespace-only");
+  assert.equal(
+    consoleError.mock.callCount(),
+    0,
+    "공백만 있는 값은 미설정과 동일하게 조용히 처리되어야 합니다",
   );
 });

--- a/mcp-trading/tests/order-dedup.test.js
+++ b/mcp-trading/tests/order-dedup.test.js
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test, { after } from "node:test";
 import {
+  DEFAULT_ORDER_DEDUP_TTL_MS,
   DuplicateOrderError,
   OrderDedupStore,
   createOrderDedupKey,
@@ -154,14 +155,13 @@ test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, warnin
 
   const consoleError = t.mock.method(console, "error", () => {});
 
-  const DEFAULT_TTL_MS = 120_000;
   const validCase = ["600000", 600_000]; // 유효한 값은 그대로 사용되고 경고가 없다
   const invalidCases = [
-    ["600_000", DEFAULT_TTL_MS], // JS 숫자 구분자(_) 습관 - Number()는 이를 파싱하지 못함
-    ["10m", DEFAULT_TTL_MS], // 단위 접미사 오타
-    ["0", DEFAULT_TTL_MS], // <= 0 분기
-    ["-1", DEFAULT_TTL_MS], // <= 0 분기, 음수
-    ["60.5", DEFAULT_TTL_MS], // !Number.isInteger 분기
+    ["600_000", DEFAULT_ORDER_DEDUP_TTL_MS], // JS 숫자 구분자(_) 습관 - Number()는 이를 파싱하지 못함
+    ["10m", DEFAULT_ORDER_DEDUP_TTL_MS], // 단위 접미사 오타
+    ["0", DEFAULT_ORDER_DEDUP_TTL_MS], // <= 0 분기
+    ["-1", DEFAULT_ORDER_DEDUP_TTL_MS], // <= 0 분기, 음수
+    ["60.5", DEFAULT_ORDER_DEDUP_TTL_MS], // !Number.isInteger 분기
   ];
 
   // 유효한 값: 파싱된 값을 그대로 쓰고, 경고가 없어야 한다.
@@ -198,12 +198,16 @@ test("OrderDedupStore resolves ttlMs from KIS_ORDER_DEDUP_TTL_MS env var, warnin
       message.includes(`="${envValue}"`),
       `경고 메시지에서 값의 경계가 따옴표로 표시되어야 합니다: ${message}`,
     );
+    assert.ok(
+      message.includes(String(DEFAULT_ORDER_DEDUP_TTL_MS)),
+      `경고 메시지에 실제 적용되는 기본값이 포함되어야 합니다: ${message}`,
+    );
   }
 
   // 값이 아예 없는 경우(정상적인 기본값 사용)는 조용해야 한다.
   consoleError.mock.resetCalls();
   delete process.env.KIS_ORDER_DEDUP_TTL_MS;
-  assert.equal(new OrderDedupStore().ttlMs, DEFAULT_TTL_MS, "env=unset");
+  assert.equal(new OrderDedupStore().ttlMs, DEFAULT_ORDER_DEDUP_TTL_MS, "env=unset");
   assert.equal(
     consoleError.mock.callCount(),
     0,


### PR DESCRIPTION
## 📝 개요

`KIS_ORDER_DEDUP_TTL_MS`에 파싱할 수 없는 값이 들어오면 아무 경고 없이 기본값 120초로 되돌아가던 것을, stderr에 경고를 남기도록 합니다.

README와 `.env.example`이 **사용자에게 이 값을 올리라고 적극 권합니다** — 기본 TTL 120초는 재빌드를 동반한 재배포 창을 덮지 못하므로 배포 중 중복 주문을 막으려면 상향이 필요하다고 안내합니다. 그런데 `600_000`(JS 숫자 구분자 습관)이나 `10m`처럼 쓰면 `Number()`가 `NaN`을 내고 조용히 120초로 돌아갑니다. 사용자는 배포 창을 덮었다고 믿지만 실제 방어선은 그대로입니다.

문서가 조정을 권하는 값이므로 이 오타는 가정이 아니라 실제로 밟게 되는 경로입니다.

## 🚀 변경 사항

- `mcp-trading/order-dedup.js`: `parsePositiveInteger`가 **값이 주어졌는데** 파싱에 실패한 경우에만 경고를 남깁니다. 값이 아예 없는 정상 기본값 경로는 그대로 조용합니다.

```
KIS_ORDER_DEDUP_TTL_MS=600_000 는 양의 정수(ms)가 아니어서 기본값 120000ms를 사용합니다.
```

`console.error`(stderr)만 씁니다. `mcp-trading`의 stdout은 MCP JSON-RPC 채널이라 `console.log`를 쓰면 프로토콜이 깨집니다. 같은 파일의 `#readLedger`가 이미 이 관례를 씁니다.

**폴백 동작 자체는 바꾸지 않았습니다.** 들리게만 만들었습니다 — 조용히 다르게 동작하면 원장의 TTL 의미가 바뀝니다.

### 기존 테스트를 뒤집었습니다

`order-dedup.test.js`에 **경고가 없다는 것**을 단언하는 테스트가 있었습니다(PR #127에서 현재 동작을 특성화한 것). `t.mock.method(console, "error")`로 `callCount() === 0`을 확인하던 부분입니다.

이 이슈를 구현하면 그 단언이 실패하는 게 **의도된 것**이라 이슈 본문에 미리 적어 뒀고, 그대로 뒤집었습니다. 테스트 이름의 `silently`도 함께 제거했습니다. 그러지 않으면 후속 PR이 빨간 CI를 만나 잘못된 방향(경고 제거)으로 "고칠" 위험이 있었습니다.

### 빈 문자열은 조용히 둡니다

`KIS_ORDER_DEDUP_TTL_MS=`(설정했지만 비어 있음)는 미설정과 같게 취급합니다. `.env`에서 빈 값은 보통 "줄은 있지만 의도적으로 비워 둠"(주석 처리된 오버라이드, 템플릿 뼈대)이지 잘못 타이핑한 값이 아닙니다. 여기서 경고하면 정상적인 "오버라이드 안 함" 패턴에 소음이 되고, 오타가 없으니 짚어 줄 것도 없습니다. 전용 테스트로 고정했습니다.

## 🔗 관련 이슈

- Closes #148
- Related to #124 / PR #127 — 이 동작을 회귀 테스트로 고정하고 수정은 본 이슈로 분리

## ✅ 체크리스트

- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요? — 동작 변경이 아니라 진단 출력 추가라 사용자 문서에 드러나지 않음

변이 확인 2건입니다.

| 되돌린 것 | 실패하는 단언 |
| :--- | :--- |
| `value !== undefined && value !== ""` 가드 제거(무조건 경고) | 미설정·빈 문자열 각각의 "경고 없음" 단언 2건 |
| 메시지에서 문제 값 제거 | "메시지에 문제 값이 포함됨" 단언 |
