### PR TITLE
fix: 종목명 매칭보다 코드 형태 지름길을 나중에 시도

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -92,9 +92,14 @@ def _has_code_digit(value: str) -> bool:
 def _looks_like_stock_code(stock: str) -> bool:
     """이미 종목코드 형태여서 MCP 조회를 생략해도 되는지 판정합니다.
 
-    mcp-trading/stock-master.js가 입력을 코드로 인정하는 범위(6~7자 영숫자)를 따르되,
-    실제 코드는 항상 숫자를 포함하므로 숫자 포함을 함께 요구합니다.
-    이 조건이 없으면 6~7자 영문 종목명이 코드로 오인됩니다.
+    주의(#150 이후): stock-master.js의 resolveStock은 코드 형태 입력이라도 이름·별칭
+    매칭을 먼저 시도하고 실패했을 때만 코드로 인정한다. 이 함수는 마스터를 볼 수 없어
+    그 확인 없이 코드로 확정하므로, JS보다 더 공격적이다.
+    지금은 _has_code_digit이 안전망 역할을 한다 — 코드 형태 이름 3종(SIMPAC/INVENI/
+    WISCOM)이 모두 숫자를 포함하지 않아 여기서 걸러지고 MCP로 넘어간다.
+    숫자를 포함한 6~7자 이름이 신규 상장되면 이 안전망이 뚫린다. mcp-trading/tests/
+    stock-master.test.js의 "exactly 3 master stock names..." 테스트가 그 신호이며,
+    그 테스트가 깨지면 이 함수도 함께 재검토해야 한다.
     """
     value = stock.strip().upper()
     return bool(_STOCK_CODE_RE.match(value)) and _has_code_digit(value)
@@ -132,6 +137,9 @@ async def _resolve_stock_code(stock: str) -> str:
             return ""
         # 지름길 에코("SIMPAC (SIMPAC, UNKNOWN)")는 숫자가 없어 위 _has_code_digit
         # 가드에서 이미 걸러진다.
+        # #150 이후 resolveStock이 이름·별칭 매칭을 코드 지름길보다 먼저 시도하므로,
+        # 실제 마스터 데이터로는 이 에코가 더 이상 발생하지 않는다. 지금은 사용자가
+        # 코드 형태 입력을 직접 준 경우에 대한 방어로만 남아 있다.
         # 상한 도달은 정상 조건이 아니다 — 종목마스터 4,353종 규모에서는 일어나지
         # 않아야 하며, 발생했다면 입력 정규화가 stock-master.js와 다시 어긋났다는
         # 신호다. dict는 자동으로 비우지 않으므로 침묵한 채 자라기만 하면 상한을

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -305,11 +305,13 @@ async def test_perform_stock_analysis_extraction_failure_not_cached(monkeypatch)
 async def test_perform_stock_analysis_rejects_digitless_extracted_code(monkeypatch, caplog):
     """SIMPAC(009160)은 실제 KOSPI 상장 종목명이 숫자 없는 6자 영문이다.
 
-    stock-master.js의 지름길(6~7자 영숫자 입력을 그대로 코드로 되돌림)이 정확한 명칭
-    매칭보다 먼저 실행되므로, resolveStock("SIMPAC")은 "SIMPAC (SIMPAC, UNKNOWN)"을
-    돌려준다. `_STOCK_CODE_EXTRACT_RE`는 이 값을 코드처럼 추출하지만 숫자가 없으므로
-    `_has_code_digit`이 걸러내야 한다. 종목마스터에서 같은 형태인 이름은
-    INVENI(015360), WISCOM(024070) 두 개뿐이다.
+    #150 이후 resolveStock은 이름·별칭 매칭을 코드 지름길보다 먼저 시도하므로
+    "SIMPAC (SIMPAC, UNKNOWN)"이 실제 마스터 데이터로 나오는 경로는 더 이상
+    없다. 이 테스트는 그 경로를 가정하지 않는다 — MCP가 어떤 이유로든(마스터
+    갱신 지연, 다른 소스 등) 숫자 없는 코드를 돌려줬을 때 `_STOCK_CODE_EXTRACT_RE`가
+    그 값을 코드처럼 추출하더라도 `_has_code_digit`이 걸러내는지를 직접
+    검증한다. 종목마스터에서 같은 형태인 이름은 INVENI(015360), WISCOM(024070)
+    두 개뿐이다.
     """
 
     async def fake_llm_chat(provider, prompt, *, conversation_id=None):

