### PR TITLE
fix: 원장 기록 실패가 성공한 주문의 중복 가드를 지우던 문제

### DIFF
--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import crypto from "node:crypto";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import axios from "axios";
@@ -322,6 +322,39 @@ async function getBalance() {
   );
 }
 
+// KIS 제출과 dedup 원장 기록을 분리한다: 주문 결과는 오직 KIS 응답으로만 결정되고,
+// 원장 기록(성공 표시/거절 시 해제)의 실패는 이미 확정된 주문 결과를 절대 뒤집지 않는다.
+export async function submitOrder({ orderDedupStore, dedupKey, submit }) {
+  let data;
+  try {
+    data = await submit();
+  } catch (error) {
+    // 명시적 허용 목록: KIS가 거절했다고 확인된 경우에만 해제한다(nothing was submitted).
+    // axios 전송 실패(제출 여부 불명)나 그 밖의 어떤 예외도 기본은 해제하지 않는다(fail-closed).
+    if (error.kisOrderRejected === true) {
+      try {
+        orderDedupStore.release(dedupKey);
+      } catch (releaseError) {
+        // release()도 원장 파일을 거쳐 던질 수 있다. 여기서 던지면 원래 KIS 거절 사유가
+        // 사라지므로, 로그만 남기고 원래 예외를 그대로 전파한다. 항목은 in_flight로 남아
+        // TTL까지 중복을 계속 막으므로 fail-closed 성질은 유지된다.
+        console.error(`주문 거절 후 원장 정리 실패(항목은 in_flight로 유지): ${releaseError.message}`);
+      }
+    }
+    throw error;
+  }
+
+  try {
+    orderDedupStore.markSucceeded(dedupKey, data);
+  } catch (error) {
+    // 주문은 이미 KIS에 체결됐다. 기록 실패로 가드를 지우면 재시도가 통과해 중복 주문이
+    // 나간다. 항목을 in_flight로 남겨두면 TTL 만료까지 중복을 계속 막는 안전한 저하다.
+    console.error(`주문 성공 후 원장 기록 실패(항목은 in_flight로 유지): ${error.message}`);
+  }
+
+  return data;
+}
+
 async function placeOrder(args) {
   requireKisCredentials({ accountRequired: true });
 
@@ -359,16 +392,11 @@ async function placeOrder(args) {
     body: request.body,
   });
 