--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -46,6 +46,11 @@ export function resolveStock(stockName, stocks) {
   }
 
   const isCodeShaped = CODE_SHAPE_PATTERN.test(input);
+  // Hoisted out of the filter loop below (recomputing per-entry cost 4,353
+  // calls on the default master) and reused by the direct-code fallback
+  // further down, since both need the same uppercased value once isCodeShaped
+  // is true.
+  const upperInput = isCodeShaped ? input.toUpperCase() : input;
 
   const stockList = stocks ?? getDefaultStocks();
   const matches = stockList.filter((stock) => {
@@ -53,19 +58,17 @@ export function resolveStock(stockName, stocks) {
     if (stock.name === input || aliases.includes(input)) {
       return true;
     }
+    if (!isCodeShaped) {
+      return false;
+    }
     // A code-shaped input (e.g. a ticker-like company name such as SIMPAC)
     // may be typed in any case, mirroring the case-insensitivity the code
-    // shortcut below already provides for direct codes.
-    if (isCodeShaped) {
-      const upperInput = input.toUpperCase();
-      if (stock.name.toUpperCase() === upperInput) {
-        return true;
-      }
-      if (aliases.some((alias) => alias.toUpperCase() === upperInput)) {
-        return true;
-      }
-    }
-    return false;
+    // shortcut below already provides for direct codes. `name`/`aliases`
+    // entries may be missing on a caller-supplied stock list (resolveStock's
+    // `stocks` parameter is public), so default to "" before upper-casing
+    // instead of letting a bare `undefined`/`null` throw.
+    return String(stock.name ?? "").toUpperCase() === upperInput
+      || aliases.some((alias) => String(alias ?? "").toUpperCase() === upperInput);
   });
 
   if (matches.length > 1) {
@@ -85,8 +88,7 @@ export function resolveStock(stockName, stocks) {
   // Nothing in the master matches by name or alias: only now treat a
   // code-shaped input (e.g. an alphanumeric ETN/fund code) as a direct code.
   if (isCodeShaped) {
-    const code = input.toUpperCase();
-    return { code, name: code, market: "UNKNOWN", aliases: [] };
+    return { code: upperInput, name: upperInput, market: "UNKNOWN", aliases: [] };
   }
 
   throw new Error(

--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -29,29 +29,44 @@ export function normalizeStockInput(value) {
   return String(value ?? "").trim();
 }
 
+const CODE_SHAPE_PATTERN = /^[A-Z0-9]{6,7}$/i;
+const NUMERIC_CODE_PATTERN = /^[0-9]{6,7}$/;
+
 export function resolveStock(stockName, stocks) {
   const input = normalizeStockInput(stockName);
   if (!input) {
     throw new Error("stock_name 파라미터가 누락되었습니다.");
   }
 
-  if (/^[A-Z0-9]{6,7}$/i.test(input)) {
-    const code = input.toUpperCase();
-    return { code, name: code, market: "UNKNOWN", aliases: [] };
+  // Pure numeric input can never be a registered stock name (Korean/English
+  // company names always contain at least one non-digit character), so it is
+  // safe to treat it as a direct code without paying for a master lookup.
+  if (NUMERIC_CODE_PATTERN.test(input)) {
+    return { code: input, name: input, market: "UNKNOWN", aliases: [] };
   }
+
+  const isCodeShaped = CODE_SHAPE_PATTERN.test(input);
 
   const stockList = stocks ?? getDefaultStocks();
   const matches = stockList.filter((stock) => {
     const aliases = Array.isArray(stock.aliases) ? stock.aliases : [];
-    return stock.name === input || aliases.includes(input);
+    if (stock.name === input || aliases.includes(input)) {
+      return true;
+    }
+    // A code-shaped input (e.g. a ticker-like company name such as SIMPAC)
+    // may be typed in any case, mirroring the case-insensitivity the code
+    // shortcut below already provides for direct codes.
+    if (isCodeShaped) {
+      const upperInput = input.toUpperCase();
+      if (stock.name.toUpperCase() === upperInput) {
+        return true;
+      }
+      if (aliases.some((alias) => alias.toUpperCase() === upperInput)) {
+        return true;
+      }
+    }
+    return false;
   });
-
-  if (matches.length === 0) {
-    throw new Error(
-      `'${input}'의 종목 코드를 찾을 수 없습니다. ` +
-        "6자리 종목코드로 직접 입력하거나 mcp-trading/data/stocks.json을 갱신하세요.",
-    );
-  }
 
   if (matches.length > 1) {
     const candidates = matches
@@ -60,8 +75,22 @@ export function resolveStock(stockName, stocks) {
     throw new Error(`'${input}'의 종목 매칭이 모호합니다: ${candidates}. 6자리 종목코드를 직접 입력하세요.`);
   }
 
-  return {
-    aliases: [],
-    ...matches[0],
-  };
+  if (matches.length === 1) {
+    return {
+      aliases: [],
+      ...matches[0],
+    };
+  }
+
+  // Nothing in the master matches by name or alias: only now treat a
+  // code-shaped input (e.g. an alphanumeric ETN/fund code) as a direct code.
+  if (isCodeShaped) {
+    const code = input.toUpperCase();
+    return { code, name: code, market: "UNKNOWN", aliases: [] };
+  }
+
+  throw new Error(
+    `'${input}'의 종목 코드를 찾을 수 없습니다. ` +
+      "6자리 종목코드로 직접 입력하거나 mcp-trading/data/stocks.json을 갱신하세요.",
+  );
 }

--- a/mcp-trading/stock-master.js
+++ b/mcp-trading/stock-master.js
@@ -29,7 +29,7 @@ export function normalizeStockInput(value) {
   return String(value ?? "").trim();
 }
 
-const CODE_SHAPE_PATTERN = /^[A-Z0-9]{6,7}$/i;
+export const CODE_SHAPE_PATTERN = /^[A-Z0-9]{6,7}$/i;
 const NUMERIC_CODE_PATTERN = /^[0-9]{6,7}$/;
 
 export function resolveStock(stockName, stocks) {

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -183,6 +183,22 @@ test("resolveStock resolves a fund's Korean name to its real 9 char code, unaffe
   });
 });
 
+test("resolveStock does not throw when a caller-supplied stock entry is missing a name", () => {
+  // resolveStock(stockName, stocks) accepts a caller-supplied array, so a
+  // stock entry without a `name` property is reachable even though the
+  // bundled master never omits one. The old `stock.name.toUpperCase()` (no
+  // `aliases`-style Array.isArray guard) threw a TypeError here; this pins
+  // that a missing `name` is defended the same way a missing/non-array
+  // `aliases` already is.
+  const stocks = [{ code: "999999", aliases: ["009160"] }];
+  assert.deepEqual(resolveStock("SIMPAC", stocks), {
+    code: "SIMPAC",
+    name: "SIMPAC",
+    market: "UNKNOWN",
+    aliases: [],
+  });
+});
+
 test("exactly 3 master stock names match the code-shaped pattern, and 0 aliases do", () => {
   // This is the issue's own acceptance query, turned into a regression test.
   // If a future stocks.json update adds or removes a name/alias matching

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
-import { clearStocksCache, DEFAULT_STOCKS_PATH, resolveStock } from "../stock-master.js";
+import { clearStocksCache, DEFAULT_STOCKS_PATH, getDefaultStocks, resolveStock } from "../stock-master.js";
 
 test("resolveStock resolves names from the expanded domestic stock master", () => {
   assert.deepEqual(resolveStock("카카오"), {
@@ -94,4 +94,118 @@ test("resolveStock resolves deduplicated ETN names without ambiguity", () => {
     market: "KOSPI",
     aliases: [],
   });
+});
+
+// Issue #150: the code-shaped shortcut (`/^[A-Z0-9]{6,7}$/i`) used to run
+// before exact name/alias matching, so a listed company whose registered
+// name happens to be a 6-7 char alphanumeric string was shadowed by its own
+// name and echoed back as an UNKNOWN "code". These three tests catch a
+// regression to that ordering: if the shortcut is moved back in front of
+// name/alias matching, each of these would fail by returning
+// { code: "SIMPAC"/"INVENI"/"WISCOM", market: "UNKNOWN" } instead of the
+// real master entry.
+
+test("resolveStock resolves SIMPAC to its real KOSPI code instead of echoing the name as a code", () => {
+  assert.deepEqual(resolveStock("SIMPAC"), {
+    code: "009160",
+    name: "SIMPAC",
+    market: "KOSPI",
+    aliases: [],
+  });
+});
+
+test("resolveStock resolves INVENI to its real KOSPI code instead of echoing the name as a code", () => {
+  assert.deepEqual(resolveStock("INVENI"), {
+    code: "015360",
+    name: "INVENI",
+    market: "KOSPI",
+    aliases: [],
+  });
+});
+
+test("resolveStock resolves WISCOM to its real KOSPI code instead of echoing the name as a code", () => {
+  assert.deepEqual(resolveStock("WISCOM"), {
+    code: "024070",
+    name: "WISCOM",
+    market: "KOSPI",
+    aliases: [],
+  });
+});
+
+test("resolveStock resolves a lowercase code-shaped name case-insensitively, not as an echoed code", () => {
+  // The old shortcut regex carried the `/i` flag, so lowercase input echoed
+  // back just like the uppercase form. This asserts the fix's name-matching
+  // fallback is likewise case-insensitive for code-shaped input, catching a
+  // regression where only exact-case name matching was restored.
+  assert.deepEqual(resolveStock("simpac"), {
+    code: "009160",
+    name: "SIMPAC",
+    market: "KOSPI",
+    aliases: [],
+  });
+});
+
+test("resolveStock still resolves a direct 6 digit stock code that matches no master name", () => {
+  // Guards the shortcut's real purpose: numeric codes must keep working
+  // without ever touching the master (see the read-count test below), even
+  // after reordering the checks.
+  assert.deepEqual(resolveStock("005930"), {
+    code: "005930",
+    name: "005930",
+    market: "UNKNOWN",
+    aliases: [],
+  });
+});
+
+test("resolveStock still resolves a direct alphanumeric ETN code that matches no master name", () => {
+  // "Q570121" is a real ETN's own code, distinct from resolving it by name
+  // (covered above). It must still fall through to the code shortcut once
+  // name/alias matching finds nothing, proving the reorder didn't remove the
+  // fallback entirely.
+  assert.deepEqual(resolveStock("Q570121"), {
+    code: "Q570121",
+    name: "Q570121",
+    market: "UNKNOWN",
+    aliases: [],
+  });
+});
+
+test("resolveStock resolves a fund's Korean name to its real 9 char code, unaffected by the shortcut reorder", () => {
+  // 9 char fund codes (e.g. F70100026) fall outside the shortcut's {6,7}
+  // pattern entirely and can only be reached via name/alias matching. This
+  // pins that the reordering did not disturb matching for names containing
+  // parentheses or codes longer than the shortcut's range.
+  assert.deepEqual(resolveStock("한투글로벌넥스트웨이브1(A)"), {
+    code: "F70100026",
+    name: "한투글로벌넥스트웨이브1(A)",
+    market: "KOSPI",
+    aliases: [],
+  });
+});
+
+test("exactly 3 master stock names match the code-shaped pattern, and 0 aliases do", () => {
+  // This is the issue's own acceptance query, turned into a regression test.
+  // If a future stocks.json update adds or removes a name/alias matching
+  // /^[A-Za-z0-9]{6,7}$/, this test documents the change and forces a
+  // conscious re-check of the shortcut-ordering fix rather than a silent
+  // reintroduction of the shadowing bug for a new listing.
+  const stocks = getDefaultStocks();
+  const codeShapePattern = /^[A-Za-z0-9]{6,7}$/;
+
+  const nameMatches = stocks.filter((stock) => codeShapePattern.test(stock.name));
+  assert.deepEqual(
+    nameMatches.map((stock) => [stock.name, stock.code, stock.market]).sort(),
+    [
+      ["INVENI", "015360", "KOSPI"],
+      ["SIMPAC", "009160", "KOSPI"],
+      ["WISCOM", "024070", "KOSPI"],
+    ],
+  );
+
+  let aliasMatchCount = 0;
+  for (const stock of stocks) {
+    const aliases = Array.isArray(stock.aliases) ? stock.aliases : [];
+    aliasMatchCount += aliases.filter((alias) => codeShapePattern.test(alias)).length;
+  }
+  assert.equal(aliasMatchCount, 0);
 });

--- a/mcp-trading/tests/stock-master.test.js
+++ b/mcp-trading/tests/stock-master.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
-import { clearStocksCache, DEFAULT_STOCKS_PATH, getDefaultStocks, resolveStock } from "../stock-master.js";
+import { CODE_SHAPE_PATTERN, clearStocksCache, DEFAULT_STOCKS_PATH, getDefaultStocks, resolveStock } from "../stock-master.js";
 
 test("resolveStock resolves names from the expanded domestic stock master", () => {
   assert.deepEqual(resolveStock("카카오"), {
@@ -202,11 +202,14 @@ test("resolveStock does not throw when a caller-supplied stock entry is missing 
 test("exactly 3 master stock names match the code-shaped pattern, and 0 aliases do", () => {
   // This is the issue's own acceptance query, turned into a regression test.
   // If a future stocks.json update adds or removes a name/alias matching
-  // /^[A-Za-z0-9]{6,7}$/, this test documents the change and forces a
+  // CODE_SHAPE_PATTERN, this test documents the change and forces a
   // conscious re-check of the shortcut-ordering fix rather than a silent
   // reintroduction of the shadowing bug for a new listing.
+  // Uses the implementation's own exported pattern (rather than a hardcoded
+  // copy) so this guard can never drift out of sync with what resolveStock
+  // actually treats as code-shaped.
   const stocks = getDefaultStocks();
-  const codeShapePattern = /^[A-Za-z0-9]{6,7}$/;
+  const codeShapePattern = CODE_SHAPE_PATTERN;
 
   const nameMatches = stocks.filter((stock) => codeShapePattern.test(stock.name));
   assert.deepEqual(


### PR DESCRIPTION
## 📝 개요

`resolveStock`이 코드 형태 지름길을 **정확한 종목명 매칭보다 먼저** 실행해, 종목명이 6~7자 영숫자인 정상 상장 종목이 자기 이름에 가려져 코드를 찾지 못하던 문제를 수정합니다.

```js
// 수정 전 — 이 분기가 이름 매칭보다 먼저
if (/^[A-Z0-9]{6,7}$/i.test(input)) {
  const code = input.toUpperCase();
  return { code, name: code, market: "UNKNOWN" };
}
```

영향 범위는 정확히 3종목입니다. 종목마스터 4,353건 중 이름이 `/^[A-Za-z0-9]{6,7}$/`에 매치되는 것이 아래 셋뿐이고, 별칭 중에는 0건입니다.

| 종목명 | 실제 코드 | 시장 |
| :--- | :--- | :--- |
| SIMPAC | 009160 | KOSPI |
| INVENI | 015360 | KOSPI |
| WISCOM | 024070 | KOSPI |

셋 다 평범한 6자리 숫자 코드를 가진 KOSPI 보통주입니다. 스팩도 ETN도 아닙니다.

## 🚀 변경 사항

**지름길을 하나가 아니라 둘로 나눴습니다.** 단순 재배치로는 기존 동작 하나가 깨집니다.

1. **순수 숫자 6~7자리** — 종목마스터를 **아예 읽지 않고** 즉시 코드로 해석합니다. 기존 테스트 `resolveStock does not read the default stock master for direct stock codes`가 이 경로를 고정하고 있는데, 이름 매칭을 먼저 하도록 통째로 옮기면 그 보장이 사라집니다. 한글·영문 종목명이 전부 숫자일 수는 없으므로 이 분기를 앞에 두는 것은 안전합니다.
2. **영문이 섞인 코드 형태** — 정확한 이름·별칭 매칭을 **먼저** 시도하고, 어느 것과도 맞지 않을 때만 코드로 해석합니다.

이 분기의 이름 매칭은 대소문자를 무시합니다. 기존 지름길 정규식에 `/i`가 붙어 있어 `simpac`도 똑같이 에코되고 있었기 때문입니다.

모호 매칭 처리(`matches.length > 1`이면 throw)는 형태·메시지 모두 그대로입니다.

## 소비자별 증상

- `backend/services.py` — PR #133 이전에는 `AgentReport.stock_code`에 `"SIMPAC"`이 저장됐습니다. #133이 숫자 불변식을 넣어 지금은 `""`가 됩니다. 조용한 오염은 막았지만 **코드를 못 찾는 것은 그대로**였고, 이 PR이 그걸 해소합니다.
- `backend/telegram_commands.py` — `/buy SIMPAC 10`이 `"SIMPAC"`을 코드로 추출해 `_ORDERABLE_STOCK_CODE_RE`에서 걸리고, **"ETN·펀드 등 영숫자 종목코드는 아직 주문 대상이 아닙니다"** 라고 응답했습니다. 코드 009160인 일반 KOSPI 종목에 사실과 다른 사유를 안내하던 것입니다.

## 건드리지 않은 것

`backend/services.py`의 `_resolve_stock_code`에 있는 지름길 에코 스킵은 그대로 뒀습니다. 이 수정 이후 실제 종목마스터 데이터에 대해서는 도달할 수 없게 되지만, 코드를 직접 입력하는 경로는 여전히 방어합니다.

## 🔗 관련 이슈

- Closes #150
- Related to #125 / PR #133 — 백엔드 측 숫자 불변식. 오염은 막았으나 조회 불가는 남아 있었음

## ✅ 체크리스트

- [x] 코딩 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성하거나 기존 테스트를 통과했나요?
- [x] 불필요한 주석이나 디버깅 코드를 제거했나요?
- [x] 변경 사항에 대한 문서(README 등)를 업데이트했나요? — 도구 내부 해석 순서 변경이라 사용자 문서에 드러나지 않음

`node --test tests/*.test.js` **61 passing / 0 failing** (변경 전 53, 신규 8건).

**변이 검증**: 수정을 stash하고 새 테스트를 원본 코드에 돌린 결과, 버그를 겨냥한 4건(SIMPAC·INVENI·WISCOM·소문자 `simpac`)만 정확히 실패하고 직접 코드 입력·9자 펀드명·수용 기준 카운트 테스트는 통과했습니다. 앞의 넷이 회귀를 잡는 단언이고 뒤는 비회귀 대조군임이 확인됩니다.

**충돌 확인**: 세 종목명이 다른 종목의 실제 `code` 필드와 겹치는지 전수 조회했고, 그런 사례는 없습니다.