-  let data;
-  try {
-    data = await kisPost(request.pathname, request.trId, request.body, { useHashKey: true });
-    orderDedupStore.markSucceeded(dedupKey, data);
-  } catch (error) {
-    if (!error.kisOrderSubmittedMaybe || error.kisOrderRejected) {
-      orderDedupStore.release(dedupKey);
-    }
-    throw error;
-  }
+  const data = await submitOrder({
+    orderDedupStore,
+    dedupKey,
+    submit: () => kisPost(request.pathname, request.trId, request.body, { useHashKey: true }),
+  });
   return formatOrderResult({
     stockName,
     stockCode,
@@ -714,7 +742,15 @@ server.registerTool(
   async (args) => callTradingTool("get_balance_rlz_pl", args),
 );
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+// 이 파일을 `node index.js`로 직접 실행할 때만 stdio transport를 연결한다.
+// 테스트가 submitOrder 등을 import할 때 실제 MCP 서버가 stdin/stdout을 점유하지
+// 않도록 막는 진입점 가드다(index.js는 그 외엔 export가 없어 이 가드가 유일한 테스트 seam).
+const isMainModule =
+  process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
 
-console.error("Trading MCP Server is running...");
+if (isMainModule) {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  console.error("Trading MCP Server is running...");
+}

--- a/mcp-trading/index.js
+++ b/mcp-trading/index.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import crypto from "node:crypto";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import axios from "axios";
@@ -24,6 +24,7 @@ import {
   createCashOrderRequest,
   formatOrderResult,
 } from "./order.js";
+import { submitOrder } from "./order-submit.js";
 import { resolveStock } from "./stock-master.js";
 
 // Redirect console.log to console.error to prevent breaking MCP JSON-RPC on stdout
@@ -223,7 +224,20 @@ async function createKisHashKey(body) {
 }
 
 async function kisPost(pathname, trId, body, { useHashKey = false } = {}) {
-  const token = await getAccessToken();
+  // 이 블록(토큰 발급, 필요 시 해시키 발급)이 던지는 오류는 아래 실제 주문 POST가 아직
+  // 나가기 전에 발생한 것이므로, 주문이 KIS에 제출되지 않았음이 확실하다.
+  let token;
+  let hashKey;
+  try {
+    token = await getAccessToken();
+    if (useHashKey) {
+      hashKey = await createKisHashKey(body);
+    }
+  } catch (error) {
+    error.kisOrderNotSubmitted = true;
+    throw error;
+  }
+
   const headers = {
     "Content-Type": "application/json",
     authorization: `Bearer ${token}`,
@@ -233,7 +247,7 @@ async function kisPost(pathname, trId, body, { useHashKey = false } = {}) {
     custtype: "P",
   };
   if (useHashKey) {
-    headers.hashkey = await createKisHashKey(body);
+    headers.hashkey = hashKey;
   }
 
   let response;
@@ -322,39 +336,6 @@ async function getBalance() {
   );
 }
 
-// KIS 제출과 dedup 원장 기록을 분리한다: 주문 결과는 오직 KIS 응답으로만 결정되고,
-// 원장 기록(성공 표시/거절 시 해제)의 실패는 이미 확정된 주문 결과를 절대 뒤집지 않는다.
-export async function submitOrder({ orderDedupStore, dedupKey, submit }) {
-  let data;
-  try {
-    data = await submit();
-  } catch (error) {
-    // 명시적 허용 목록: KIS가 거절했다고 확인된 경우에만 해제한다(nothing was submitted).
-    // axios 전송 실패(제출 여부 불명)나 그 밖의 어떤 예외도 기본은 해제하지 않는다(fail-closed).
-    if (error.kisOrderRejected === true) {
-      try {
-        orderDedupStore.release(dedupKey);
-      } catch (releaseError) {
-        // release()도 원장 파일을 거쳐 던질 수 있다. 여기서 던지면 원래 KIS 거절 사유가
-        // 사라지므로, 로그만 남기고 원래 예외를 그대로 전파한다. 항목은 in_flight로 남아
-        // TTL까지 중복을 계속 막으므로 fail-closed 성질은 유지된다.
-        console.error(`주문 거절 후 원장 정리 실패(항목은 in_flight로 유지): ${releaseError.message}`);
-      }
-    }
-    throw error;
-  }
-
-  try {
-    orderDedupStore.markSucceeded(dedupKey, data);
-  } catch (error) {
-    // 주문은 이미 KIS에 체결됐다. 기록 실패로 가드를 지우면 재시도가 통과해 중복 주문이
-    // 나간다. 항목을 in_flight로 남겨두면 TTL 만료까지 중복을 계속 막는 안전한 저하다.
-    console.error(`주문 성공 후 원장 기록 실패(항목은 in_flight로 유지): ${error.message}`);
-  }
-
-  return data;
-}
-
 async function placeOrder(args) {
   requireKisCredentials({ accountRequired: true });
 
@@ -393,7 +374,7 @@ async function placeOrder(args) {
   });
 
   const data = await submitOrder({
-    orderDedupStore,
+    dedupStore: orderDedupStore,
     dedupKey,
     submit: () => kisPost(request.pathname, request.trId, request.body, { useHashKey: true }),
   });
@@ -742,15 +723,7 @@ server.registerTool(
   async (args) => callTradingTool("get_balance_rlz_pl", args),
 );
 
-// 이 파일을 `node index.js`로 직접 실행할 때만 stdio transport를 연결한다.
-// 테스트가 submitOrder 등을 import할 때 실제 MCP 서버가 stdin/stdout을 점유하지
-// 않도록 막는 진입점 가드다(index.js는 그 외엔 export가 없어 이 가드가 유일한 테스트 seam).
-const isMainModule =
-  process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+const transport = new StdioServerTransport();
+await server.connect(transport);
 
-if (isMainModule) {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-
-  console.error("Trading MCP Server is running...");
-}
+console.error("Trading MCP Server is running...");

--- a/mcp-trading/order-submit.js
+++ b/mcp-trading/order-submit.js
@@ -1,0 +1,43 @@
+// index.js는 부작용을 가진 서버 진입점이라 여기서 import하지 않는다(balance.js:17와 동일한
+// 컨벤션) — order.js, order-dedup.js, formatters.js, stock-master.js처럼 이 파일도 그래서
+// index.js 밖으로 분리했다.
+//
+// KIS 제출과 dedup 원장 기록을 분리한다: 주문 결과는 오직 KIS 응답으로만 결정되고,
+// 원장 기록(성공 표시/거절·미제출 확인 시 해제)의 실패는 이미 확정된 주문 결과를
+// 절대 뒤집지 않는다.
+export async function submitOrder({ dedupStore, dedupKey, submit }) {
+  let data;
+  try {
+    data = await submit();
+  } catch (error) {
+    // 명시적 허용 목록: KIS가 거절했다고 확인됐거나(kisOrderRejected) KIS로 보내는 POST
+    // 자체가 나가기 전에 실패해 제출되지 않았음이 확실한 경우(kisOrderNotSubmitted)에만
+    // 해제한다. axios 전송 실패(제출 여부 불명, kisOrderSubmittedMaybe)나 그 밖에
+    // 인식하지 못한 예외는 기본적으로 해제하지 않는다(fail-closed).
+    if (error?.kisOrderRejected === true || error?.kisOrderNotSubmitted === true) {
+      try {
+        dedupStore.release(dedupKey);
+      } catch (releaseError) {
+        // release()도 원장 파일을 거쳐 던질 수 있다. 여기서 던지면 원래 KIS 오류(거절/
+        // 미제출 사유)가 사라지므로, 로그만 남기고 원래 예외를 그대로 전파한다. 항목은
+        // in_flight로 남아 TTL까지 중복을 계속 막으므로 fail-closed 성질은 유지된다.
+        console.error(
+          `주문 거절/미제출 확인 후 원장 정리 실패(항목은 in_flight로 유지): ${String(releaseError?.message ?? releaseError)}`,
+        );
+      }
+    }
+    throw error;
+  }
+
+  try {
+    dedupStore.markSucceeded(dedupKey, data);
+  } catch (error) {
+    // 주문은 이미 KIS에 체결됐다. 기록 실패로 가드를 지우면 재시도가 통과해 중복 주문이
+    // 나간다. 항목을 in_flight로 남겨두면 TTL 만료까지 중복을 계속 막는 안전한 저하다.
+    console.error(
+      `주문 성공 후 원장 기록 실패(항목은 in_flight로 유지): ${String(error?.message ?? error)}`,
+    );
+  }
+
+  return data;
+}

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -5,7 +5,6 @@ import path from "node:path";
 import test from "node:test";
 import util from "node:util";
 import { buildBalanceParams, fetchAllBalance, formatBalanceReport, formatPercent } from "../balance.js";
-import { submitOrder } from "../index.js";
 import { DuplicateOrderError, OrderDedupStore } from "../order-dedup.js";
 import {
   buildCashOrderBody,
@@ -14,6 +13,7 @@ import {
   selectCashOrderTrId,
   validateOrderEnvMatchesUrl,
 } from "../order.js";
+import { submitOrder } from "../order-submit.js";
 
 test("selectCashOrderTrId maps demo buy and sell to paper TR IDs", () => {
   assert.equal(selectCashOrderTrId({ orderEnv: "demo", side: "BUY" }), "VTTC0012U");
@@ -884,9 +884,16 @@ test("createCashOrderRequest builds market order body", () => {
 
 // #161: markSucceeded (ledger bookkeeping) sitting inside the same try as the KIS call
 // used to make a filesystem write failure look identical to an order failure, deleting
-// the duplicate guard for an order KIS had already accepted. submitOrder() (index.js)
+// the duplicate guard for an order KIS had already accepted. submitOrder() (order-submit.js)
 // separates "did KIS accept the order" from "did we finish recording it" so a ledger
 // write failure can never undo an accepted order.
+//
+// The release() allowlist recognizes three flags kisPost (index.js) can attach to a
+// thrown error: kisOrderRejected (KIS said rt_cd !== "0" — nothing was submitted),
+// kisOrderNotSubmitted (token/hashkey pre-flight failed before the order POST ever went
+// out — also nothing was submitted), and kisOrderSubmittedMaybe (the order POST itself
+// failed — submission status unknown). Only the first two release; the third, and any
+// unrecognized error, hold the guard (fail-closed).
 
 function tempDedupLedgerPath(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "finus-submit-order-test-"));
@@ -915,7 +922,7 @@ test("submitOrder: a markSucceeded (ledger write) failure after a successful KIS
 
   const kisResponse = { rt_cd: "0", output: { ODNO: "0000001234" } };
   const data = await submitOrder({
-    orderDedupStore: store,
+    dedupStore: store,
     dedupKey,
     submit: async () => kisResponse,
   });
@@ -929,7 +936,12 @@ test("submitOrder: a markSucceeded (ledger write) failure after a successful KIS
 // swallowing the error by writing an empty/succeeded-but-then-cleared entry). If the
 // entry disappeared, this reserve() would succeed instead of throwing, and a retried
 // order would go through — reproducing the duplicate-order bug from #161.
-test("submitOrder: after a markSucceeded failure, the ledger entry stays in place (in_flight) so a retried reserve() is still blocked as a duplicate", async (t) => {
+//
+// Caveat noted for the PR body, not fixed here: markSucceeded failing leaves the
+// original reservedAt/expiresAt untouched, so this only blocks a retry for whatever
+// remains of the original TTL window (order-dedup.js:80). A retry after the window
+// fully elapses still duplicates — that is pre-existing dedup design, not new here.
+test("submitOrder: after a markSucceeded failure, the ledger entry stays in place (in_flight) so a retried reserve() is still blocked as a duplicate within the TTL window", async (t) => {
   const store = new OrderDedupStore({ filePath: tempDedupLedgerPath(t), ttlMs: 60_000, now: () => 1_000 });
   const dedupKey = "order-key-retry-blocked";
   const request = { pathname: "/uapi/domestic-stock/v1/trading/order-cash", trId: "TTTC0012U", body: {} };
@@ -941,7 +953,7 @@ test("submitOrder: after a markSucceeded failure, the ledger entry stays in plac
   t.mock.method(console, "error", () => {});
 
   await submitOrder({
-    orderDedupStore: store,
+    dedupStore: store,
     dedupKey,
     submit: async () => ({ rt_cd: "0", output: { ODNO: "0000005678" } }),
   });
@@ -972,10 +984,38 @@ test("submitOrder: releases the dedup guard when KIS rejects the order (rt_cd !=
   rejected.kisOrderRejected = true;
 
   await assert.rejects(
-    () => submitOrder({ orderDedupStore: store, dedupKey: "order-key-rejected", submit: async () => { throw rejected; } }),
+    () => submitOrder({ dedupStore: store, dedupKey: "order-key-rejected", submit: async () => { throw rejected; } }),
     (err) => err === rejected,
   );
   assert.deepEqual(releaseCalls, ["order-key-rejected"]);
+});
+
+// Mutation this catches: dropping the `error.kisOrderNotSubmitted === true` allowlist
+// entry added after review of #161. getAccessToken() and createKisHashKey() both run
+// before the order POST in kisPost (index.js); a failure there — expired credentials,
+// a rate-limited token endpoint, a cold token cache after a container restart — means
+// the order was never sent. Without this class, that dedup key sits reserved for the
+// full TTL and DuplicateOrderError tells the user to "check the order shortly" for an
+// order that provably never existed, with no escape except changing quantity/price.
+test("submitOrder: releases the dedup guard when the KIS POST never went out (kisOrderNotSubmitted, e.g. token/hashkey pre-flight failure)", async (t) => {
+  const releaseCalls = [];
+  const store = {
+    release(key) {
+      releaseCalls.push(key);
+    },
+    markSucceeded() {
+      throw new Error("markSucceeded should not run when submit() throws");
+    },
+  };
+
+  const notSubmitted = new Error("Access Token 발급 실패: EGW00133 초당 거래건수를 초과하였습니다.");
+  notSubmitted.kisOrderNotSubmitted = true;
+
+  await assert.rejects(
+    () => submitOrder({ dedupStore: store, dedupKey: "order-key-not-submitted", submit: async () => { throw notSubmitted; } }),
+    (err) => err === notSubmitted,
+  );
+  assert.deepEqual(releaseCalls, ["order-key-not-submitted"]);
 });
 
 // Mutation this catches: releasing whenever `kisOrderSubmittedMaybe` is absent, which
@@ -995,18 +1035,18 @@ test("submitOrder: does not release the dedup guard when the axios POST fails an
   submitFailure.kisOrderSubmittedMaybe = true;
 
   await assert.rejects(
-    () => submitOrder({ orderDedupStore: store, dedupKey: "order-key-submit-unknown", submit: async () => { throw submitFailure; } }),
+    () => submitOrder({ dedupStore: store, dedupKey: "order-key-submit-unknown", submit: async () => { throw submitFailure; } }),
     (err) => err === submitFailure,
   );
   assert.deepEqual(releaseCalls, [], "an unknown submission outcome must not release the guard");
 });
 
-// Mutation this catches: reverting the allowlist inversion. Old code released whenever
-// `kisOrderSubmittedMaybe` was falsy, so ANY exception without that flag (including one
-// with neither flag, e.g. a getAccessToken()/hashkey failure before the KIS POST even
-// ran) fell through to release(). This is the deliberate behavior flip from #161: an
-// unrecognized error must now default to NOT releasing.
-test("submitOrder: does not release the dedup guard for an error with neither kisOrderRejected nor kisOrderSubmittedMaybe (inversion of pre-#161 behavior, which released here)", async (t) => {
+// Mutation this catches: reverting the allowlist inversion, or widening it beyond the
+// two named flags. This is the deliberate behavior flip from #161: an error carrying
+// none of kisOrderRejected/kisOrderNotSubmitted/kisOrderSubmittedMaybe (e.g. a bug in
+// application code unrelated to the KIS call) must default to NOT releasing — the old
+// code's `!error.kisOrderSubmittedMaybe` fell through to release() here instead.
+test("submitOrder: does not release the dedup guard for an error with none of the three recognized flags (inversion of pre-#161 behavior, which released here)", async (t) => {
   const releaseCalls = [];
   const store = {
     release(key) {
@@ -1014,10 +1054,10 @@ test("submitOrder: does not release the dedup guard for an error with neither ki
     },
   };
 
-  const unrecognizedError = new Error("Access Token 발급 실패: EGW00133");
+  const unrecognizedError = new TypeError("Cannot read properties of undefined (reading 'output')");
 
   await assert.rejects(
-    () => submitOrder({ orderDedupStore: store, dedupKey: "order-key-unrecognized", submit: async () => { throw unrecognizedError; } }),
+    () => submitOrder({ dedupStore: store, dedupKey: "order-key-unrecognized", submit: async () => { throw unrecognizedError; } }),
     (err) => err === unrecognizedError,
   );
   assert.deepEqual(releaseCalls, [], "an unrecognized error must default to fail-closed (no release)");
@@ -1038,10 +1078,49 @@ test("submitOrder: a release() failure during a KIS rejection does not replace t
   rejected.kisOrderRejected = true;
 
   await assert.rejects(
-    () => submitOrder({ orderDedupStore: store, dedupKey: "order-key-release-fails", submit: async () => { throw rejected; } }),
+    () => submitOrder({ dedupStore: store, dedupKey: "order-key-release-fails", submit: async () => { throw rejected; } }),
     (err) => err === rejected,
     "the original KIS rejection must still be the thrown error, not release()'s fs error",
   );
   const logged = consoleError.mock.calls.map((call) => util.format(...call.arguments)).join("\n");
   assert.match(logged, /EIO: i\/o error, write/);
+});
+
+// Mutation this catches: dereferencing `error.message` unguarded in the markSucceeded
+// catch block. A ledger write path could reject with a non-Error value (e.g. a plain
+// string thrown by some intermediary); `error.message` on a string is undefined, and on
+// null/undefined it throws a TypeError from inside the one block whose whole contract
+// is "must never throw", which would destroy the already-accepted order result.
+test("submitOrder: a non-Error thrown by markSucceeded (e.g. a plain string) does not crash, and the order result still reaches the caller", async (t) => {
+  const consoleError = t.mock.method(console, "error", () => {});
+  const store = {
+    markSucceeded() {
+      throw "disk full"; // eslint-disable-line no-throw-literal -- simulating a non-Error rejection
+    },
+  };
+
+  const kisResponse = { rt_cd: "0", output: { ODNO: "0000009999" } };
+  const data = await submitOrder({ dedupStore: store, dedupKey: "order-key-non-error-mark", submit: async () => kisResponse });
+
+  assert.equal(data, kisResponse, "the KIS success response must still reach the caller");
+  const logged = consoleError.mock.calls.map((call) => util.format(...call.arguments)).join("\n");
+  assert.match(logged, /disk full/);
+});
+
+// Mutation this catches: dereferencing `error.kisOrderRejected` or `releaseError.message`
+// unguarded when submit() itself rejects with a non-Error value (e.g. `throw null`,
+// which real code should never do, but a defensive guard must still not crash on it).
+test("submitOrder: a non-Error value thrown by submit() (e.g. null) does not crash and defaults to not releasing", async (t) => {
+  const releaseCalls = [];
+  const store = {
+    release(key) {
+      releaseCalls.push(key);
+    },
+  };
+
+  await assert.rejects(
+    () => submitOrder({ dedupStore: store, dedupKey: "order-key-null-throw", submit: async () => { throw null; } }), // eslint-disable-line no-throw-literal
+    (err) => err === null,
+  );
+  assert.deepEqual(releaseCalls, [], "a non-Error rejection must default to fail-closed (no release)");
 });

--- a/mcp-trading/tests/order.test.js
+++ b/mcp-trading/tests/order.test.js
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import util from "node:util";
 import { buildBalanceParams, fetchAllBalance, formatBalanceReport, formatPercent } from "../balance.js";
+import { submitOrder } from "../index.js";
+import { DuplicateOrderError, OrderDedupStore } from "../order-dedup.js";
 import {
   buildCashOrderBody,
   createCashOrderRequest,
@@ -875,4 +880,168 @@ test("createCashOrderRequest builds market order body", () => {
       },
     },
   );
+});
+
+// #161: markSucceeded (ledger bookkeeping) sitting inside the same try as the KIS call
+// used to make a filesystem write failure look identical to an order failure, deleting
+// the duplicate guard for an order KIS had already accepted. submitOrder() (index.js)
+// separates "did KIS accept the order" from "did we finish recording it" so a ledger
+// write failure can never undo an accepted order.
+
+function tempDedupLedgerPath(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "finus-submit-order-test-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 }));
+  return path.join(dir, "ledger.json");
+}
+
+// Mutation this catches: moving markSucceeded back inside the try (or letting any
+// exception from it flow into the shared catch) so that a ledger write failure is
+// treated the same as an order failure — release() gets called and/or the success
+// result never reaches the caller. This exact scenario is what #161 reported: KIS
+// accepted the order, but a later fs error made it look like the order itself failed.
+// Confirmed to fail on unmodified origin/main: there, markSucceeded runs inside the
+// try, its exception has neither kisOrderSubmittedMaybe nor kisOrderRejected, so
+// `!undefined || undefined` is true and release() deletes the guard.
+test("submitOrder: a markSucceeded (ledger write) failure after a successful KIS order does not release the dedup guard, and the order result still reaches the caller", async (t) => {
+  const store = new OrderDedupStore({ filePath: tempDedupLedgerPath(t), ttlMs: 60_000, now: () => 1_000 });
+  const dedupKey = "order-key-mark-succeeded-throws";
+  store.reserve(dedupKey, { pathname: "/uapi/domestic-stock/v1/trading/order-cash", trId: "TTTC0012U", body: {} });
+
+  const releaseSpy = t.mock.method(store, "release");
+  t.mock.method(store, "markSucceeded", () => {
+    throw new Error("ENOSPC: no space left on device, write");
+  });
+  t.mock.method(console, "error", () => {});
+
+  const kisResponse = { rt_cd: "0", output: { ODNO: "0000001234" } };
+  const data = await submitOrder({
+    orderDedupStore: store,
+    dedupKey,
+    submit: async () => kisResponse,
+  });
+
+  assert.equal(data, kisResponse, "the KIS success response must still reach the caller");
+  assert.equal(releaseSpy.mock.callCount(), 0, "release() must not run when only bookkeeping failed");
+});
+
+// Mutation this catches: any change that deletes or expires the ledger entry when
+// markSucceeded fails (e.g. calling release() unconditionally in a finally block, or
+// swallowing the error by writing an empty/succeeded-but-then-cleared entry). If the
+// entry disappeared, this reserve() would succeed instead of throwing, and a retried
+// order would go through — reproducing the duplicate-order bug from #161.
+test("submitOrder: after a markSucceeded failure, the ledger entry stays in place (in_flight) so a retried reserve() is still blocked as a duplicate", async (t) => {
+  const store = new OrderDedupStore({ filePath: tempDedupLedgerPath(t), ttlMs: 60_000, now: () => 1_000 });
+  const dedupKey = "order-key-retry-blocked";
+  const request = { pathname: "/uapi/domestic-stock/v1/trading/order-cash", trId: "TTTC0012U", body: {} };
+  store.reserve(dedupKey, request);
+
+  t.mock.method(store, "markSucceeded", () => {
+    throw new Error("EACCES: permission denied, open '/state/order-dedup.json'");
+  });
+  t.mock.method(console, "error", () => {});
+
+  await submitOrder({
+    orderDedupStore: store,
+    dedupKey,
+    submit: async () => ({ rt_cd: "0", output: { ODNO: "0000005678" } }),
+  });
+
+  assert.throws(
+    () => store.reserve(dedupKey, request),
+    DuplicateOrderError,
+    "the reservation must still be present, blocking a retry of the same order",
+  );
+});
+
+// Mutation this catches: dropping the `error.kisOrderRejected === true` check (e.g.
+// releasing unconditionally, or never releasing at all). This is unchanged behavior
+// from before #161: KIS explicitly said rt_cd !== "0", so nothing was submitted and
+// the guard must be released for a legitimate retry.
+test("submitOrder: releases the dedup guard when KIS rejects the order (rt_cd !== \"0\") — unchanged behavior", async (t) => {
+  const releaseCalls = [];
+  const store = {
+    release(key) {
+      releaseCalls.push(key);
+    },
+    markSucceeded() {
+      throw new Error("markSucceeded should not run when submit() throws");
+    },
+  };
+
+  const rejected = new Error("KIS API 오류: 주문가능금액을 초과하였습니다.");
+  rejected.kisOrderRejected = true;
+
+  await assert.rejects(
+    () => submitOrder({ orderDedupStore: store, dedupKey: "order-key-rejected", submit: async () => { throw rejected; } }),
+    (err) => err === rejected,
+  );
+  assert.deepEqual(releaseCalls, ["order-key-rejected"]);
+});
+
+// Mutation this catches: releasing whenever `kisOrderSubmittedMaybe` is absent, which
+// is exactly the old `!error.kisOrderSubmittedMaybe` fail-open logic this issue removes.
+// Unchanged behavior from before #161: the axios POST itself failed, so whether KIS
+// received the order is unknown — releasing here could let a duplicate through while
+// the original order might still be live, so the guard must stay (fail-closed).
+test("submitOrder: does not release the dedup guard when the axios POST fails and submission status is unknown — unchanged behavior", async (t) => {
+  const releaseCalls = [];
+  const store = {
+    release(key) {
+      releaseCalls.push(key);
+    },
+  };
+
+  const submitFailure = new Error("connect ETIMEDOUT");
+  submitFailure.kisOrderSubmittedMaybe = true;
+
+  await assert.rejects(
+    () => submitOrder({ orderDedupStore: store, dedupKey: "order-key-submit-unknown", submit: async () => { throw submitFailure; } }),
+    (err) => err === submitFailure,
+  );
+  assert.deepEqual(releaseCalls, [], "an unknown submission outcome must not release the guard");
+});
+
+// Mutation this catches: reverting the allowlist inversion. Old code released whenever
+// `kisOrderSubmittedMaybe` was falsy, so ANY exception without that flag (including one
+// with neither flag, e.g. a getAccessToken()/hashkey failure before the KIS POST even
+// ran) fell through to release(). This is the deliberate behavior flip from #161: an
+// unrecognized error must now default to NOT releasing.
+test("submitOrder: does not release the dedup guard for an error with neither kisOrderRejected nor kisOrderSubmittedMaybe (inversion of pre-#161 behavior, which released here)", async (t) => {
+  const releaseCalls = [];
+  const store = {
+    release(key) {
+      releaseCalls.push(key);
+    },
+  };
+
+  const unrecognizedError = new Error("Access Token 발급 실패: EGW00133");
+
+  await assert.rejects(
+    () => submitOrder({ orderDedupStore: store, dedupKey: "order-key-unrecognized", submit: async () => { throw unrecognizedError; } }),
+    (err) => err === unrecognizedError,
+  );
+  assert.deepEqual(releaseCalls, [], "an unrecognized error must default to fail-closed (no release)");
+});
+
+// Mutation this catches: letting release()'s own exception propagate out of the catch
+// block unguarded, which would replace the original KIS rejection error and destroy
+// the diagnostic (per issue's "also look at" section on release()).
+test("submitOrder: a release() failure during a KIS rejection does not replace the original KIS error", async (t) => {
+  const consoleError = t.mock.method(console, "error", () => {});
+  const store = {
+    release() {
+      throw new Error("EIO: i/o error, write");
+    },
+  };
+
+  const rejected = new Error("KIS API 오류: 모의투자 장운영시간이 아닙니다.");
+  rejected.kisOrderRejected = true;
+
+  await assert.rejects(
+    () => submitOrder({ orderDedupStore: store, dedupKey: "order-key-release-fails", submit: async () => { throw rejected; } }),
+    (err) => err === rejected,
+    "the original KIS rejection must still be the thrown error, not release()'s fs error",
+  );
+  const logged = consoleError.mock.calls.map((call) => util.format(...call.arguments)).join("\n");
+  assert.match(logged, /EIO: i\/o error, write/);
 });


### PR DESCRIPTION
Closes #161

## 요약

주문이 KIS에 **성공적으로 접수된 뒤** 원장 기록이 실패하면 중복 방지 가드가 지워지던 문제를 고칩니다. 사용자에게는 주문이 실패한 것으로 보이고, 재시도하면 그대로 통과해 **두 번째 실주문**이 나갑니다.

```js
try {
  data = await kisPost(...);
  orderDedupStore.markSucceeded(dedupKey, data);   // ← 파일시스템 실패 시 던짐
} catch (error) {
  if (!error.kisOrderSubmittedMaybe || error.kisOrderRejected) {
    orderDedupStore.release(dedupKey);             // ← 접수된 주문의 가드가 지워짐
  }
  throw error;
}
```

`kisOrderSubmittedMaybe`는 axios POST 실패에서만, `kisOrderRejected`는 `rt_cd !== "0"`에서만 세워집니다. 파일시스템 예외는 **둘 다 없어서** `!undefined === true`가 되어 release로 갑니다.

## 변경

**기록 실패가 주문 결과에 영향을 주지 못하게 분리했습니다.** `markSucceeded`를 자체 try/catch로 옮겨, 실패해도 stderr 로그만 남기고 주문 성공 결과가 그대로 호출자에게 갑니다. 항목은 `in_flight`로 남아 TTL까지 중복을 계속 막습니다. 부기 실패는 이미 제출된 주문을 되돌릴 근거가 아닙니다.

**release 조건을 부정에서 허용목록으로 바꿨습니다.** 기존 `!error.kisOrderSubmittedMaybe || ...`는 한 곳에서만 세우는 플래그의 부정이라, 새로운 예외 유형은 전부 기본값이 release — 즉 기본값이 fail-open이었습니다.

**제출 여부를 3상태로 구분합니다.** 리뷰에서 조건을 `kisOrderRejected`만으로 좁히면 POST **이전** 실패까지 잡힌다는 지적이 나왔습니다. 확인한 결과 네 곳이 해당합니다.

| 실패 지점 | 분류 | 이전 | 이후 |
| :--- | :--- | :--- | :--- |
| `requireKisCredentials()` | 제출 안 됨 확실 | release | release |
| `Access Token 발급 실패` | 제출 안 됨 확실 | release | release |
| `createKisHashKey` axios 실패 | 제출 안 됨 확실 | release | release |
| `KIS hashkey 발급 실패` | 제출 안 됨 확실 | release | release |
| 주문 POST 실패 (8초 타임아웃 포함) | 제출 여부 불명 | 유지 | 유지 |
| `rt_cd !== "0"` | 제출 안 됨 확실 | release | release |
| `markSucceeded` 기록 실패 | **제출됨 확실** | **release (버그)** | **유지** |

`kisPost`의 pre-flight를 감싸 `kisOrderNotSubmitted`를 세우고, release 조건을 `kisOrderRejected || kisOrderNotSubmitted`로 두었습니다. 인식하지 못한 예외는 여전히 fail-closed입니다.

이 구분이 없으면 토큰 발급 실패 시 제출된 적 없는 주문이 120초간 막히면서 사용자에게 "잠시 후 주문 내역을 확인하세요"가 뜹니다. 빠져나갈 방법은 수량·가격 변경뿐입니다(키 해시에 들어감). 드문 경로도 아닙니다 — 토큰 캐시가 `os.tmpdir()`에 있고 `KIS_TOKEN_CACHE_PATH`가 MCP env 허용목록에 없어, 컨테이너 재시작 후 첫 주문은 항상 콜드 토큰 발급을 탑니다.

**`release()`도 감쌌습니다.** 이것도 원장을 거치므로 던질 수 있는데, catch 블록 안에서 호출되어 원래의 KIS 에러를 덮어써 진단을 파괴합니다.

**`submitOrder`를 `mcp-trading/order-submit.js`로 분리했습니다.** `index.js`는 export가 없고 import 시점에 `StdioServerTransport`를 연결하는 진입점이라 테스트가 불가능했습니다. 처음에는 `isMainModule` 가드를 넣었으나, 리뷰에서 심볼릭 링크·정션을 통과할 때 재현 가능하게 깨지는 것이 실측됐습니다 — Node가 main 모듈을 realpath하는 반면 `path.resolve(argv[1])`는 링크 경로를 유지합니다. 지금 안 깨지는 이유가 런처들이 우연히 `.resolve()`를 한다는 것뿐이라(`backend/config.py:41`, `finus_api.py:162`), 누군가 `.absolute()`로 바꾸면 MCP 서버가 조용히 연결되지 않습니다.

가드를 없애고 형제 모듈로 분리했습니다. 이 저장소의 기존 규칙이기도 합니다 — `balance.js:17`에 명시돼 있고 `order.js`·`order-dedup.js`·`formatters.js`·`stock-master.js`가 전부 같은 이유로 분리돼 있습니다. `index.js`의 transport 블록은 `origin/main`과 바이트 동일합니다.

**비객체 throw를 견디게 했습니다.** 두 catch 블록이 `error`를 무방비로 역참조하고 있었습니다. `throw null`이면 "절대 던지면 안 되는" 블록 안에서 `TypeError`가 나 접수된 주문 결과를 파괴합니다.

## 검증

63 → 72 테스트. 신규 9개 전부 변형 테스트를 거쳤습니다.

| 변형 | 결과 |
| :--- | :--- |
| `markSucceeded`를 공용 try 안으로 되돌림 | 2건 red |
| release 조건을 원래 부정형으로 | 1건 red |
| 허용목록에서 `kisOrderNotSubmitted` 제거 | 1건 red |
| `release()` 감싸기 제거 | 1건 red |
| 옵셔널 체이닝 제거 | 1건 red |
| `String(x ?? y)` 가드 제거 | 1건 red |

`mcp-server.test.js`가 `node index.js`를 실제로 띄워 MCP 핸드셰이크를 완료하므로 진입점 변경도 실행으로 검증됩니다. 실제 기동에서 stdout 0바이트를 확인했습니다(stdio JSON-RPC 채널 오염 없음). 로그에 `appkey`·`appsecret`·`authorization`·`CANO` 없음을 확인했습니다.

## 알려진 한계

`markSucceeded` 실패 시 `expiresAt`이 갱신되지 않으므로(`order-dedup.js:80`), 이 수정은 **원래 TTL 창의 잔여 시간만** 막습니다. 120초가 다 지난 뒤의 재시도는 여전히 중복됩니다. 기존 중복 방지 설계이지 이 PR이 만든 것도, 고친다고 주장하는 것도 아닙니다.

## 후속

- **#163** — `kisPost`의 플래그 생산 경계를 고정하는 테스트가 없습니다. try 범위를 주문 POST까지 넓히는 변형을 넣어도 72개가 전부 통과합니다. 소비 측 테스트만 9개 있고 생산 측은 0개입니다.
- **#128** — 같은 주문 경로의 원장 읽기 fail-open. **이 PR이 먼저 머지되어야 합니다.** #128이 읽기·쓰기를 던지게 만들면 이 결함의 발동 빈도가 크게 올라갑니다. #128 리뷰에서 rename 실패 한 번으로 중복 실주문이 나가는 것을 end-to-end로 재현했습니다.
